### PR TITLE
fix(pl): support count-based CCC heatmaps

### DIFF
--- a/omicverse/pl/_ccc.py
+++ b/omicverse/pl/_ccc.py
@@ -3042,12 +3042,13 @@ def ccc_heatmap(
             color_by=color_by,
             allowed_color_by=("score",),
             value=value,
-            allowed_value=("sum", "mean"),
+            allowed_value=("sum", "mean", "count"),
         )
         viz = _build_cellchatviz(adata)
         plotter = viz.netVisual_heatmap_marsilea(
             signaling=_normalize_use_arg(signaling),
             pvalue_threshold=pvalue_threshold,
+            measure="count" if value == "count" else "weight",
             color_heatmap=cmap,
             add_dendrogram=cluster_rows or cluster_columns,
             add_row_sum=True,
@@ -3481,7 +3482,10 @@ def ccc_heatmap(
         top_n_pairs=top_n_pairs,
         facet_by=facet_by,
     )
-    display_color_label = "Interaction Strength" if display_by == "aggregation" and color_by == "score" else color_label
+    if display_by == "aggregation" and color_by == "score":
+        display_color_label = "Number of interactions" if value == "count" else "Interaction Strength"
+    else:
+        display_color_label = color_label
     matrix = _apply_cluster_order(matrix, cluster_rows=cluster_rows, cluster_columns=cluster_columns)
     size_matrix = size_matrix.reindex(index=matrix.index, columns=matrix.columns, fill_value=0.0)
 

--- a/omicverse/pl/_cpdbviz.py
+++ b/omicverse/pl/_cpdbviz.py
@@ -1776,11 +1776,12 @@ class CellChatViz(CellChatVizPlus):
         plt.tight_layout()
         return fig, ax
     
-    def netVisual_heatmap_marsilea(self, signaling=None, pvalue_threshold=0.05, 
+    def netVisual_heatmap_marsilea(self, signaling=None, pvalue_threshold=0.05,
                                 color_heatmap="Reds", add_dendrogram=True,
                                 add_row_sum=True, add_col_sum=True,
                                 show_row_names=False, show_col_names=False,
-                                linewidth=0.5, figsize=(8, 6), title="Communication Heatmap"):
+                                linewidth=0.5, figsize=(8, 6), title="Communication Heatmap",
+                                measure="weight"):
         """
         Draw a CellChat-style communication heatmap with Marsilea.
 
@@ -1813,6 +1814,9 @@ class CellChatViz(CellChatVizPlus):
             at render time.
         title : str
             Base title displayed on the Marsilea heatmap.
+        measure : {"weight", "count"}
+            Plot summed interaction strength or the number of significant
+            interactions. Row totals are outgoing and column totals incoming.
             
         Returns
         -------
@@ -1821,6 +1825,8 @@ class CellChatViz(CellChatVizPlus):
         """
         if not MARSILEA_AVAILABLE:
             raise ImportError("marsilea package is not available. Please install it: pip install marsilea")
+        if measure not in {"weight", "count"}:
+            raise ValueError("`measure` must be either 'weight' or 'count'.")
         
         # Calculate communication matrix
         if signaling is not None:
@@ -1835,7 +1841,8 @@ class CellChatViz(CellChatVizPlus):
                     raise ValueError(f"Pathway '{pathway}' not found. Available pathways: {list(available_pathways)}")
             
             # Calculate communication matrix for specific pathway
-            pathway_matrix = np.zeros((self.n_cell_types, self.n_cell_types))
+            count_matrix = np.zeros((self.n_cell_types, self.n_cell_types))
+            weight_matrix = np.zeros((self.n_cell_types, self.n_cell_types))
             pathway_mask = self.adata.var['classification'].isin(signaling)
             pathway_indices = np.where(pathway_mask)[0]
             
@@ -1853,13 +1860,15 @@ class CellChatViz(CellChatVizPlus):
                 
                 sig_mask = pvals < pvalue_threshold
                 if np.any(sig_mask):
-                    pathway_matrix[sender_idx, receiver_idx] += np.sum(means[sig_mask])
+                    count_matrix[sender_idx, receiver_idx] += np.sum(sig_mask)
+                    weight_matrix[sender_idx, receiver_idx] += np.sum(means[sig_mask])
             
-            matrix = pathway_matrix
+            matrix = count_matrix if measure == "count" else weight_matrix
             heatmap_title = f"{title} - {', '.join(signaling)}"
         else:
             # Use aggregated communication matrix
-            _, matrix = self.compute_aggregated_network(pvalue_threshold)
+            count_matrix, weight_matrix = self.compute_aggregated_network(pvalue_threshold)
+            matrix = count_matrix if measure == "count" else weight_matrix
             heatmap_title = title
         
         # Create DataFrame for better labeling
@@ -1870,7 +1879,8 @@ class CellChatViz(CellChatVizPlus):
         
         # Create marsilea heatmap
         h = ma.Heatmap(df_matrix, linewidth=linewidth, 
-                    cmap=color_heatmap, label="Interaction Strength")
+                    cmap=color_heatmap,
+                    label="Number of interactions" if measure == "count" else "Interaction Strength")
         
         # Add row and column grouping - this is a key step!
         #h.group_rows(df_matrix.index, order=df_matrix.index.tolist())

--- a/tests/pl/test_ccc_plots.py
+++ b/tests/pl/test_ccc_plots.py
@@ -413,6 +413,108 @@ def test_ccc_heatmap_aggregation_routes_through_cellchatviz_backend(monkeypatch,
     assert called["kwargs"]["show_col_names"] is True
 
 
+def test_ccc_heatmap_count_measure(monkeypatch, comm_adata: AnnData) -> None:
+    called: dict[str, object] = {}
+
+    class _StubViz:
+        def netVisual_heatmap_marsilea(self, **kwargs):
+            called.update(kwargs)
+            return "plotter"
+
+    monkeypatch.setattr(ccc_mod, "_build_cellchatviz", lambda adata, *, palette=None: _StubViz())
+    monkeypatch.setattr(
+        ccc_mod,
+        "_render_plotter_figure",
+        lambda plotter, *, title=None, add_custom_legends=False: plt.subplots(),
+    )
+
+    ov.pl.ccc_heatmap(
+        comm_adata,
+        plot_type="heatmap",
+        display_by="aggregation",
+        value="count",
+        show=False,
+    )
+
+    assert called["measure"] == "count"
+
+
+def test_cpdb_heatmap_count_direction(monkeypatch) -> None:
+    captured: dict[str, object] = {"numbers": {}}
+
+    class _Heatmap:
+        def __init__(self, data, **kwargs):
+            captured["matrix"] = data.to_numpy()
+            captured["label"] = kwargs["label"]
+
+        def add_left(self, plotter, **kwargs):
+            return None
+
+        def add_top(self, plotter, **kwargs):
+            return None
+
+        def add_bottom(self, plotter, **kwargs):
+            return None
+
+        def add_legends(self):
+            return None
+
+        def add_title(self, title):
+            return None
+
+        def add_dendrogram(self, side, **kwargs):
+            return None
+
+    class _Plotter:
+        @staticmethod
+        def Numbers(values, **kwargs):
+            captured["numbers"][kwargs["label"]] = np.asarray(values)
+            return object()
+
+        @staticmethod
+        def Colors(*args, **kwargs):
+            return object()
+
+        @staticmethod
+        def Labels(*args, **kwargs):
+            return object()
+
+    class _Marsilea:
+        Heatmap = _Heatmap
+        plotter = _Plotter
+
+    monkeypatch.setattr(cpdbviz_mod, "MARSILEA_AVAILABLE", True)
+    monkeypatch.setattr(cpdbviz_mod, "ma", _Marsilea)
+
+    viz = ov.pl.CellChatViz(_build_comm_adata_with_duplicate_pairs())
+    viz.netVisual_heatmap_marsilea(measure="count", add_dendrogram=False)
+
+    np.testing.assert_array_equal(captured["matrix"], np.array([[0.0, 3.0], [2.0, 0.0]]))
+    np.testing.assert_array_equal(captured["numbers"]["Outgoing"], np.array([3.0, 2.0]))
+    np.testing.assert_array_equal(captured["numbers"]["Incoming"], np.array([2.0, 3.0]))
+    assert captured["label"] == "Number of interactions"
+
+
+def test_ccc_count_legend(monkeypatch, comm_adata: AnnData) -> None:
+    captured: dict[str, object] = {}
+
+    def _fake_plot(matrix, size_matrix, **kwargs):
+        captured.update(kwargs)
+        return plt.subplots()
+
+    monkeypatch.setattr(ccc_mod, "_dot_matrix_plot", _fake_plot)
+
+    ov.pl.ccc_heatmap(
+        comm_adata,
+        plot_type="bubble",
+        display_by="aggregation",
+        value="count",
+        show=False,
+    )
+
+    assert captured["color_label"] == "Number of interactions"
+
+
 def test_ccc_heatmap_aggregation_rejects_interaction_filters(comm_adata: AnnData) -> None:
     with pytest.raises(ValueError, match="interaction_use"):
         ov.pl.ccc_heatmap(


### PR DESCRIPTION
## Summary

- allow `ccc_heatmap(..., display_by="aggregation", value="count")` to use the significant-interaction count matrix
- label count-based color scales as `Number of interactions` instead of `Interaction Strength`
- preserve the CellPhoneDB orientation: row totals are outgoing and column totals are incoming

## Reproduction

Before this change, the aggregation heatmap rejected `value="count"`, while related aggregation views could still label count-valued colors as interaction strength. This made count tables appear inconsistent with the heatmap even though the incoming/outgoing orientation was correct.

## Tests

- added count-measure routing coverage
- added asymmetric incoming/outgoing total coverage
- added count legend coverage for aggregation views
- `pytest tests/pl/test_ccc_plots.py -q` (136 passed)