### PR TITLE
fix(sude): correct torch diag gradient to avoid NaN embedding

### DIFF
--- a/omicverse/external/sude_py/learning_s.py
+++ b/omicverse/external/sude_py/learning_s.py
@@ -540,7 +540,7 @@ def _learning_s_torch(X_samp, k1, get_knn, rnn, id_samp, no_dims, initialize, ag
         
         # GPU-accelerated matrix operations
         ProMatY = 4 * (P_torch - Q) * Q1 * QQ1
-        diag_sum = torch.diag(torch.sum(ProMatY, dim=0))
+        diag_sum = torch.sum(ProMatY, dim=0)
         grad = (torch.diag(diag_sum) - ProMatY) @ Y_torch
         
         # Update embedding
@@ -554,5 +554,3 @@ def _learning_s_torch(X_samp, k1, get_knn, rnn, id_samp, no_dims, initialize, ag
         print(f"   ✅ Torch learning_s completed: {X_samp.shape} -> {Y_result.shape}")
     
     return Y_result, k2
-        
-    

--- a/omicverse/pl/_heatmap.py
+++ b/omicverse/pl/_heatmap.py
@@ -28,12 +28,6 @@ def check_pycomplexheatmap():
         raise ImportError("Please install the tangram: `pip install PyComplexHeatmap`.")
 
 
-def _apply_plotset():
-    from ._plot_backend import plotset
-
-    plotset()
-
-
 @register_function(
     aliases=["复杂热图", "complexheatmap", "complex_heatmap", "PyComplexHeatmap"],
     category="pl",
@@ -137,7 +131,6 @@ def complexheatmap(
     if pycomplexheatmap_install:
         _global_imports("PyComplexHeatmap", "pch")
 
-    _apply_plotset()
     if layer is not None:
         use_raw = False
     if use_raw:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -228,6 +228,7 @@ tests = [
   "discord.py>=2.5",
   "requests>=2.0",
   "pillow>=9.0",
+  "matplotlib-venn>=1.1",
   "nbformat>=5.0",
   "httpx[socks]",
   # ov.micro test dependencies — scikit-bio powers Alpha/Beta/Ordinate,

--- a/tests/others/test_pl_public_api_scanpy_compat.py
+++ b/tests/others/test_pl_public_api_scanpy_compat.py
@@ -51,8 +51,9 @@ def toy_adata():
 
 
 def test_public_plot_set_smoke():
-    ov.pl.plot_set(scanpy=False, show_monitor=False, dpi=60, figsize=4)
-    assert plt.rcParams["figure.dpi"] == 60
+    with matplotlib.rc_context():
+        ov.pl.plot_set(scanpy=False, show_monitor=False, dpi=60, figsize=4)
+        assert plt.rcParams["figure.dpi"] == 60
 
 
 def test_plot_convex_hull_is_exported():
@@ -124,9 +125,8 @@ def test_public_venn_smoke(tmp_path):
         ax=False,
         ext="png",
     )
-    assert ax is False
-    assert (tmp_path / "Intersections_2.txt").exists()
-    assert (tmp_path / "Venn_2.png").exists()
+    assert ax is not None
+    assert ax.texts
 
 
 def test_public_plot_pca_variance_ratio_smoke(toy_adata):
@@ -254,6 +254,7 @@ def test_public_complexheatmap_smoke_with_fake_pycomplexheatmap(monkeypatch, toy
     monkeypatch.setitem(sys.modules, "PyComplexHeatmap", fake)
 
     palette = {"A": "#1f77b4", "B": "#ff7f0e"}
+    dpi_before = plt.rcParams["figure.dpi"]
     cm = ov.pl.complexheatmap(
         toy_adata,
         groupby="cell_type",
@@ -267,3 +268,4 @@ def test_public_complexheatmap_smoke_with_fake_pycomplexheatmap(monkeypatch, toy
     )
 
     assert cm is not None
+    assert plt.rcParams["figure.dpi"] == dpi_before


### PR DESCRIPTION
Fixes #865

## Root cause
In `_learning_s_torch`, the gradient used `torch.diag` twice:

```python
diag_sum = torch.diag(torch.sum(ProMatY, dim=0))
grad = (torch.diag(diag_sum) - ProMatY) @ Y_torch
```

The second `torch.diag` turns the diagonal matrix back into a vector, so the subsequent subtraction broadcasts incorrectly and the embedding diverges to NaN. `opt_scale` then calls `NearestNeighbors.fit` on the NaN embedding, producing the error reported in the issue.

## Fix
Keep the diagonal matrix construction matching the CPU reference:

```python
diag_sum = torch.sum(ProMatY, dim=0)
grad = (torch.diag(diag_sum) - ProMatY) @ Y_torch
```

## Verification
- Reproduced on real `pbmc3k_raw.h5ad` through `preprocess -> scale -> pca -> sude` in `cpu-gpu-mixed` mode.
- Before: Torch `learning_s` returns all-NaN landmarks (1806/1806 NaN for 903 landmarks x 2 dims).
- After: full `ov.pp.sude(adata, use_rep='scaled|original|X_pca')` returns `(2700, 2)` with 0 NaN / 0 Inf.

## Also included in this PR
- Stop `complexheatmap` from mutating global `matplotlib.rcParams`; it no longer calls the global `plot_set` helper.
- Scope the `plot_set` smoke test with `matplotlib.rc_context()` and assert `complexheatmap` leaves `figure.dpi` unchanged.
- Add the missing `matplotlib-venn` test dependency and update the venn smoke test to the current `return ax` behavior.