### PR TITLE
chore(licences): carry the upstream MIT licences for vendored UCE and SAMap

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,6 +6,9 @@ include setup.cfg
 include requirements.txt
 include requirements-latest.txt
 
+# Vendored third-party licences carry no file extension, so the pattern below
+# would miss them; they must ship in the sdist with the code they cover.
+recursive-include omicverse LICENSE*
 recursive-include omicverse *.py *.pyi *.json *.txt *.yaml *.yml *.csv *.tsv *.md *.ipynb *.html *.css *.js *.png *.jpg *.jpeg *.svg *.ico *.db *.npz *.gz *.fasta *.pkl
 include omicverse/external/scMulan/utils/meta_info.pt
 

--- a/omicverse/external/samap/LICENSE
+++ b/omicverse/external/samap/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 atarashansky
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/omicverse/external/samap/__init__.py
+++ b/omicverse/external/samap/__init__.py
@@ -1,5 +1,10 @@
 """Vendored SAMap (Tarashansky et al. 2021, eLife) + sam-algorithm.
 
+Source: https://github.com/atarashansky/SAMap (Tarashansky, Musser, Khariton,
+Li & Wang, Stanford University). Upstream is MIT-licensed; the license is
+carried verbatim beside this file in ``LICENSE`` and applies to every source
+file in this directory.
+
 Cross-species single-cell integration via BLAST protein-homology graphs and the
 Self-Assembling Manifold algorithm. Vendored (source copied) rather than pip
 -installed because upstream pins ``numpy==1.23.5`` / ``scanpy==1.9.3`` /

--- a/omicverse/llm/UCE/LICENSE
+++ b/omicverse/llm/UCE/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Yanay Rosen, Yusuf Roohani, Jure Leskovec
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/omicverse/llm/UCE/__init__.py
+++ b/omicverse/llm/UCE/__init__.py
@@ -1,0 +1,17 @@
+"""Vendored UCE — Universal Cell Embeddings.
+
+Source: https://github.com/snap-stanford/UCE (Rosen, Roohani, Leskovec et al.,
+Stanford University). Copied into omicverse because upstream ships no package on
+PyPI; the inference path is used by :mod:`omicverse.llm.uce_model`.
+
+Upstream is MIT-licensed; the license is carried verbatim beside this file in
+``LICENSE`` and applies to every source file in this directory. Model weights are
+distributed separately by the upstream authors and are covered by their own terms,
+not by this license.
+
+Reference
+---------
+Rosen, Y., Roohani, Y., Agarwal, A., Samotorcan, L., Tabula Sapiens Consortium,
+Quake, S. R., & Leskovec, J. (2023). "Universal Cell Embeddings: A Foundation
+Model for Cell Biology." bioRxiv.
+"""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -503,6 +503,10 @@ exclude = [
 "omicverse.synbio" = ["external/*.fasta", "external/cfd/*.pkl"]
 # Vendored PDBFixer: residue templates + forcefield XML must ship in the wheel
 "omicverse.external.pdbfixer" = ["*.xml", "templates/*.pdb", "LICENSE"]
+# Vendored third-party source: the upstream licence has to travel with the code
+# that it covers, so it ships in the wheel alongside it.
+"omicverse.external.samap" = ["LICENSE"]
+"omicverse.llm.UCE" = ["LICENSE"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"


### PR DESCRIPTION
`omicverse/llm/UCE/` and `omicverse/external/samap/` hold third-party source copied verbatim, and neither carried the licence that covers it. MIT requires the copyright and permission notice to travel with every copy, so as it stood we redistributed both without meeting that condition.

| Directory | Upstream | Licence |
|---|---|---|
| `omicverse/llm/UCE/` (11 files) | [snap-stanford/UCE](https://github.com/snap-stanford/UCE) | MIT — © 2023 Yanay Rosen, Yusuf Roohani, Jure Leskovec |
| `omicverse/external/samap/` (8 files) | [atarashansky/SAMap](https://github.com/atarashansky/SAMap) | MIT — © 2020 atarashansky |

Both `LICENSE` files are the upstream text verbatim. The `__init__` docstrings now name the source repository and point at the licence beside them. UCE's `__init__.py` was empty, so it also gains the reference and a note that **model weights are distributed separately by the upstream authors under their own terms, which this licence does not cover**.

### Packaging — the part that would have made this cosmetic

A bare `LICENSE` has no file extension, so `MANIFEST.in`'s extension list would have dropped both from the sdist, and with no `package-data` entry they would not have reached the wheel either. The licence would have sat in git and been absent from every `pip install`. Both are fixed, following the entry that already exists for the vendored PDBFixer.

Verified by building the sdist:

```
omicverse-2.3.1/omicverse/external/pdbfixer/LICENSE
omicverse-2.3.1/omicverse/external/samap/LICENSE
omicverse-2.3.1/omicverse/llm/UCE/LICENSE
```

### Not in this PR

A third vendored directory, `omicverse/external/cytotrace2/`, is also missing its licence, but adding it is not the fix. Upstream is the **Stanford Non-Commercial Software License Agreement**, which prohibits use by any commercial entity and directs them to Stanford OTL under docket S24-057. That is an additional restriction, and GPL-3.0 does not permit further restrictions on what it distributes — so dropping the file in would document a conflict rather than resolve one. Handled separately.

This PR is scoped to the two directories where carrying the licence is both necessary and sufficient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0156k5ARWtUbtjbfRypRavEa