### PR TITLE
fix(io): require flowio 1.4 for cytometry extras

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,7 @@ rust = [
 # was previously an UNDECLARED runtime dependency of a public function.
 #   pip install omicverse[cytometry]
 cytometry = [
-    "flowio>=1.3",
+    "flowio>=1.4",
 ]
 # Adds the scverse cytometry stack: compensation, logicle/biexponential
 # transforms and FlowSOM on top of the reader. Kept separate because flowutils
@@ -107,7 +107,7 @@ cytometry = [
 # itself needs.
 #   pip install omicverse[cytometry-full]
 cytometry-full = [
-    "flowio>=1.3",
+    "flowio>=1.4",
     "pytometry>=0.1.4",
 ]
 full = [

--- a/tests/test_cytometry_dependency_contract.py
+++ b/tests/test_cytometry_dependency_contract.py
@@ -1,0 +1,20 @@
+"""Packaging contracts for the optional cytometry reader."""
+
+from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # Python 3.10
+    import tomli as tomllib
+
+
+def test_every_cytometry_extra_requires_flowio_with_as_array():
+    project = tomllib.loads((Path(__file__).parents[1] / "pyproject.toml").read_text())
+    optional = project["project"]["optional-dependencies"]
+
+    for extra in ("cytometry", "cytometry-full"):
+        flowio = next(dep for dep in optional[extra] if dep.startswith("flowio"))
+        assert flowio == "flowio>=1.4", (
+            f"{extra} must require flowio>=1.4 because read_fcs calls "
+            "FlowData.as_array(), which is absent from flowio 1.3"
+        )


### PR DESCRIPTION
## Summary

Correct the minimum FlowIO version for the cytometry extras so that the dependency metadata matches the FCS reader implementation.

## Root cause

The FCS reader calls `FlowData.as_array()`, which requires FlowIO 1.4. However, the existing cytometry extras still allowed FlowIO 1.3, so an environment could satisfy the declared dependencies and then fail at runtime.

## Changes

- Raise the minimum FlowIO version from 1.3 to 1.4 in both `cytometry` and `cytometry-full`.
- Add an independent dependency-contract test covering both extras.
- Use the declared `tomli` backport on Python 3.10 and the standard-library `tomllib` on Python 3.11 and later.

The dependency-contract test is intentionally separate because `tests/test_io_fcs.py` is skipped at module level when FlowIO is unavailable and therefore cannot reliably protect the package metadata.

## Local validation

Base commit: `e78930e5f0595fc323620d258681ed2b230b4dd0`

- Targeted cytometry and dependency-contract tests: 25 passed, 3 skipped because optional dependencies were unavailable.
- Python 3.10 dependency-contract test: 1 passed.
- FlowIO 1.4 integration with the current `read_fcs` implementation: a valid FCS file was read successfully as 34,499 events × 18 parameters.
- `git diff --check`: passed.

All validation was performed in local isolated environments. GitHub CI was not used.

A fresh resolution of the complete project environment encountered the repository's existing yanked `openff-toolkit 0.18.0` dependency. That issue predates this PR and does not affect the cytometry-extra contract changed here.

## Regression and scope review

- Does not change the Omicverse package version.
- Does not modify CI, GitHub Actions, publishing, or build configuration.
- Does not change FCS reading logic; it only corrects the dependency contract.
- Does not record local paths, server details, or real test-sample information.
- Does not add production variables, constants, or helper modules.
- The candidate was independently reviewed, including the Python 3.10 collection compatibility fix.
