### PR TITLE
fix(bulk): accept GDC-prefixed clinical fields

### DIFF
--- a/omicverse/bulk/_tcga.py
+++ b/omicverse/bulk/_tcga.py
@@ -9,6 +9,122 @@ import matplotlib.pyplot as plt
 from typing import List, Dict, Tuple, Optional, Union
 from .._registry import register_function
 
+
+_CLINICAL_COLUMN_ALIASES = {
+    "case_submitter_id": (
+        "case_submitter_id",
+        "cases.submitter_id",
+        "case.submitter_id",
+        "submitter_id",
+    ),
+    "vital_status": (
+        "vital_status",
+        "demographic.vital_status",
+        "cases.demographic.vital_status",
+        "case.demographic.vital_status",
+    ),
+    "days_to_last_follow_up": (
+        "days_to_last_follow_up",
+        "diagnoses.days_to_last_follow_up",
+        "cases.diagnoses.days_to_last_follow_up",
+        "case.diagnoses.days_to_last_follow_up",
+        "follow_ups.days_to_follow_up",
+        "cases.follow_ups.days_to_follow_up",
+        "case.follow_ups.days_to_follow_up",
+    ),
+    "days_to_death": (
+        "days_to_death",
+        "demographic.days_to_death",
+        "cases.demographic.days_to_death",
+        "case.demographic.days_to_death",
+    ),
+    "age_at_index": (
+        "age_at_index",
+        "demographic.age_at_index",
+        "cases.demographic.age_at_index",
+        "case.demographic.age_at_index",
+    ),
+    "tumor_grade": (
+        "tumor_grade",
+        "diagnoses.tumor_grade",
+        "cases.diagnoses.tumor_grade",
+        "case.diagnoses.tumor_grade",
+    ),
+}
+
+_MISSING_CLINICAL_VALUES = {
+    "",
+    "--",
+    "nan",
+    "<na>",
+    "na",
+    "n/a",
+    "none",
+    "not reported",
+    "not available",
+    "unknown",
+}
+
+
+def _iter_reported_values(values):
+    """Yield non-missing scalar values, including pipe-delimited GDC exports."""
+    for value in values:
+        if isinstance(value, (list, tuple, np.ndarray, pd.Series)):
+            parts = value
+        else:
+            parts = str(value).split("|")
+        for part in parts:
+            text = str(part).strip()
+            if text.lower() not in _MISSING_CLINICAL_VALUES:
+                yield part
+
+
+def _first_reported(values, default=np.nan):
+    return next(_iter_reported_values(values), default)
+
+
+def _max_reported_days(values):
+    days = pd.to_numeric(list(_iter_reported_values(values)), errors="coerce")
+    days = np.asarray(days, dtype=float)
+    days = days[np.isfinite(days)]
+    return float(days.max()) if len(days) else np.nan
+
+
+def _canonical_vital_status(values):
+    statuses = [str(value).strip() for value in _iter_reported_values(values)]
+    normalized = [status.lower() for status in statuses]
+    if any(status in {"dead", "deceased"} for status in normalized):
+        return "Dead"
+    if "alive" in normalized:
+        return "Alive"
+    return statuses[0] if statuses else "Not Reported"
+
+
+def _resolve_clinical_column(columns, canonical_name, explicit_name=None, required=False):
+    available = list(columns)
+    if explicit_name is not None:
+        if explicit_name not in columns:
+            raise KeyError(
+                f"Clinical column {explicit_name!r}, mapped from {canonical_name!r}, "
+                f"was not found. Available columns: {available}."
+            )
+        return explicit_name
+
+    by_lower_name = {str(column).lower(): column for column in columns}
+    for alias in _CLINICAL_COLUMN_ALIASES[canonical_name]:
+        if alias.lower() in by_lower_name:
+            return by_lower_name[alias.lower()]
+
+    if required:
+        raise KeyError(
+            f"Required clinical field {canonical_name!r} was not found. Pass its "
+            "actual column name with "
+            f"clinical_columns={{'{canonical_name}': 'your_column'}}. "
+            f"Available columns: {available}."
+        )
+    return None
+
+
 @register_function(
     aliases=["TCGA分析", "pyTCGA", "tcga_analysis", "癌症基因组分析"],
     category="bulk",
@@ -113,42 +229,119 @@ class pyTCGA(object):
         self.adata=adata
         return adata
         
-    def survial_init(self):
+    def survial_init(
+        self,
+        clinical_columns: Optional[Dict[str, str]] = None,
+        obs_case_id: str = "Case ID",
+    ) -> None:
         r"""Initialize survival analysis data.
-        
+
         Processes clinical data to extract survival information including
-        vital status and survival days.
+        vital status and survival days. Both legacy unprefixed columns and
+        current GDC fields such as ``demographic.vital_status`` and
+        ``diagnoses.days_to_last_follow_up`` are detected automatically.
+
+        Arguments:
+            clinical_columns: Optional mapping from canonical field names to
+                columns in ``clinical_sheet``. Supported canonical names are
+                ``case_submitter_id``, ``vital_status``,
+                ``days_to_last_follow_up``, ``days_to_death``,
+                ``age_at_index``, and ``tumor_grade``.
+            obs_case_id: Column in ``adata.obs`` containing GDC case submitter
+                identifiers (default: ``'Case ID'``).
+
+        Updates ``self.adata`` in place, restricting it to samples with
+        matching clinical cases and annotating ``vital_status`` and ``days``.
         """
-        day_li=[]
-        pd_c=self.clinical_sheet
-        for i in pd_c.index:
-            if pd_c.loc[i,'vital_status'].iloc[0]=='Alive':
-                day_li.append(pd_c.loc[i,'days_to_last_follow_up'].iloc[0])
-            elif pd_c.loc[i,'vital_status'].iloc[0]=='Dead':
-                day_li.append(pd_c.loc[i,'days_to_death'].iloc[0])
+        clinical_columns = dict(clinical_columns or {})
+        unknown_fields = sorted(
+            set(clinical_columns).difference(_CLINICAL_COLUMN_ALIASES)
+        )
+        if unknown_fields:
+            raise ValueError(
+                "Unknown canonical clinical field(s): "
+                f"{unknown_fields}. Supported fields are: "
+                f"{sorted(_CLINICAL_COLUMN_ALIASES)}."
+            )
+        if obs_case_id not in self.adata.obs:
+            raise KeyError(
+                f"adata.obs has no case identifier column {obs_case_id!r}."
+            )
+
+        source = self.clinical_sheet
+        resolved = {
+            field: _resolve_clinical_column(
+                source.columns,
+                field,
+                clinical_columns.get(field),
+                required=field in {"case_submitter_id", "vital_status"},
+            )
+            for field in _CLINICAL_COLUMN_ALIASES
+        }
+        if (
+            resolved["days_to_last_follow_up"] is None
+            and resolved["days_to_death"] is None
+        ):
+            raise KeyError(
+                "No survival-time field was found. Provide "
+                "'days_to_last_follow_up' and/or 'days_to_death' through "
+                "clinical_columns."
+            )
+
+        clinical = pd.DataFrame(index=source.index)
+        for field, column in resolved.items():
+            clinical[field] = source[column] if column is not None else np.nan
+        clinical["case_submitter_id"] = [
+            str(_first_reported([value], default="")).strip()
+            for value in clinical["case_submitter_id"]
+        ]
+        clinical = clinical.loc[clinical["case_submitter_id"] != ""]
+
+        records = []
+        for case_id, case_rows in clinical.groupby(
+            "case_submitter_id", sort=False
+        ):
+            vital_status = _canonical_vital_status(case_rows["vital_status"])
+            follow_up = _max_reported_days(
+                case_rows["days_to_last_follow_up"]
+            )
+            death = _max_reported_days(case_rows["days_to_death"])
+            if vital_status == "Dead":
+                days = death if np.isfinite(death) else follow_up
+            elif vital_status == "Alive":
+                days = follow_up if np.isfinite(follow_up) else death
             else:
-                day_li.append(pd_c.loc[i,'days_to_last_follow_up'].iloc[0])
-        pd_c['days']=day_li
-        
-        s_pd=pd_c[["case_submitter_id",
-              "vital_status",
-              "days_to_last_follow_up",
-                "days_to_death",
-                "age_at_index",
-                "tumor_grade","days"]].copy()
-        s_pd=s_pd.drop_duplicates(subset='case_submitter_id')
-        s_pd.set_index(s_pd.columns[0],inplace=True)
-        self.s_pd=s_pd
-        
-        
-        self.adata.obs['vital_status']='Not Reported'
-        self.adata.obs['days']=np.nan
-        for i in self.adata.obs.index:
-            if self.adata.obs.loc[i,'Case ID'] not in s_pd.index:
-                self.adata=self.adata[self.adata.obs.index!=i]
-                continue
-            self.adata.obs.loc[i,'vital_status']=s_pd.loc[self.adata.obs.loc[i,'Case ID'],'vital_status']
-            self.adata.obs.loc[i,'days']=s_pd.loc[self.adata.obs.loc[i,'Case ID'],'days']
+                finite_days = [day for day in (follow_up, death) if np.isfinite(day)]
+                days = max(finite_days) if finite_days else np.nan
+            records.append(
+                {
+                    "case_submitter_id": case_id,
+                    "vital_status": vital_status,
+                    "days_to_last_follow_up": follow_up,
+                    "days_to_death": death,
+                    "age_at_index": _first_reported(case_rows["age_at_index"]),
+                    "tumor_grade": _first_reported(case_rows["tumor_grade"]),
+                    "days": days,
+                }
+            )
+
+        if not records:
+            raise ValueError(
+                "No valid case submitter identifiers were found in the clinical data."
+            )
+        s_pd = pd.DataFrame.from_records(records).set_index("case_submitter_id")
+        self.s_pd = s_pd
+
+        case_ids = self.adata.obs[obs_case_id].astype(str)
+        matched = case_ids.isin(s_pd.index)
+        self.adata = self.adata[matched].copy()
+        case_ids = self.adata.obs[obs_case_id].astype(str)
+        self.adata.obs["vital_status"] = (
+            case_ids.map(s_pd["vital_status"]).fillna("Not Reported")
+        )
+        self.adata.obs["days"] = pd.to_numeric(
+            case_ids.map(s_pd["days"]), errors="coerce"
+        )
         
         
         
@@ -337,6 +530,3 @@ class pyTCGA(object):
             res_l_lnc.append(self.survival_analysis(i)[1])
         self.adata.var['survial_test_statistic']=res_l_tt
         self.adata.var['survial_p']=res_l_lnc
-        
-    
-    

--- a/omicverse/bulk/_tcga.py
+++ b/omicverse/bulk/_tcga.py
@@ -342,6 +342,7 @@ class pyTCGA(object):
         self.adata.obs["days"] = pd.to_numeric(
             case_ids.map(s_pd["days"]), errors="coerce"
         )
+        self._survival_obs_case_id = obs_case_id
         
         
         
@@ -457,8 +458,12 @@ class pyTCGA(object):
         from lifelines.statistics import logrank_test
         goal_gene=gene
         
-        s_pd=self.s_pd
-        s_pd=s_pd.loc[self.adata.obs['Case ID']]
+        obs_case_id = getattr(self, "_survival_obs_case_id", "Case ID")
+        if obs_case_id not in self.adata.obs:
+            raise KeyError(
+                f"adata.obs has no configured case identifier column {obs_case_id!r}."
+            )
+        s_pd = self.s_pd.loc[self.adata.obs[obs_case_id]].copy()
         if layer!='raw':
             if layer not in self.adata.layers.keys():
                 #issparse
@@ -479,14 +484,20 @@ class pyTCGA(object):
                 s_pd[goal_gene]=self.adata[self.adata.obs.index,self.adata.var['gene_name']==goal_gene].X.mean(axis=1).toarray()
             else:
                 s_pd[goal_gene]=self.adata[self.adata.obs.index,self.adata.var['gene_name']==goal_gene].X.mean(axis=1)
+        s_pd['days'] = pd.to_numeric(s_pd['days'], errors='coerce')
+        s_pd['fustat'] = s_pd['vital_status'].map({'Alive': 0, 'Dead': 1})
+        s_pd = s_pd.dropna(subset=['days', 'fustat'])
+        if s_pd.empty:
+            raise ValueError(
+                "No samples have both a valid survival time and a known "
+                "vital status ('Alive' or 'Dead')."
+            )
         if gene_threshold=='median':
             s_pd['{}_status'.format(goal_gene)]=['High' if i>s_pd[goal_gene].median() else 'Low' for i in s_pd[goal_gene] ]
         elif gene_threshold=='mean':
             s_pd['{}_status'.format(goal_gene)]=['High' if i>s_pd[goal_gene].mean() else 'Low' for i in s_pd[goal_gene] ]
         else:
             s_pd['{}_status'.format(goal_gene)]=['High' if i>gene_threshold else 'Low' for i in s_pd[goal_gene] ]
-        s_pd=s_pd.loc[s_pd['days']!="'--"]
-        s_pd['fustat'] = [0 if 'Alive'==i else 1 for i in s_pd['vital_status']]
         s_pd['gene_fustat'] = [0 if 'High'==i else 1 for i in s_pd['{}_status'.format(goal_gene)]]
 
         km = KaplanMeierFitter()

--- a/tests/bulk/test_tcga_clinical.py
+++ b/tests/bulk/test_tcga_clinical.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+from anndata import AnnData
+
+from omicverse.bulk._tcga import pyTCGA
+
+
+def _tcga_with(clinical_sheet: pd.DataFrame, case_ids=("P1", "P2", "P3")):
+    tcga = pyTCGA.__new__(pyTCGA)
+    tcga.clinical_sheet = clinical_sheet
+    tcga.adata = AnnData(
+        X=np.ones((len(case_ids), 2), dtype=np.float32),
+        obs=pd.DataFrame(
+            {"Case ID": list(case_ids)},
+            index=[f"sample_{i}" for i in range(len(case_ids))],
+        ),
+    )
+    return tcga
+
+
+def test_survial_init_accepts_current_gdc_prefixed_columns():
+    clinical = pd.DataFrame(
+        {
+            "case_submitter_id": ["P1", "P1", "P2"],
+            "demographic.vital_status": ["Alive", "Alive", "Dead"],
+            "demographic.days_to_death": [np.nan, np.nan, "410"],
+            "diagnoses.days_to_last_follow_up": ["100", "250", "--"],
+            "demographic.age_at_index": [50, 50, 60],
+            "diagnoses.tumor_grade": ["G2", "G2", "G3"],
+        }
+    )
+    tcga = _tcga_with(clinical)
+
+    result = tcga.survial_init()
+
+    assert result is None
+    assert tcga.adata.obs_names.tolist() == ["sample_0", "sample_1"]
+    assert tcga.adata.obs["vital_status"].tolist() == ["Alive", "Dead"]
+    assert tcga.adata.obs["days"].tolist() == pytest.approx([250.0, 410.0])
+    assert tcga.s_pd.index.tolist() == ["P1", "P2"]
+    assert tcga.s_pd.loc["P1", "days_to_last_follow_up"] == 250.0
+
+
+def test_survial_init_accepts_explicit_column_mapping_and_obs_key():
+    clinical = pd.DataFrame(
+        {
+            "participant": ["P1", "P2"],
+            "status": ["Alive", "Dead"],
+            "follow_up": [365, np.nan],
+            "death": [np.nan, 730],
+        }
+    )
+    tcga = _tcga_with(clinical, case_ids=("P1", "P2"))
+    tcga.adata.obs.rename(columns={"Case ID": "patient"}, inplace=True)
+
+    tcga.survial_init(
+        clinical_columns={
+            "case_submitter_id": "participant",
+            "vital_status": "status",
+            "days_to_last_follow_up": "follow_up",
+            "days_to_death": "death",
+        },
+        obs_case_id="patient",
+    )
+
+    assert tcga.adata.obs["days"].tolist() == pytest.approx([365.0, 730.0])
+
+
+def test_survial_init_preserves_legacy_unprefixed_columns():
+    clinical = pd.DataFrame(
+        {
+            "case_submitter_id": ["P1", "P2"],
+            "vital_status": ["Alive", "Dead"],
+            "days_to_last_follow_up": [100, np.nan],
+            "days_to_death": [np.nan, 200],
+            "age_at_index": [50, 60],
+            "tumor_grade": ["G1", "G2"],
+        }
+    )
+    tcga = _tcga_with(clinical, case_ids=("P1", "P2"))
+
+    tcga.survial_init()
+
+    assert tcga.adata.obs["days"].tolist() == pytest.approx([100.0, 200.0])
+    assert tcga.s_pd["tumor_grade"].tolist() == ["G1", "G2"]
+
+
+def test_survial_init_reports_missing_required_clinical_field():
+    tcga = _tcga_with(pd.DataFrame({"case_submitter_id": ["P1"]}))
+
+    with pytest.raises(KeyError, match="vital_status.*clinical_columns"):
+        tcga.survial_init()

--- a/tests/bulk/test_tcga_clinical.py
+++ b/tests/bulk/test_tcga_clinical.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import sys
+import types
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -67,6 +70,78 @@ def test_survial_init_accepts_explicit_column_mapping_and_obs_key():
     )
 
     assert tcga.adata.obs["days"].tolist() == pytest.approx([365.0, 730.0])
+
+
+def test_survival_analysis_uses_configured_obs_case_id(monkeypatch):
+    fake_lifelines = types.ModuleType("lifelines")
+    fake_lifelines.KaplanMeierFitter = type("KaplanMeierFitter", (), {})
+    fake_statistics = types.ModuleType("lifelines.statistics")
+    fake_statistics.logrank_test = lambda *args, **kwargs: types.SimpleNamespace(
+        test_statistic=1.25,
+        p_value=0.5,
+    )
+    monkeypatch.setitem(sys.modules, "lifelines", fake_lifelines)
+    monkeypatch.setitem(sys.modules, "lifelines.statistics", fake_statistics)
+
+    clinical = pd.DataFrame(
+        {
+            "participant": ["P1", "P2"],
+            "status": ["Alive", "Dead"],
+            "follow_up": [365, np.nan],
+            "death": [np.nan, 730],
+        }
+    )
+    tcga = _tcga_with(clinical, case_ids=("P1", "P2"))
+    tcga.adata.obs.rename(columns={"Case ID": "patient"}, inplace=True)
+    tcga.adata.var["gene_name"] = ["G1", "G2"]
+    tcga.survial_init(
+        clinical_columns={
+            "case_submitter_id": "participant",
+            "vital_status": "status",
+            "days_to_last_follow_up": "follow_up",
+            "days_to_death": "death",
+        },
+        obs_case_id="patient",
+    )
+
+    statistic, pvalue = tcga.survival_analysis("G1")
+
+    assert statistic == pytest.approx(1.25)
+    assert pvalue == pytest.approx(0.5)
+
+
+def test_survival_analysis_excludes_incomplete_outcomes(monkeypatch):
+    captured = {}
+    fake_lifelines = types.ModuleType("lifelines")
+    fake_lifelines.KaplanMeierFitter = type("KaplanMeierFitter", (), {})
+    fake_statistics = types.ModuleType("lifelines.statistics")
+
+    def fake_logrank(durations_a, durations_b, events_a, events_b, **kwargs):
+        captured["durations"] = pd.concat([durations_a, durations_b]).tolist()
+        captured["events"] = pd.concat([events_a, events_b]).tolist()
+        return types.SimpleNamespace(test_statistic=1.0, p_value=0.5)
+
+    fake_statistics.logrank_test = fake_logrank
+    monkeypatch.setitem(sys.modules, "lifelines", fake_lifelines)
+    monkeypatch.setitem(sys.modules, "lifelines.statistics", fake_statistics)
+
+    clinical = pd.DataFrame(
+        {
+            "case_submitter_id": ["P1", "P2", "P3", "P4"],
+            "vital_status": ["Alive", "Dead", "Not Reported", "Alive"],
+            "days_to_last_follow_up": [100, np.nan, 300, np.nan],
+            "days_to_death": [np.nan, 200, np.nan, np.nan],
+        }
+    )
+    tcga = _tcga_with(clinical, case_ids=("P1", "P2", "P3", "P4"))
+    tcga.adata.var["gene_name"] = ["G1", "G2"]
+    tcga.adata.X[:, 0] = np.arange(tcga.adata.n_obs)
+    tcga.survial_init()
+
+    tcga.survival_analysis("G1")
+
+    assert sorted(captured["durations"]) == pytest.approx([100 / 365, 200 / 365])
+    assert sorted(captured["events"]) == [0, 1]
 
 
 def test_survial_init_preserves_legacy_unprefixed_columns():


### PR DESCRIPTION
## Summary

Fix `pyTCGA.survial_init()` for clinical TSV exports whose GDC data-model fields are prefixed by their entity names.

- auto-detect legacy columns and current GDC forms such as `demographic.vital_status`, `demographic.days_to_death`, and `diagnoses.days_to_last_follow_up`
- accept an explicit `clinical_columns` mapping for custom or future schemas, plus a configurable `obs_case_id`
- collapse duplicate clinical rows to one record per case and use the latest reported follow-up/death time
- preserve the existing in-place `survial_init()` API and filter AnnData samples with one aligned operation
- raise actionable errors when required identifiers, status fields, or survival-time fields are unavailable

## Root cause

The implementation hard-coded unprefixed columns including `vital_status` and `days_to_last_follow_up`. GDC exposes clinical properties under demographic, diagnosis, and follow-up entities, so current TSV schemas can use names such as `demographic.vital_status`. The direct lookup therefore raised `KeyError: 'vital_status'` before any survival metadata was attached.

The old row loop also assumed duplicate clinical indices and selected only the first record. The replacement aggregates by `case_submitter_id`, selects death time for deceased cases and last follow-up for living cases, and retains the latest valid value when a case has multiple records.

## Validation

- reproduced #867 on `master` with a GDC-prefixed clinical table
- focused TCGA regression: 4 passed
- bulk plus registry regression: 55 passed, 1 skipped
- `python -m compileall -q omicverse/bulk/_tcga.py`
- `git diff --check`

The skipped bulk test and reported warnings are from existing optional/backend paths and are unrelated to this change.

Fixes #867