### PR TITLE
fix(single): handle duplicate genes in CellPhoneDB scoring

### DIFF
--- a/omicverse/single/_cpdb.py
+++ b/omicverse/single/_cpdb.py
@@ -2,6 +2,8 @@ r"""
 The downanlysis of cellphonedb
 """
 
+from threading import RLock
+
 import matplotlib.pyplot as plt
 import pandas as pd
 import numpy as np
@@ -12,7 +14,36 @@ import matplotlib
 import anndata
 from .._registry import register_function
 
-kpy_install=False
+kpy_install = False
+_cpdb_scoring_lock = RLock()
+
+
+def _call_cpdb_statistical_analysis(
+    cpdb_statistical_analysis_method,
+    analysis_params,
+):
+    """Call CellPhoneDB with unique gene names in its scoring matrix."""
+    scoring_utils = getattr(cpdb_statistical_analysis_method, "scoring_utils", None)
+    scorer_name = "heteromer_geometric_expression_per_cell_type"
+    if scoring_utils is None or not hasattr(scoring_utils, scorer_name):
+        return cpdb_statistical_analysis_method.call(**analysis_params)
+
+    with _cpdb_scoring_lock:
+        original = getattr(scoring_utils, scorer_name)
+
+        def unique_gene_rows(*args, **kwargs):
+            matrix = original(*args, **kwargs)
+            if matrix.index.has_duplicates:
+                # A gene can map to multiple CellPhoneDB protein records.
+                matrix = matrix.groupby(level=0, sort=False).mean()
+            return matrix
+
+        setattr(scoring_utils, scorer_name, unique_gene_rows)
+        try:
+            return cpdb_statistical_analysis_method.call(**analysis_params)
+        finally:
+            setattr(scoring_utils, scorer_name, original)
+
 
 def global_imports(modulename,shortname = None, asfunction = False):
     if shortname is None: 
@@ -656,7 +687,10 @@ def cellphonedb_v5(adata,
         analysis_params.update(kwargs)
         
         # Run analysis
-        cpdb_results = cpdb_statistical_analysis_method.call(**analysis_params)
+        cpdb_results = _call_cpdb_statistical_analysis(
+            cpdb_statistical_analysis_method,
+            analysis_params,
+        )
         
         print("   - CellPhoneDB analysis completed successfully!")
         
@@ -1158,7 +1192,10 @@ def run_cellphonedb_v5(adata,
         analysis_params.update(kwargs)
         
         # Run analysis
-        cpdb_results = cpdb_statistical_analysis_method.call(**analysis_params)
+        cpdb_results = _call_cpdb_statistical_analysis(
+            cpdb_statistical_analysis_method,
+            analysis_params,
+        )
         
         print("   - CellPhoneDB analysis completed successfully!")
         

--- a/tests/single/test_cpdb_scoring_compat.py
+++ b/tests/single/test_cpdb_scoring_compat.py
@@ -1,0 +1,60 @@
+from types import SimpleNamespace
+
+import pandas as pd
+import pytest
+
+from omicverse.single._cpdb import _call_cpdb_statistical_analysis
+
+
+def test_cpdb_scoring_deduplicates_genes() -> None:
+    def build_scoring_matrix() -> pd.DataFrame:
+        return pd.DataFrame(
+            [[1.0, 2.0], [1.0, 2.0], [3.0, 4.0]],
+            index=["NRXN1", "NRXN1", "CXCL12"],
+            columns=["EVT", "dNK1"],
+        )
+
+    scoring_utils = SimpleNamespace(
+        heteromer_geometric_expression_per_cell_type=build_scoring_matrix
+    )
+    original = scoring_utils.heteromer_geometric_expression_per_cell_type
+
+    def call(**kwargs):
+        matrix = scoring_utils.heteromer_geometric_expression_per_cell_type()
+        # CellPhoneDB transposes this matrix before downstream dataframe
+        # consumers inspect the columns.
+        assert matrix.T.columns.is_unique
+        return matrix
+
+    analysis_method = SimpleNamespace(scoring_utils=scoring_utils, call=call)
+
+    result = _call_cpdb_statistical_analysis(analysis_method, {})
+
+    assert result.index.tolist() == ["NRXN1", "CXCL12"]
+    assert result.loc["NRXN1"].tolist() == [1.0, 2.0]
+    assert (
+        scoring_utils.heteromer_geometric_expression_per_cell_type is original
+    )
+
+
+def test_cpdb_scoring_restores_patch_on_error() -> None:
+    def build_scoring_matrix() -> pd.DataFrame:
+        return pd.DataFrame([[1.0]], index=["NRXN1"], columns=["EVT"])
+
+    scoring_utils = SimpleNamespace(
+        heteromer_geometric_expression_per_cell_type=build_scoring_matrix
+    )
+    original = scoring_utils.heteromer_geometric_expression_per_cell_type
+
+    def call(**kwargs):
+        scoring_utils.heteromer_geometric_expression_per_cell_type()
+        raise RuntimeError("analysis failed")
+
+    analysis_method = SimpleNamespace(scoring_utils=scoring_utils, call=call)
+
+    with pytest.raises(RuntimeError, match="analysis failed"):
+        _call_cpdb_statistical_analysis(analysis_method, {})
+
+    assert (
+        scoring_utils.heteromer_geometric_expression_per_cell_type is original
+    )


### PR DESCRIPTION
## Background

`ov.single.run_cellphonedb_v5()` can fail during interaction scoring with the official CellPhoneDB EVT tutorial data when `score_interactions=True`:

```text
DuplicateError: Expected unique column names, got:
- 'NRXN1' 2 times
```

The official `normalised_log_counts.h5ad` input already has unique `var_names` and contains a single `NRXN1` entry. The duplication is introduced by CellPhoneDB's database mapping: one HGNC symbol can map to multiple protein records. After CellPhoneDB maps protein IDs back to gene symbols, its scoring matrix contains two `NRXN1` rows. Transposing that matrix creates duplicate columns, which newer dataframe consumers reject.

## Changes

- Collapse duplicate gene rows created by CellPhoneDB's protein-to-gene mapping before the official scaling and scoring steps.
- Average records expanded from the same input gene while preserving their original order. In the official EVT case, both `NRXN1` rows contain identical expression values, so the expression signal is unchanged and both database protein interaction records remain available.
- Apply the compatibility layer to both `cellphonedb_v5()` and `run_cellphonedb_v5()`.
- Restore the original CellPhoneDB function after both successful and failed analyses so the compatibility patch cannot leak into later calls.
- Add regression coverage for duplicate-gene collapsing and restoration after an exception.

## Validation

- `8 passed` across:
  - `tests/single/test_cpdb_scoring_compat.py`
  - `tests/single/test_comm_adapter.py`
  - `tests/architecture/test_optional_torch_dependencies.py`
- `compileall` passed.
- The new test file passed `flake8`; `git diff --check` passed.
- Completed a real analysis using the EVT dataset from CellPhoneDB's official `data_tutorial.zip`:
  - input: `1065 cells x 30800 genes`
  - after filtering: `19642 genes`
  - `100` permutations and `196` cell-type pairs
  - generated `interaction_scores (1441, 209)`
  - generated communication AnnData `(196, 1441)`

Official test data: https://github.com/ventolab/CellphoneDB/blob/master/notebooks/data_tutorial.zip
