### PR TITLE
feat(pl): add optional trend guides to cellproportion (#955)

### DIFF
--- a/omicverse/pl/_single.py
+++ b/omicverse/pl/_single.py
@@ -364,7 +364,10 @@ def embedding(
         "                     transpose=True, figsize=(6,4))",
         "# Custom group order",
         "ov.pl.cellproportion(adata, celltype_clusters='cell_type', groupby='leiden',",
-        "                     groupby_li=['0', '1', '2'], legend=True)"
+        "                     groupby_li=['0', '1', '2'], legend=True)",
+        "# Connect cumulative proportions across ordered groups",
+        "ov.pl.cellproportion(adata, celltype_clusters='cell_type', groupby='condition',",
+        "                     groupby_li=['control', 'treated'], trend=True)"
     ],
     related=["pl.embedding", "tl.leiden"]
 )
@@ -373,6 +376,7 @@ def cellproportion(adata:AnnData,celltype_clusters:str,groupby:str,
                        groupby_li=None,figsize:tuple=(4,6),
                        ticks_fontsize:int=12,labels_fontsize:int=12,ax=None,
                        legend:bool=False,legend_awargs=None,transpose:bool=False,
+                       trend:bool=False,trend_kwargs=None,
                        save:str=None,**kwargs):
     r"""Plot cell proportion of each cell type in each visual cluster.
 
@@ -388,6 +392,12 @@ def cellproportion(adata:AnnData,celltype_clusters:str,groupby:str,
         legend: Whether to show legend. (False)
         legend_awargs: Legend arguments. ({'ncol':1})
         transpose: Whether to transpose the plot (horizontal bars). (False)
+        trend: Whether to connect cumulative cell-type proportions across
+            adjacent groups. The group order follows ``groupby_li`` when
+            supplied; these are visual guides, not fitted statistical trends.
+            (False)
+        trend_kwargs: Additional keyword arguments passed to the cumulative
+            boundary lines drawn when ``trend=True``. (None)
     
     Returns:
         None
@@ -456,6 +466,26 @@ def cellproportion(adata:AnnData,celltype_clusters:str,groupby:str,
             test1=test2
             bottoms+=test1['value'].values
         n+=1
+
+    if trend and len(all_celltype) > 1:
+        week_order = [i.replace('Retinoblastoma_','') for i in visual_li]
+        proportions = (
+            b.pivot(index='Week', columns='cell_type', values='value')
+            .reindex(index=week_order, columns=all_celltype, fill_value=0)
+            .fillna(0)
+        )
+        cumulative = proportions.cumsum(axis=1)
+        line_kw = {'linewidth': 1.5, 'alpha': 0.9, 'zorder': 3}
+        line_kw.update(trend_kwargs or {})
+        line_kw.setdefault('label', '_nolegend_')
+        for cell_type in all_celltype[:-1]:
+            boundary = cumulative[cell_type].to_numpy()
+            type_line_kw = dict(line_kw)
+            type_line_kw.setdefault('color', plot_data2_color_dict[cell_type])
+            if transpose:
+                ax.plot(boundary, week_order, **type_line_kw)
+            else:
+                ax.plot(week_order, boundary, **type_line_kw)
     if legend!=False:
         # Merge defaults with user-supplied legend kwargs to avoid duplicate bbox_to_anchor
         legend_kw = {'bbox_to_anchor': (1.05, -0.05), 'loc': 3, 'borderaxespad': 0, 'fontsize': 10}

--- a/tests/pl/test_cellproportion_trend.py
+++ b/tests/pl/test_cellproportion_trend.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import matplotlib
+import pandas as pd
+import pytest
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    yield
+    plt.close("all")
+
+
+@pytest.fixture
+def cells():
+    return pd.DataFrame(
+        {
+            "cell_type": ["A", "A", "B", "A", "B", "B", "A", "B"],
+            "sample": ["S1", "S1", "S1", "S2", "S2", "S2", "S3", "S3"],
+        }
+    )
+
+
+def test_cellproportion_trend_connects_cumulative_boundaries(cells):
+    from omicverse.pl import cellproportion
+
+    fig, ax = plt.subplots()
+    cellproportion(
+        cells,
+        celltype_clusters="cell_type",
+        groupby="sample",
+        groupby_li=["S1", "S2", "S3"],
+        trend=True,
+        trend_kwargs={"linewidth": 2.5, "linestyle": "--"},
+        ax=ax,
+    )
+
+    assert len(ax.lines) == 1
+    assert list(ax.lines[0].get_ydata()) == pytest.approx([2 / 3, 1 / 3, 1 / 2])
+    assert ax.lines[0].get_linewidth() == pytest.approx(2.5)
+    assert ax.lines[0].get_linestyle() == "--"
+
+
+def test_cellproportion_trend_respects_transpose(cells):
+    from omicverse.pl import cellproportion
+
+    fig, ax = plt.subplots()
+    cellproportion(
+        cells,
+        celltype_clusters="cell_type",
+        groupby="sample",
+        groupby_li=["S1", "S2", "S3"],
+        trend=True,
+        transpose=True,
+        ax=ax,
+    )
+
+    assert len(ax.lines) == 1
+    assert list(ax.lines[0].get_xdata()) == pytest.approx([2 / 3, 1 / 3, 1 / 2])
+
+
+def test_cellproportion_default_has_no_trend_lines(cells):
+    from omicverse.pl import cellproportion
+
+    fig, ax = plt.subplots()
+    cellproportion(
+        cells,
+        celltype_clusters="cell_type",
+        groupby="sample",
+        ax=ax,
+    )
+
+    assert not ax.lines


### PR DESCRIPTION
## Summary

- add an opt-in `trend=True` mode to `ov.pl.cellproportion`
- connect cumulative stacked proportions in the explicit `groupby_li` order
- support vertical and transposed plots plus `trend_kwargs` styling
- keep the existing output unchanged by default

The connecting lines are documented as visual guides across ordered discrete groups, not fitted statistical trends.

## Validation

- `python -m pytest tests/pl/test_cellproportion_trend.py tests/pl/test_generic_plots.py -q` (`139 passed`)
- `python -m pytest tests/pl/test_cellproportion_trend.py tests/pl/test_ax_contract.py tests/architecture/test_pl_canonical_aliases.py::test_plot_cellproportion_warns_and_delegates -q` (`26 passed`)
- visual smoke test for stacked bars plus cumulative boundaries
- `git diff --check`

Fixes #955