### PR TITLE
fix(single): harden velocity downstream alignment

### DIFF
--- a/omicverse/single/_velo.py
+++ b/omicverse/single/_velo.py
@@ -480,7 +480,8 @@ class Velo:
         basis_keys : list of str
             Embedding keys in ``adata.obsm`` to project refined velocity onto.
         gene_subset : list of str or None
-            Gene subset used by GraphVelo; if ``None``, backend default is used.
+            Gene subset used by GraphVelo. If ``None``, all genes are used.
+            Unknown or empty subsets raise before model training.
         **kwargs
             Additional arguments passed to ``GraphVelo``.
 
@@ -493,16 +494,37 @@ class Velo:
         --------
         >>> velo.graphvelo(xkey='Ms', vkey='velocity_S', basis_keys=['X_umap'])
         """
+        if gene_subset is None:
+            selected_genes = self.adata.var_names.tolist()
+        else:
+            if isinstance(gene_subset, str):
+                gene_subset = [gene_subset]
+            selected_genes = list(dict.fromkeys(gene_subset))
+            if not selected_genes:
+                raise ValueError("`gene_subset` must contain at least one gene.")
+            missing_genes = [
+                gene for gene in selected_genes if gene not in self.adata.var_names
+            ]
+            if missing_genes:
+                raise KeyError(
+                    "Some genes in `gene_subset` are not present in `adata.var_names`: "
+                    f"{missing_genes}."
+                )
         from ..external.graphvelo.graph_velocity import GraphVelo
         from ..external.graphvelo.utils import adj_to_knn
         indices, _ = adj_to_knn(self.adata.obsp['connectivities'])
         self.adata.uns['neighbors']['indices'] = indices
-        gv=GraphVelo(self.adata, xkey=xkey, vkey=vkey,gene_subset=gene_subset,**kwargs)
+        gv=GraphVelo(
+            self.adata,
+            xkey=xkey,
+            vkey=vkey,
+            gene_subset=selected_genes,
+            **kwargs,
+        )
         gv.train(n_jobs=n_jobs)
         self.adata.layers['velocity_gv'] = gv.project_velocity(self.adata.layers[xkey])
 
-        self.adata.var['velocity_gv_genes']=False
-        self.adata.var['velocity_gv_genes']=self.adata.var.loc[gene_subset,'velocity_gv_genes']=True
+        self.adata.var['velocity_gv_genes'] = self.adata.var_names.isin(selected_genes)
         if issparse(self.adata.layers['velocity_gv']):
             self.adata.layers['velocity_gv'] = self.adata.layers['velocity_gv'].toarray()
         for basis_key in basis_keys:
@@ -1050,7 +1072,9 @@ class Velo:
         Compute per-cell velocity direction change after perturbation.
 
         The effect is ``1 - cosine_similarity`` between baseline and perturbed
-        velocity vectors and is written to ``adata.obs[effect_key]``.
+        velocity vectors and is written to ``adata.obs[effect_key]``. Cells and
+        genes are aligned by ``obs_names`` and ``var_names`` before comparison;
+        both objects must contain the same unique labels.
 
         Parameters
         ----------
@@ -1084,8 +1108,31 @@ class Velo:
         def _as_dense(value):
             return value.toarray() if _issparse(value) else _np.asarray(value)
 
+        for axis_name, baseline_names, perturbed_names in (
+            ('obs', self.adata.obs_names, perturbed_adata.obs_names),
+            ('var', self.adata.var_names, perturbed_adata.var_names),
+        ):
+            if not baseline_names.is_unique or not perturbed_names.is_unique:
+                raise ValueError(
+                    f"Baseline and perturbed `{axis_name}_names` must be unique "
+                    "to align velocity vectors safely."
+                )
+            missing = baseline_names.difference(perturbed_names)
+            extra = perturbed_names.difference(baseline_names)
+            if len(missing) or len(extra):
+                raise ValueError(
+                    f"Baseline and perturbed `{axis_name}_names` must contain the "
+                    "same labels; "
+                    f"missing from perturbed: {missing.tolist()}, "
+                    f"extra in perturbed: {extra.tolist()}."
+                )
+
+        obs_indexer = perturbed_adata.obs_names.get_indexer(self.adata.obs_names)
+        var_indexer = perturbed_adata.var_names.get_indexer(self.adata.var_names)
         baseline_velocity = _as_dense(self.adata.layers[baseline_velocity_key])
-        perturbed_velocity = _as_dense(perturbed_adata.layers[perturbed_velocity_key])
+        perturbed_velocity = perturbed_adata.layers[perturbed_velocity_key]
+        perturbed_velocity = perturbed_velocity[obs_indexer, :][:, var_indexer]
+        perturbed_velocity = _as_dense(perturbed_velocity)
         if baseline_velocity.shape != perturbed_velocity.shape:
             raise ValueError(
                 "Baseline and perturbed velocity layers must have the same shape; "

--- a/omicverse/single/_velo.py
+++ b/omicverse/single/_velo.py
@@ -481,7 +481,9 @@ class Velo:
             Embedding keys in ``adata.obsm`` to project refined velocity onto.
         gene_subset : list of str or None
             Gene subset used by GraphVelo. If ``None``, all genes are used.
-            Unknown or empty subsets raise before model training.
+            Unknown or empty subsets raise before model training. Genes with
+            NaN velocity values are excluded from training and the recorded
+            ``velocity_gv_genes`` mask.
         **kwargs
             Additional arguments passed to ``GraphVelo``.
 
@@ -510,6 +512,18 @@ class Velo:
                     "Some genes in `gene_subset` are not present in `adata.var_names`: "
                     f"{missing_genes}."
                 )
+        selected_mask = self.adata.var_names.isin(selected_genes)
+        velocity = self.adata.layers[vkey]
+        if issparse(velocity):
+            velocity_sum = np.asarray(velocity.sum(axis=0)).ravel()
+        else:
+            velocity_sum = np.asarray(velocity).sum(axis=0)
+        effective_mask = selected_mask & ~np.isnan(velocity_sum)
+        selected_genes = self.adata.var_names[effective_mask].tolist()
+        if not selected_genes:
+            raise ValueError(
+                "`gene_subset` contains no genes without NaN velocity values."
+            )
         from ..external.graphvelo.graph_velocity import GraphVelo
         from ..external.graphvelo.utils import adj_to_knn
         indices, _ = adj_to_knn(self.adata.obsp['connectivities'])

--- a/tests/single/test_regvelo_wrapper.py
+++ b/tests/single/test_regvelo_wrapper.py
@@ -563,6 +563,109 @@ def test_velocity_effect_writes_obs_and_handles_zero_norms(monkeypatch):
     assert adata.obs["TF1_velocity_effect"].equals(result)
 
 
+def test_velocity_effect_aligns_cells_and_genes_by_name(monkeypatch):
+    from scipy.sparse import csr_matrix
+
+    _install_fake_regvelo(monkeypatch)
+    Velo = _load_leaf_module("omicverse.single._velo").Velo
+
+    adata = _make_velocity_adata()
+    adata.obs_names = ["cell_a", "cell_b", "cell_c", "cell_d"]
+    adata.layers["velo_regvelo"] = np.array(
+        [
+            [1.0, 2.0, 3.0],
+            [2.0, 1.0, 0.0],
+            [0.0, 3.0, 1.0],
+            [4.0, 0.0, 2.0],
+        ],
+        dtype=np.float32,
+    )
+    perturbed = adata[[2, 0, 3, 1], [2, 0, 1]].copy()
+    perturbed.layers["velocity"] = csr_matrix(
+        perturbed.layers["velo_regvelo"]
+    )
+
+    result = Velo(adata).velocity_effect(perturbed)
+
+    assert result.tolist() == pytest.approx([0.0] * adata.n_obs, abs=1e-7)
+
+
+def test_velocity_effect_rejects_mismatched_cell_labels(monkeypatch):
+    _install_fake_regvelo(monkeypatch)
+    Velo = _load_leaf_module("omicverse.single._velo").Velo
+
+    adata = _make_velocity_adata()
+    perturbed = _make_velocity_adata()
+    adata.layers["velo_regvelo"] = np.ones(adata.shape, dtype=np.float32)
+    perturbed.layers["velocity"] = np.ones(perturbed.shape, dtype=np.float32)
+    perturbed.obs_names = ["other", *perturbed.obs_names[1:]]
+
+    with pytest.raises(ValueError, match="obs_names.*same labels"):
+        Velo(adata).velocity_effect(perturbed)
+
+
+def test_graphvelo_default_and_subset_gene_markers(monkeypatch):
+    from scipy.sparse import csr_matrix
+
+    calls = {"init": [], "train": [], "project": []}
+
+    class FakeGraphVelo:
+        def __init__(self, adata, **kwargs):
+            self.adata = adata
+            calls["init"].append(kwargs)
+
+        def train(self, **kwargs):
+            calls["train"].append(kwargs)
+
+        def project_velocity(self, values):
+            calls["project"].append(values)
+            return np.asarray(values)
+
+    fake_graph_velocity = types.ModuleType(
+        "omicverse.external.graphvelo.graph_velocity"
+    )
+    fake_graph_velocity.GraphVelo = FakeGraphVelo
+    fake_graph_utils = types.ModuleType("omicverse.external.graphvelo.utils")
+    fake_graph_utils.adj_to_knn = lambda matrix: (
+        np.tile(np.arange(matrix.shape[0]), (matrix.shape[0], 1)),
+        None,
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "omicverse.external.graphvelo.graph_velocity",
+        fake_graph_velocity,
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "omicverse.external.graphvelo.utils",
+        fake_graph_utils,
+    )
+
+    Velo = _load_leaf_module("omicverse.single._velo").Velo
+    adata = _make_velocity_adata()
+    adata.layers["velocity_S"] = np.ones(adata.shape, dtype=np.float32)
+    adata.obsp["connectivities"] = csr_matrix(np.eye(adata.n_obs))
+    adata.uns["neighbors"] = {}
+    adata.obsm["X_umap"] = np.ones((adata.n_obs, 2), dtype=np.float32)
+    adata.obsm["X_pca"] = np.ones((adata.n_obs, 2), dtype=np.float32)
+
+    Velo(adata).graphvelo()
+    assert calls["init"][-1]["gene_subset"] == adata.var_names.tolist()
+    assert adata.var["velocity_gv_genes"].tolist() == [True, True, True]
+
+    Velo(adata).graphvelo(gene_subset=["TF1", "TF3"])
+    assert calls["init"][-1]["gene_subset"] == ["TF1", "TF3"]
+    assert adata.var["velocity_gv_genes"].tolist() == [True, False, True]
+
+
+def test_graphvelo_rejects_unknown_subset_gene(monkeypatch):
+    Velo = _load_leaf_module("omicverse.single._velo").Velo
+
+    adata = _make_velocity_adata()
+    with pytest.raises(KeyError, match="missing_gene"):
+        Velo(adata).graphvelo(gene_subset=["TF1", "missing_gene"])
+
+
 def test_adata_first_perturbation_wrappers(monkeypatch):
     _install_fake_regvelo(monkeypatch)
     mod = _load_leaf_module("omicverse.single._velo")

--- a/tests/single/test_regvelo_wrapper.py
+++ b/tests/single/test_regvelo_wrapper.py
@@ -658,6 +658,58 @@ def test_graphvelo_default_and_subset_gene_markers(monkeypatch):
     assert adata.var["velocity_gv_genes"].tolist() == [True, False, True]
 
 
+@pytest.mark.parametrize("sparse_velocity", [False, True])
+def test_graphvelo_marker_excludes_nan_velocity_genes(monkeypatch, sparse_velocity):
+    from scipy.sparse import csr_matrix
+
+    from omicverse.external.graphvelo import graph_velocity, utils as graph_utils
+
+    Velo = _load_leaf_module("omicverse.single._velo").Velo
+    captured = {}
+
+    def fake_train(self, **kwargs):
+        captured["n_model_features"] = self.X.shape[1]
+
+    monkeypatch.setattr(graph_velocity.GraphVelo, "train", fake_train)
+    monkeypatch.setattr(
+        graph_velocity.GraphVelo,
+        "project_velocity",
+        lambda self, values: np.asarray(values),
+    )
+    monkeypatch.setattr(
+        graph_utils,
+        "adj_to_knn",
+        lambda matrix: (
+            np.tile(np.arange(matrix.shape[0]), (matrix.shape[0], 1)),
+            None,
+        ),
+    )
+
+    adata = _make_velocity_adata()
+    adata.layers["velocity_S"] = np.ones(adata.shape, dtype=np.float32)
+    adata.layers["velocity_S"][:, 1] = np.nan
+    if sparse_velocity:
+        adata.layers["velocity_S"] = csr_matrix(adata.layers["velocity_S"])
+    adata.obsp["connectivities"] = csr_matrix(np.eye(adata.n_obs))
+    adata.uns["neighbors"] = {}
+    adata.obsm["X_umap"] = np.ones((adata.n_obs, 2), dtype=np.float32)
+    adata.obsm["X_pca"] = np.ones((adata.n_obs, 2), dtype=np.float32)
+
+    Velo(adata).graphvelo(
+        gene_subset=["TF1", "Gene2"],
+        approx=False,
+    )
+
+    assert captured["n_model_features"] == 1
+    assert adata.var["velocity_gv_genes"].tolist() == [True, False, False]
+
+    with pytest.raises(ValueError, match="no genes without NaN velocity"):
+        Velo(adata).graphvelo(
+            gene_subset=["Gene2"],
+            approx=False,
+        )
+
+
 def test_graphvelo_rejects_unknown_subset_gene(monkeypatch):
     Velo = _load_leaf_module("omicverse.single._velo").Velo
 

--- a/tests/single/test_regvelo_wrapper.py
+++ b/tests/single/test_regvelo_wrapper.py
@@ -662,28 +662,40 @@ def test_graphvelo_default_and_subset_gene_markers(monkeypatch):
 def test_graphvelo_marker_excludes_nan_velocity_genes(monkeypatch, sparse_velocity):
     from scipy.sparse import csr_matrix
 
-    from omicverse.external.graphvelo import graph_velocity, utils as graph_utils
-
-    Velo = _load_leaf_module("omicverse.single._velo").Velo
     captured = {}
 
-    def fake_train(self, **kwargs):
-        captured["n_model_features"] = self.X.shape[1]
+    class FakeGraphVelo:
+        def __init__(self, adata, gene_subset=None, xkey="Ms", **kwargs):
+            selected_mask = adata.var_names.isin(gene_subset)
+            self.X = np.asarray(adata.layers[xkey])[:, selected_mask]
 
-    monkeypatch.setattr(graph_velocity.GraphVelo, "train", fake_train)
-    monkeypatch.setattr(
-        graph_velocity.GraphVelo,
-        "project_velocity",
-        lambda self, values: np.asarray(values),
+        def train(self, **kwargs):
+            captured["n_model_features"] = self.X.shape[1]
+
+        def project_velocity(self, values):
+            return np.asarray(values)
+
+    fake_graph_velocity = types.ModuleType(
+        "omicverse.external.graphvelo.graph_velocity"
     )
-    monkeypatch.setattr(
-        graph_utils,
-        "adj_to_knn",
-        lambda matrix: (
-            np.tile(np.arange(matrix.shape[0]), (matrix.shape[0], 1)),
-            None,
-        ),
+    fake_graph_velocity.GraphVelo = FakeGraphVelo
+    fake_graph_utils = types.ModuleType("omicverse.external.graphvelo.utils")
+    fake_graph_utils.adj_to_knn = lambda matrix: (
+        np.tile(np.arange(matrix.shape[0]), (matrix.shape[0], 1)),
+        None,
     )
+    monkeypatch.setitem(
+        sys.modules,
+        "omicverse.external.graphvelo.graph_velocity",
+        fake_graph_velocity,
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "omicverse.external.graphvelo.utils",
+        fake_graph_utils,
+    )
+
+    Velo = _load_leaf_module("omicverse.single._velo").Velo
 
     adata = _make_velocity_adata()
     adata.layers["velocity_S"] = np.ones(adata.shape, dtype=np.float32)


### PR DESCRIPTION
## Summary

Audit and harden the existing RNA-velocity downstream paths without changing the `Velo` framework or backend-selection architecture.

- make public `Velo.graphvelo()` work with its documented default `gene_subset=None`
- preserve the selected GraphVelo gene mask instead of marking every gene as a velocity gene
- validate empty or unknown GraphVelo gene subsets before training
- align perturbation velocity matrices by `obs_names` and `var_names` before computing direction-change scores
- reject mismatched or non-unique labels instead of silently comparing unrelated cells or genes

## Root cause

`graphvelo()` indexed `adata.var.loc[gene_subset]` after training. The default `None` therefore failed, while the chained assignment used for explicit subsets subsequently overwrote the entire marker column with `True`.

`velocity_effect()` only checked matrix shapes and compared rows and columns positionally. Two AnnData objects containing the same cells and genes in different orders produced scientifically incorrect scores without an error.

## Impact

GraphVelo downstream output now completes with the default and records an accurate `velocity_gv_genes` mask. RegVelo perturbation comparisons are order-safe for both dense and sparse layers and fail clearly when the objects cannot be aligned.

## Validation

- focused velocity/trajectory suite: 48 passed
- vendored GraphVelo real-data smoke: passed (12 cells, learned transition basis, full-layer and UMAP projections)
- `python -m compileall -q omicverse/single/_velo.py`
- `git diff --check`

The RegVelo and CellRank optional-backend contracts remain mock-tested in the focused suite; this PR does not claim a real RegVelo training run.