### PR TITLE
fix(space): sync cell2location one-hot handling

### DIFF
--- a/omicverse/external/space/cell2location/models/_cell2location_WTA_module.py
+++ b/omicverse/external/space/cell2location/models/_cell2location_WTA_module.py
@@ -8,7 +8,7 @@ import torch
 from pyro.nn import PyroModule
 from scipy.sparse import csr_matrix
 from scvi import REGISTRY_KEYS
-from scvi.nn import one_hot
+from torch.nn.functional import one_hot
 
 # class NegativeBinomial(TorchDistributionMixin, ScVINegativeBinomial):
 #    pass
@@ -247,7 +247,7 @@ class LocationModelWTAMultiExperimentHierarchicalGeneLevel(PyroModule):
     def forward(self, x_data, neg_data, n_nuclei, idx, batch_index):
         self.n_neg_probes = neg_data.shape[1]
 
-        obs2sample = one_hot(batch_index, self.n_batch)
+        obs2sample = one_hot(batch_index.squeeze(-1), self.n_batch).float()
 
         obs_plate = self.create_plates(x_data, neg_data, n_nuclei, idx, batch_index)
 

--- a/omicverse/external/space/cell2location/models/_cell2location_module.py
+++ b/omicverse/external/space/cell2location/models/_cell2location_module.py
@@ -8,7 +8,7 @@ import torch
 from pyro.nn import PyroModule
 from scipy.sparse import csr_matrix
 from scvi import REGISTRY_KEYS
-from scvi.nn import one_hot
+from torch.nn.functional import one_hot
 
 # class NegativeBinomial(TorchDistributionMixin, ScVINegativeBinomial):
 #    pass
@@ -240,7 +240,7 @@ class LocationModelLinearDependentWMultiExperimentLocationBackgroundNormLevelGen
         }
 
     def forward(self, x_data, idx, batch_index):
-        obs2sample = one_hot(batch_index, self.n_batch)
+        obs2sample = one_hot(batch_index.squeeze(-1), self.n_batch).float()
 
         obs_plate = self.create_plates(x_data, idx, batch_index)
 

--- a/omicverse/external/space/cell2location/models/reference/_reference_module.py
+++ b/omicverse/external/space/cell2location/models/reference/_reference_module.py
@@ -7,7 +7,7 @@ import pyro.distributions as dist
 import torch
 from pyro.nn import PyroModule
 from scvi import REGISTRY_KEYS
-from scvi.nn import one_hot
+from torch.nn.functional import one_hot
 
 
 class RegressionBackgroundDetectionTechPyroModel(PyroModule):
@@ -176,15 +176,15 @@ class RegressionBackgroundDetectionTechPyroModel(PyroModule):
         }
 
     def forward(self, x_data, idx, batch_index, label_index, extra_categoricals):
-        obs2sample = one_hot(batch_index, self.n_batch)
-        obs2label = one_hot(label_index, self.n_factors)
+        obs2sample = one_hot(batch_index.squeeze(-1), self.n_batch).float()
+        obs2label = one_hot(label_index.squeeze(-1), self.n_factors).float()
         if self.n_extra_categoricals is not None:
             obs2extra_categoricals = torch.cat(
                 [
                     one_hot(
-                        extra_categoricals[:, i].view((extra_categoricals.shape[0], 1)),
+                        extra_categoricals[:, i].view((extra_categoricals.shape[0], 1)).squeeze(-1),
                         n_cat,
-                    )
+                    ).float()
                     for i, n_cat in enumerate(self.n_extra_categoricals)
                 ],
                 dim=1,

--- a/omicverse/external/space/cell2location/models/simplified/_cell2location_v3_no_factorisation_module.py
+++ b/omicverse/external/space/cell2location/models/simplified/_cell2location_v3_no_factorisation_module.py
@@ -5,7 +5,7 @@ import pyro.distributions as dist
 import torch
 from pyro.nn import PyroModule
 from scvi import REGISTRY_KEYS
-from scvi.nn import one_hot
+from torch.nn.functional import one_hot
 
 # class NegativeBinomial(TorchDistributionMixin, ScVINegativeBinomial):
 #    pass
@@ -215,7 +215,7 @@ class LocationModelMultiExperimentLocationBackgroundNormLevelGeneAlphaPyroModel(
         }
 
     def forward(self, x_data, idx, batch_index):
-        obs2sample = one_hot(batch_index, self.n_batch)
+        obs2sample = one_hot(batch_index.squeeze(-1), self.n_batch).float()
 
         obs_plate = self.create_plates(x_data, idx, batch_index)
 

--- a/omicverse/external/space/cell2location/models/simplified/_cell2location_v3_no_mg_module.py
+++ b/omicverse/external/space/cell2location/models/simplified/_cell2location_v3_no_mg_module.py
@@ -5,7 +5,7 @@ import pyro.distributions as dist
 import torch
 from pyro.nn import PyroModule
 from scvi import REGISTRY_KEYS
-from scvi.nn import one_hot
+from torch.nn.functional import one_hot
 
 # class NegativeBinomial(TorchDistributionMixin, ScVINegativeBinomial):
 #    pass
@@ -208,7 +208,7 @@ class LocationModelLinearDependentWMultiExperimentLocationBackgroundNormLevelNoM
         }
 
     def forward(self, x_data, idx, batch_index):
-        obs2sample = one_hot(batch_index, self.n_batch)
+        obs2sample = one_hot(batch_index.squeeze(-1), self.n_batch).float()
 
         obs_plate = self.create_plates(x_data, idx, batch_index)
 

--- a/omicverse/external/space/cell2location/nn/fclayers.py
+++ b/omicverse/external/space/cell2location/nn/fclayers.py
@@ -2,8 +2,8 @@ import collections
 from typing import Iterable
 
 import torch
-from scvi.nn._utils import one_hot
 from torch import nn as nn
+from torch.nn.functional import one_hot
 
 
 class FCLayers(nn.Module):
@@ -149,7 +149,7 @@ class FCLayers(nn.Module):
                 raise ValueError("cat not provided while n_cat != 0 in init. params.")
             if n_cat > 1:  # n_cat = 1 will be ignored - no additional information
                 if cat.size(1) != n_cat:
-                    one_hot_cat = one_hot(cat, n_cat)
+                    one_hot_cat = one_hot(cat.squeeze(-1), n_cat).float()
                 else:
                     one_hot_cat = cat  # cat has already been one_hot encoded
                 one_hot_cat_list += [one_hot_cat]

--- a/omicverse/external/space/cell2location/nn/fclayers_context.py
+++ b/omicverse/external/space/cell2location/nn/fclayers_context.py
@@ -2,8 +2,8 @@ import collections
 from typing import Iterable
 
 import torch
-from scvi.nn._utils import one_hot
 from torch import nn as nn
+from torch.nn.functional import one_hot
 
 
 class FCLayers(nn.Module):
@@ -176,7 +176,7 @@ class FCLayers(nn.Module):
                 raise ValueError("cat not provided while n_cat != 0 in init. params.")
             if n_cat > 1:  # n_cat = 1 will be ignored - no additional information
                 if cat.size(1) != n_cat:
-                    one_hot_cat = one_hot(cat, n_cat)
+                    one_hot_cat = one_hot(cat.squeeze(-1), n_cat).float()
                 else:
                     one_hot_cat = cat  # cat has already been one_hot encoded
                 one_hot_cat_list += [one_hot_cat]

--- a/tests/space/test_cell2location_one_hot_compat.py
+++ b/tests/space/test_cell2location_one_hot_compat.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+from torch.nn import functional
+
+pyro = pytest.importorskip("pyro")
+
+
+CELL2LOCATION_ROOT = (
+    Path(__file__).parents[2] / "omicverse" / "external" / "space" / "cell2location"
+)
+
+
+def _install_scvi_14_surface(monkeypatch):
+    """Expose the one-hot API shape used by scvi-tools 1.4.x."""
+
+    class RegistryKeys:
+        X_KEY = "X"
+        BATCH_KEY = "batch"
+
+    scvi = types.ModuleType("scvi")
+    scvi.REGISTRY_KEYS = RegistryKeys
+    scvi_nn = types.ModuleType("scvi.nn")
+    scvi_nn.__path__ = []
+    scvi_nn.one_hot = functional.one_hot
+    monkeypatch.setitem(sys.modules, "scvi", scvi)
+    monkeypatch.setitem(sys.modules, "scvi.nn", scvi_nn)
+
+
+def _load_module(name: str, relative_path: str):
+    spec = importlib.util.spec_from_file_location(name, CELL2LOCATION_ROOT / relative_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_spatial_model_handles_column_batch_indices_from_scvi_14(monkeypatch):
+    _install_scvi_14_surface(monkeypatch)
+    module = _load_module("cell2location_spatial_module", "models/_cell2location_module.py")
+    model_class = (
+        module.LocationModelLinearDependentWMultiExperimentLocationBackgroundNormLevelGeneAlphaPyroModel
+    )
+    model = model_class(
+        n_obs=4,
+        n_vars=3,
+        n_factors=2,
+        n_batch=2,
+        cell_state_mat=np.ones((3, 2), dtype=np.float32),
+        n_groups=2,
+    )
+
+    x_data = torch.ones((4, 3), dtype=torch.float32)
+    batch_index = torch.tensor([[0], [0], [1], [1]], dtype=torch.long)
+    pyro.clear_param_store()
+    pyro.enable_validation(True)
+
+    trace = pyro.poutine.trace(model).get_trace(x_data, torch.arange(4), batch_index)
+    trace.compute_log_prob()
+
+    assert trace.nodes["data_target"]["log_prob"].shape == (4, 3)
+
+
+def test_vendored_fc_layers_support_scvi_14_without_private_utils(monkeypatch):
+    _install_scvi_14_surface(monkeypatch)
+    module = _load_module("cell2location_fc_layers", "nn/fclayers.py")
+    layers = module.FCLayers(
+        n_in=2,
+        n_out=3,
+        n_cat_list=[2],
+        dropout_rate=0,
+        use_batch_norm=False,
+        use_activation=False,
+    )
+
+    result = layers(
+        torch.ones((4, 2), dtype=torch.float32),
+        torch.tensor([[0], [0], [1], [1]], dtype=torch.long),
+    )
+
+    assert result.shape == (4, 3)
+    assert result.dtype == torch.float32
+
+
+def test_reference_model_handles_column_categorical_indices(monkeypatch):
+    _install_scvi_14_surface(monkeypatch)
+    module = _load_module(
+        "cell2location_reference_module", "models/reference/_reference_module.py"
+    )
+    model = module.RegressionBackgroundDetectionTechPyroModel(
+        n_obs=4,
+        n_vars=3,
+        n_factors=2,
+        n_batch=2,
+        n_extra_categoricals=[2],
+    )
+
+    x_data = torch.ones((4, 3), dtype=torch.float32)
+    batch_index = torch.tensor([[0], [0], [1], [1]], dtype=torch.long)
+    label_index = torch.tensor([[0], [1], [0], [1]], dtype=torch.long)
+    extra_categoricals = torch.tensor([[0], [1], [1], [0]], dtype=torch.long)
+    pyro.clear_param_store()
+
+    trace = pyro.poutine.trace(model).get_trace(
+        x_data,
+        torch.arange(4),
+        batch_index,
+        label_index,
+        extra_categoricals,
+    )
+    trace.compute_log_prob()
+
+    assert trace.nodes["data_target"]["log_prob"].shape == (4, 3)


### PR DESCRIPTION
## Summary

- sync the vendored cell2location one-hot compatibility fix from BayraktarLab/cell2location#418
- squeeze column-shaped categorical indices before one-hot encoding and cast encoded values to float
- remove reliance on the removed private `scvi.nn._utils.one_hot` API
- cover spatial, reference, and FCLayers paths with focused regression tests

## Root cause

scvi-tools 1.4 exposes `torch.nn.functional.one_hot` directly. It returns integer tensors and preserves the trailing singleton dimension of `(N, 1)` category indices. The vendored cell2location code therefore first fails with `long != float`; casting without squeezing then broadcasts model parameters to `(N, N, genes)` and triggers the reported Pyro log-prob shape error.

## Validation

- `3 passed`: `tests/space/test_cell2location_one_hot_compat.py`
- `17 passed`: DecontX batch, font fallback, TCGA clinical, SUDE, and existing cell2location orchestration tests
- real clean Python 3.12 environment with scvi-tools 1.4.3, Pyro 1.9.1, and Torch 2.13.0: FCLayers and spatial model trace passed with `(4, 3)` float outputs
- Ruff passed
- `git diff --check` passed

Fixes #859
