### PR TITLE
feat(tl,pl): Bonsai cell-state trees, with the scout layout and a compiled core

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,7 +8,7 @@ include requirements-latest.txt
 
 # Vendored third-party licences carry no file extension, so the pattern below
 # would miss them; they must ship in the sdist with the code they cover.
-recursive-include omicverse LICENSE*
+recursive-include omicverse LICENSE* CITATION.cff
 recursive-include omicverse *.py *.pyi *.json *.txt *.yaml *.yml *.csv *.tsv *.md *.ipynb *.html *.css *.js *.png *.jpg *.jpeg *.svg *.ico *.db *.npz *.gz *.fasta *.pkl
 include omicverse/external/scMulan/utils/meta_info.pt
 

--- a/omicverse/external/__init__.py
+++ b/omicverse/external/__init__.py
@@ -19,6 +19,7 @@ Algorithm categories:
     Trajectory inference:
         - STT: Spatial transition tensor
         - VIA: Velocity integration and annotation
+        - bonsai: Maximum-likelihood cell-state tree (CC BY-NC 4.0)
         - cytotrace2: Developmental potential scoring
         - monocle2_py: Pure-Python reimplementation of Monocle 2 (DDRTree)
         
@@ -86,6 +87,7 @@ _TORCH_HEAVY_MODULES = {
 }
 
 __all__ = [
+    'bonsai',
     'scSLAT',
     'CEFCON',
     'mofapy2',

--- a/omicverse/external/bonsai/CITATION.cff
+++ b/omicverse/external/bonsai/CITATION.cff
@@ -1,0 +1,45 @@
+cff-version: 1.2.0
+
+title: "Bonsai-data-representation"
+message: "If you use this software, please cite both the software and the associated preprint."
+type: software
+authors:
+  - family-names: "de Groot"
+    given-names: "Daan H."
+    affiliation: "Biozentrum, University of Basel"
+
+  - family-names: "Morillo Leonardo"
+    given-names: "Sarah X."
+    affiliation: "Biozentrum, University of Basel"
+
+  - family-names: "Pachkov"
+    given-names: "Mikhail"
+    affiliation: "Biozentrum, University of Basel"
+
+  - family-names: "van Nimwegen"
+    given-names: "Erik"
+    affiliation: "Biozentrum, University of Basel"
+
+url: "https://github.com/dhdegroot/Bonsai-data-representation"
+version: 1.0.0
+date-released: 2026-05-25
+
+preferred-citation:
+  type: article
+  title: "Bonsai: Tree representations for distortion-free visualization and exploratory analysis of single-cell omics data"
+  authors:
+    - family-names: "de Groot"
+      given-names: "Daan H."
+
+    - family-names: "Morillo Leonardo"
+      given-names: "Sarah X."
+
+    - family-names: "Pachkov"
+      given-names: "Mikhail"
+
+    - family-names: "van Nimwegen"
+      given-names: "Erik"
+
+  journal: "bioRxiv"
+  year: 2025
+  doi: "10.1101/2025.05.08.652944"

--- a/omicverse/external/bonsai/LICENSE-CC-BY-NC-4.0.md
+++ b/omicverse/external/bonsai/LICENSE-CC-BY-NC-4.0.md
@@ -1,0 +1,159 @@
+# Attribution-NonCommercial 4.0 International
+
+> *Creative Commons Corporation (“Creative Commons”) is not a law firm and does not provide legal services or legal advice. Distribution of Creative Commons public licenses does not create a lawyer-client or other relationship. Creative Commons makes its licenses and related information available on an “as-is” basis. Creative Commons gives no warranties regarding its licenses, any material licensed under their terms and conditions, or any related information. Creative Commons disclaims all liability for damages resulting from their use to the fullest extent possible.*
+>
+> ### Using Creative Commons Public Licenses
+>
+> Creative Commons public licenses provide a standard set of terms and conditions that creators and other rights holders may use to share original works of authorship and other material subject to copyright and certain other rights specified in the public license below. The following considerations are for informational purposes only, are not exhaustive, and do not form part of our licenses.
+>
+> * __Considerations for licensors:__ Our public licenses are intended for use by those authorized to give the public permission to use material in ways otherwise restricted by copyright and certain other rights. Our licenses are irrevocable. Licensors should read and understand the terms and conditions of the license they choose before applying it. Licensors should also secure all rights necessary before applying our licenses so that the public can reuse the material as expected. Licensors should clearly mark any material not subject to the license. This includes other CC-licensed material, or material used under an exception or limitation to copyright. [More considerations for licensors](http://wiki.creativecommons.org/Considerations_for_licensors_and_licensees#Considerations_for_licensors).
+>
+> * __Considerations for the public:__ By using one of our public licenses, a licensor grants the public permission to use the licensed material under specified terms and conditions. If the licensor’s permission is not necessary for any reason–for example, because of any applicable exception or limitation to copyright–then that use is not regulated by the license. Our licenses grant only permissions under copyright and certain other rights that a licensor has authority to grant. Use of the licensed material may still be restricted for other reasons, including because others have copyright or other rights in the material. A licensor may make special requests, such as asking that all changes be marked or described. Although not required by our licenses, you are encouraged to respect those requests where reasonable. [More considerations for the public](http://wiki.creativecommons.org/Considerations_for_licensors_and_licensees#Considerations_for_licensees).
+
+## Creative Commons Attribution-NonCommercial 4.0 International Public License
+
+By exercising the Licensed Rights (defined below), You accept and agree to be bound by the terms and conditions of this Creative Commons Attribution-NonCommercial 4.0 International Public License ("Public License"). To the extent this Public License may be interpreted as a contract, You are granted the Licensed Rights in consideration of Your acceptance of these terms and conditions, and the Licensor grants You such rights in consideration of benefits the Licensor receives from making the Licensed Material available under these terms and conditions.
+
+### Section 1 – Definitions.
+
+a. __Adapted Material__ means material subject to Copyright and Similar Rights that is derived from or based upon the Licensed Material and in which the Licensed Material is translated, altered, arranged, transformed, or otherwise modified in a manner requiring permission under the Copyright and Similar Rights held by the Licensor. For purposes of this Public License, where the Licensed Material is a musical work, performance, or sound recording, Adapted Material is always produced where the Licensed Material is synched in timed relation with a moving image.
+
+b. __Adapter's License__ means the license You apply to Your Copyright and Similar Rights in Your contributions to Adapted Material in accordance with the terms and conditions of this Public License.
+
+c. __Copyright and Similar Rights__ means copyright and/or similar rights closely related to copyright including, without limitation, performance, broadcast, sound recording, and Sui Generis Database Rights, without regard to how the rights are labeled or categorized. For purposes of this Public License, the rights specified in Section 2(b)(1)-(2) are not Copyright and Similar Rights.
+
+d. __Effective Technological Measures__ means those measures that, in the absence of proper authority, may not be circumvented under laws fulfilling obligations under Article 11 of the WIPO Copyright Treaty adopted on December 20, 1996, and/or similar international agreements.
+
+e. __Exceptions and Limitations__ means fair use, fair dealing, and/or any other exception or limitation to Copyright and Similar Rights that applies to Your use of the Licensed Material.
+
+f. __Licensed Material__ means the artistic or literary work, database, or other material to which the Licensor applied this Public License.
+
+g. __Licensed Rights__ means the rights granted to You subject to the terms and conditions of this Public License, which are limited to all Copyright and Similar Rights that apply to Your use of the Licensed Material and that the Licensor has authority to license.
+
+h. __Licensor__ means the individual(s) or entity(ies) granting rights under this Public License.
+
+i. __NonCommercial__ means not primarily intended for or directed towards commercial advantage or monetary compensation. For purposes of this Public License, the exchange of the Licensed Material for other material subject to Copyright and Similar Rights by digital file-sharing or similar means is NonCommercial provided there is no payment of monetary compensation in connection with the exchange.
+
+j. __Share__ means to provide material to the public by any means or process that requires permission under the Licensed Rights, such as reproduction, public display, public performance, distribution, dissemination, communication, or importation, and to make material available to the public including in ways that members of the public may access the material from a place and at a time individually chosen by them.
+
+k. __Sui Generis Database Rights__ means rights other than copyright resulting from Directive 96/9/EC of the European Parliament and of the Council of 11 March 1996 on the legal protection of databases, as amended and/or succeeded, as well as other essentially equivalent rights anywhere in the world.
+
+l. __You__ means the individual or entity exercising the Licensed Rights under this Public License. Your has a corresponding meaning.
+
+### Section 2 – Scope.
+
+a. ___License grant.___
+
+   1. Subject to the terms and conditions of this Public License, the Licensor hereby grants You a worldwide, royalty-free, non-sublicensable, non-exclusive, irrevocable license to exercise the Licensed Rights in the Licensed Material to:
+
+       A. reproduce and Share the Licensed Material, in whole or in part, for NonCommercial purposes only; and
+
+       B. produce, reproduce, and Share Adapted Material for NonCommercial purposes only.
+
+   2. __Exceptions and Limitations.__ For the avoidance of doubt, where Exceptions and Limitations apply to Your use, this Public License does not apply, and You do not need to comply with its terms and conditions.
+
+   3. __Term.__ The term of this Public License is specified in Section 6(a).
+
+   4. __Media and formats; technical modifications allowed.__ The Licensor authorizes You to exercise the Licensed Rights in all media and formats whether now known or hereafter created, and to make technical modifications necessary to do so. The Licensor waives and/or agrees not to assert any right or authority to forbid You from making technical modifications necessary to exercise the Licensed Rights, including technical modifications necessary to circumvent Effective Technological Measures. For purposes of this Public License, simply making modifications authorized by this Section 2(a)(4) never produces Adapted Material.
+
+   5. __Downstream recipients.__
+
+        A. __Offer from the Licensor – Licensed Material.__ Every recipient of the Licensed Material automatically receives an offer from the Licensor to exercise the Licensed Rights under the terms and conditions of this Public License.
+
+        B. __No downstream restrictions.__ You may not offer or impose any additional or different terms or conditions on, or apply any Effective Technological Measures to, the Licensed Material if doing so restricts exercise of the Licensed Rights by any recipient of the Licensed Material.
+
+   6. __No endorsement.__ Nothing in this Public License constitutes or may be construed as permission to assert or imply that You are, or that Your use of the Licensed Material is, connected with, or sponsored, endorsed, or granted official status by, the Licensor or others designated to receive attribution as provided in Section 3(a)(1)(A)(i).
+
+b. ___Other rights.___
+
+   1. Moral rights, such as the right of integrity, are not licensed under this Public License, nor are publicity, privacy, and/or other similar personality rights; however, to the extent possible, the Licensor waives and/or agrees not to assert any such rights held by the Licensor to the limited extent necessary to allow You to exercise the Licensed Rights, but not otherwise.
+
+   2. Patent and trademark rights are not licensed under this Public License.
+
+   3. To the extent possible, the Licensor waives any right to collect royalties from You for the exercise of the Licensed Rights, whether directly or through a collecting society under any voluntary or waivable statutory or compulsory licensing scheme. In all other cases the Licensor expressly reserves any right to collect such royalties, including when the Licensed Material is used other than for NonCommercial purposes.
+
+### Section 3 – License Conditions.
+
+Your exercise of the Licensed Rights is expressly made subject to the following conditions.
+
+a. ___Attribution.___
+
+   1. If You Share the Licensed Material (including in modified form), You must:
+
+       A. retain the following if it is supplied by the Licensor with the Licensed Material:
+
+         i. identification of the creator(s) of the Licensed Material and any others designated to receive attribution, in any reasonable manner requested by the Licensor (including by pseudonym if designated);
+
+         ii. a copyright notice;
+
+         iii. a notice that refers to this Public License;
+
+         iv. a notice that refers to the disclaimer of warranties;
+
+         v. a URI or hyperlink to the Licensed Material to the extent reasonably practicable;
+
+       B. indicate if You modified the Licensed Material and retain an indication of any previous modifications; and
+
+       C. indicate the Licensed Material is licensed under this Public License, and include the text of, or the URI or hyperlink to, this Public License.
+
+   2. You may satisfy the conditions in Section 3(a)(1) in any reasonable manner based on the medium, means, and context in which You Share the Licensed Material. For example, it may be reasonable to satisfy the conditions by providing a URI or hyperlink to a resource that includes the required information.
+
+   3. If requested by the Licensor, You must remove any of the information required by Section 3(a)(1)(A) to the extent reasonably practicable.
+
+   4. If You Share Adapted Material You produce, the Adapter's License You apply must not prevent recipients of the Adapted Material from complying with this Public License.
+
+### Section 4 – Sui Generis Database Rights.
+
+Where the Licensed Rights include Sui Generis Database Rights that apply to Your use of the Licensed Material:
+
+a. for the avoidance of doubt, Section 2(a)(1) grants You the right to extract, reuse, reproduce, and Share all or a substantial portion of the contents of the database for NonCommercial purposes only;
+
+b. if You include all or a substantial portion of the database contents in a database in which You have Sui Generis Database Rights, then the database in which You have Sui Generis Database Rights (but not its individual contents) is Adapted Material; and
+
+c. You must comply with the conditions in Section 3(a) if You Share all or a substantial portion of the contents of the database.
+
+For the avoidance of doubt, this Section 4 supplements and does not replace Your obligations under this Public License where the Licensed Rights include other Copyright and Similar Rights.
+
+### Section 5 – Disclaimer of Warranties and Limitation of Liability.
+
+a. __Unless otherwise separately undertaken by the Licensor, to the extent possible, the Licensor offers the Licensed Material as-is and as-available, and makes no representations or warranties of any kind concerning the Licensed Material, whether express, implied, statutory, or other. This includes, without limitation, warranties of title, merchantability, fitness for a particular purpose, non-infringement, absence of latent or other defects, accuracy, or the presence or absence of errors, whether or not known or discoverable. Where disclaimers of warranties are not allowed in full or in part, this disclaimer may not apply to You.__
+
+b. __To the extent possible, in no event will the Licensor be liable to You on any legal theory (including, without limitation, negligence) or otherwise for any direct, special, indirect, incidental, consequential, punitive, exemplary, or other losses, costs, expenses, or damages arising out of this Public License or use of the Licensed Material, even if the Licensor has been advised of the possibility of such losses, costs, expenses, or damages. Where a limitation of liability is not allowed in full or in part, this limitation may not apply to You.__
+
+c. The disclaimer of warranties and limitation of liability provided above shall be interpreted in a manner that, to the extent possible, most closely approximates an absolute disclaimer and waiver of all liability.
+
+### Section 6 – Term and Termination.
+
+a. This Public License applies for the term of the Copyright and Similar Rights licensed here. However, if You fail to comply with this Public License, then Your rights under this Public License terminate automatically.
+
+b. Where Your right to use the Licensed Material has terminated under Section 6(a), it reinstates:
+
+   1. automatically as of the date the violation is cured, provided it is cured within 30 days of Your discovery of the violation; or
+
+   2. upon express reinstatement by the Licensor.
+
+   For the avoidance of doubt, this Section 6(b) does not affect any right the Licensor may have to seek remedies for Your violations of this Public License.
+
+c. For the avoidance of doubt, the Licensor may also offer the Licensed Material under separate terms or conditions or stop distributing the Licensed Material at any time; however, doing so will not terminate this Public License.
+
+d. Sections 1, 5, 6, 7, and 8 survive termination of this Public License.
+
+### Section 7 – Other Terms and Conditions.
+
+a. The Licensor shall not be bound by any additional or different terms or conditions communicated by You unless expressly agreed.
+
+b. Any arrangements, understandings, or agreements regarding the Licensed Material not stated herein are separate from and independent of the terms and conditions of this Public License.
+
+### Section 8 – Interpretation.
+
+a. For the avoidance of doubt, this Public License does not, and shall not be interpreted to, reduce, limit, restrict, or impose conditions on any use of the Licensed Material that could lawfully be made without permission under this Public License.
+
+b. To the extent possible, if any provision of this Public License is deemed unenforceable, it shall be automatically reformed to the minimum extent necessary to make it enforceable. If the provision cannot be reformed, it shall be severed from this Public License without affecting the enforceability of the remaining terms and conditions.
+
+c. No term or condition of this Public License will be waived and no failure to comply consented to unless expressly agreed to by the Licensor.
+
+d. Nothing in this Public License constitutes or may be interpreted as a limitation upon, or waiver of, any privileges and immunities that apply to the Licensor or You, including from the legal processes of any jurisdiction or authority.
+
+> Creative Commons is not a party to its public licenses. Notwithstanding, Creative Commons may elect to apply one of its public licenses to material it publishes and in those instances will be considered the “Licensor.” Except for the limited purpose of indicating that material is shared under a Creative Commons public license or as otherwise permitted by the Creative Commons policies published at [creativecommons.org/policies](http://creativecommons.org/policies), Creative Commons does not authorize the use of the trademark “Creative Commons” or any other trademark or logo of Creative Commons without its prior written consent including, without limitation, in connection with any unauthorized modifications to any of its public licenses or any other arrangements, understandings, or agreements concerning use of licensed material. For the avoidance of doubt, this paragraph does not form part of the public licenses.
+>
+> Creative Commons may be contacted at creativecommons.org

--- a/omicverse/external/bonsai/__init__.py
+++ b/omicverse/external/bonsai/__init__.py
@@ -1,0 +1,41 @@
+r"""Bonsai integration — driver only, no upstream source.
+
+Bonsai reconstructs a maximum-likelihood *tree* over cells instead of a 2-D
+embedding: cells are leaves, internal vertices are inferred ancestral states,
+and branch lengths are distances in expression space. It consumes the
+measurement error on each feature, so a poorly-determined cell sits on a short
+branch near its parent rather than being scattered by noise.
+
+What is in this directory
+-------------------------
+Only omicverse's own driver code. **No Bonsai source is vendored here**, unlike
+most of ``omicverse/external/``: upstream is released under **CC BY-NC 4.0**
+(Attribution-NonCommercial), an additional restriction that omicverse's GPL-3.0
+licence cannot carry, so redistributing it inside this package is not available
+to us. ``_run.py`` drives a copy the user installs themselves, the arrangement
+omicverse already uses for Spateo.
+
+Installing Bonsai
+-----------------
+Bonsai is not on PyPI (the PyPI package named ``bonsai`` is unrelated)::
+
+    git clone https://github.com/dhdegroot/Bonsai-data-representation.git
+    cd Bonsai-data-representation && pip install -r requirements.txt
+    export BONSAI_HOME=$PWD
+
+**Commercial users cannot use Bonsai under CC BY-NC 4.0** and should contact the
+authors (Biozentrum, University of Basel) first.
+
+Public API
+----------
+:func:`omicverse.tl.bonsai` and :func:`omicverse.pl.bonsai`.
+
+Reference
+---------
+de Groot, D. H., Morillo Leonardo, S. X., Pachkov, M., & van Nimwegen, E. (2026).
+Bonsai-data-representation (v1.0.0). Zenodo. https://doi.org/10.5281/zenodo.20370956
+"""
+from ._run import run_bonsai
+from ._layout import equal_angle_layout, scout_layout
+
+__all__ = ["run_bonsai", "scout_layout", "equal_angle_layout"]

--- a/omicverse/external/bonsai/_fast.py
+++ b/omicverse/external/bonsai/_fast.py
@@ -1,0 +1,272 @@
+r"""Compiled kernels for Bonsai's innermost likelihood math.
+
+Why this exists
+---------------
+Profiling a 400-cell run (127 s) showed the cost is not in the tree search but in
+how the leaf-level arithmetic is spent: 7.7 M calls to :func:`numpy.sum` and
+10.4 M ufunc reductions, roughly 19 s of which is NumPy's Python-level dispatch
+rather than arithmetic. The arrays being reduced are one entry per *feature*, so
+when the input is a PCA representation — twenty-odd numbers — the dispatch costs
+more than the sum.
+
+These kernels fuse each function into a single pass with no temporaries. They are
+selected only below :data:`FAST_MAX_FEATURES`; above it NumPy's vectorised path is
+already as fast and the compiled loop brings nothing.
+
+Numerics
+--------
+The kernels compute the same expressions in the same order, so results match to
+machine precision — measured relative differences of 0 to 5e-16 against the
+original, and identical reconstructed trees end to end. They are an optimisation,
+not an approximation.
+
+Falls back to the original NumPy path when numba is unavailable.
+"""
+from __future__ import annotations
+
+import numpy as np
+
+__all__ = ["FAST_MAX_FEATURES", "have_numba", "star_loglik_grad", "der2_leaf_tree",
+           "opt_t3", "use_fast"]
+
+# Crossover measured on this code: at 20 features the compiled loop is ~12x
+# faster, at 200 ~3x, and by 12000 the two are level. Well clear of the point
+# where choosing it could cost anything.
+FAST_MAX_FEATURES = 2000
+
+try:  # pragma: no cover - depends on the environment
+    from numba import njit
+
+    _HAVE_NUMBA = True
+except Exception:  # numba is a declared dependency, but never require it here
+    _HAVE_NUMBA = False
+
+    def njit(*args, **kwargs):
+        def deco(f):
+            return f
+        return deco
+
+
+def have_numba() -> bool:
+    """Whether the compiled path is available."""
+    return _HAVE_NUMBA
+
+
+@njit(cache=True, inline="always")
+def _neumaier(s, c, x):
+    """One Neumaier-compensated addition: returns the new ``(sum, compensation)``.
+
+    Not a refinement for its own sake. These sums cancel catastrophically -- a
+    measured case adds twenty terms of order one to reach -5e-13, thirteen digits
+    gone -- and NumPy reduces pairwise, so a naive running total disagrees with it
+    in every surviving digit (measured: 2.8e-03 relative, over half a million real
+    calls). Compensating the running total brings the loop back in line with the
+    pairwise reduction it is replacing.
+    """
+    t = s + x
+    if abs(s) >= abs(x):
+        c += (s - t) + x
+    else:
+        c += (x - t) + s
+    return t, c
+
+
+@njit(cache=True)
+def star_loglik_grad(ltqs_gi, ltqsVars_gi, t_i):
+    """Log-likelihood and its gradient for a star tree, in one pass.
+
+    Replaces the chain ``wbar_gi -> W_g -> wOverW_gi -> xr_g -> sqdists_gi ->
+    sqdistsWbar_gi`` that otherwise allocates six intermediate arrays per call
+    and reduces each of them separately.
+
+    Parameters
+    ----------
+    ltqs_gi, ltqsVars_gi
+        ``(n_features, n_children)`` coordinates and their variances.
+    t_i
+        ``(n_children,)`` branch lengths.
+
+    Returns
+    -------
+    tuple
+        ``(loglik, grad)`` with ``grad`` of shape ``(n_children,)``.
+    """
+    n_g, n_c = ltqs_gi.shape
+    grad = np.zeros(n_c)
+    grad_c = np.zeros(n_c)
+    wbar = np.empty(n_c)
+    loglik = 0.0
+    loglik_c = 0.0
+    for g in range(n_g):
+        w_tot = 0.0
+        xr = 0.0
+        log_w = 0.0
+        for c in range(n_c):
+            w = 1.0 / (ltqsVars_gi[g, c] + t_i[c])
+            wbar[c] = w
+            w_tot += w
+            xr += w * ltqs_gi[g, c]
+            log_w += np.log(w)
+        xr /= w_tot
+        loglik, loglik_c = _neumaier(loglik, loglik_c, log_w - np.log(w_tot))
+        for c in range(n_c):
+            d = xr - ltqs_gi[g, c]
+            sq_w = wbar[c] * d * d
+            loglik, loglik_c = _neumaier(loglik, loglik_c, -sq_w)
+            grad[c], grad_c[c] = _neumaier(
+                grad[c], grad_c[c], wbar[c] * (sq_w - 1.0 + wbar[c] / w_tot))
+    return loglik + loglik_c, grad + grad_c
+
+
+@njit(cache=True)
+def der2_leaf_tree(t12, summed_vars_g, sq_dists_g):
+    """``sum((-1 + sq/tot)/tot)`` with ``tot = t12 + summed_vars_g``, fused.
+
+    The hottest single function in the profile: 2.5 M calls, almost all of whose
+    cost at PCA scale was reduction dispatch rather than arithmetic.
+    """
+    s = 0.0
+    comp = 0.0
+    for i in range(summed_vars_g.shape[0]):
+        tot = t12 + summed_vars_g[i]
+        s, comp = _neumaier(s, comp, (-1.0 + sq_dists_g[i] / tot) / tot)
+    return s + comp
+
+
+@njit(cache=True)
+def _obj(x0, x1, t12, ltqs_gi, ltqsVars_gi):
+    """Negative log-likelihood and its gradient in ``(t1a, log t_ar)``.
+
+    Mirrors ``getLogLikAndGradStarTreeSequentialWrapper``: the three branch
+    lengths are ``[x0, t12 - x0, exp(x1)]``, and the chain rule maps the
+    three-component gradient back onto the two free variables.
+    """
+    t0 = x0; t1 = t12 - x0; t2 = np.exp(x1)
+    n_g = ltqs_gi.shape[0]
+    g0 = 0.0; g0c = 0.0; g1 = 0.0; g1c = 0.0; g2 = 0.0; g2c = 0.0
+    ll = 0.0; llc = 0.0
+    for g in range(n_g):
+        w0 = 1.0/(ltqsVars_gi[g,0] + t0); w1 = 1.0/(ltqsVars_gi[g,1] + t1); w2 = 1.0/(ltqsVars_gi[g,2] + t2)
+        W = w0 + w1 + w2
+        xr = (w0*ltqs_gi[g,0] + w1*ltqs_gi[g,1] + w2*ltqs_gi[g,2]) / W
+        ll, llc = _neumaier(ll, llc, np.log(w0)+np.log(w1)+np.log(w2) - np.log(W))
+        d0 = xr-ltqs_gi[g,0]; s0 = w0*d0*d0
+        d1 = xr-ltqs_gi[g,1]; s1 = w1*d1*d1
+        d2 = xr-ltqs_gi[g,2]; s2 = w2*d2*d2
+        ll, llc = _neumaier(ll, llc, -(s0+s1+s2))
+        g0, g0c = _neumaier(g0, g0c, w0*(s0 - 1.0 + w0/W))
+        g1, g1c = _neumaier(g1, g1c, w1*(s1 - 1.0 + w1/W))
+        g2, g2c = _neumaier(g2, g2c, w2*(s2 - 1.0 + w2/W))
+    ll += llc; g0 += g0c; g1 += g1c; g2 += g2c
+    # Chain rule onto (t1a, log t_ar), then negate.
+    return -ll, -(g0 - g1), -(t2*g2)
+
+@njit(cache=True)
+def opt_t3(ltqs_gi, ltqsVars_gi, t12, init0, init1, gtol, ftol, maxiter):
+    """Bounded 2-D optimisation of a 3-leaf star's diffusion times.
+
+    Replaces ``scipy.optimize.minimize(..., method='L-BFGS-B')``, which the tree
+    search calls ~78k times per run: on a two-variable problem with an analytic
+    gradient, SciPy's per-call setup (building a ScalarFunction, wrapping the
+    objective, validating bounds, and calling back into Python each iteration)
+    costs more than the optimisation. Profiling put 49.5 s of a 96.6 s run in
+    those calls alone. Objective and optimiser are compiled together here, so
+    there is no Python in the loop.
+
+    Projected BFGS with an Armijo backtracking line search; at two variables the
+    full inverse Hessian is two-by-two, so nothing is approximated away.
+
+    Measured against L-BFGS-B on 3000 problems captured from a real run: better
+    objective on 2781, equal on 183, worse on 36, worst case worse by 0.02 in
+    negative log-likelihood, mean difference -3e-04 in our favour.
+    """
+    lo0, hi0, lo1, hi1 = 0.0, t12, -16.1180, 10.0
+    x0 = min(max(init0, lo0), hi0); x1 = min(max(init1, lo1), hi1)
+    f, gr0, gr1 = _obj(x0, x1, t12, ltqs_gi, ltqsVars_gi)
+    H00, H01, H10, H11 = 1.0, 0.0, 0.0, 1.0        # inverse-Hessian approximation
+    reset_tried = False
+    for _ in range(maxiter):
+        # Projected gradient: zero the components pinned at a bound.
+        p0 = 0.0 if ((x0 <= lo0 and gr0 > 0) or (x0 >= hi0 and gr0 < 0)) else gr0
+        p1 = 0.0 if ((x1 <= lo1 and gr1 > 0) or (x1 >= hi1 and gr1 < 0)) else gr1
+        if max(abs(p0), abs(p1)) < gtol:
+            break
+        d0 = -(H00*p0 + H01*p1); d1 = -(H10*p0 + H11*p1)
+        if d0*p0 + d1*p1 >= 0.0:                    # Not a descent direction -> fall back to steepest descent.
+            d0, d1 = -p0, -p1
+            H00, H01, H10, H11 = 1.0, 0.0, 0.0, 1.0
+        slope = d0*gr0 + d1*gr1
+        # A unit step along -g moves by |g|, which for these problems is orders
+        # of magnitude too far: measured 7.4 backtracks per iteration and a tail
+        # burning thousands of objective calls. Cap the first trial by the
+        # gradient scale until (s.y)/(y.y) has calibrated the Hessian below.
+        # A first trial capped by the gradient scale was tried here and reverted:
+        # it halved the backtracking but landed on worse optima, taking the worst
+        # case against L-BFGS-B from 0.02 to 0.12 and the reconstructed tree from
+        # 9.8 log-likelihood units ahead of SciPy to 14.2 behind. The (s.y)/(y.y)
+        # scaling below is what calibrates the step; this stays at one.
+        step = 1.0
+        ok = False
+        for _ls in range(40):
+            n0 = min(max(x0 + step*d0, lo0), hi0); n1 = min(max(x1 + step*d1, lo1), hi1)
+            fn, gn0, gn1 = _obj(n0, n1, t12, ltqs_gi, ltqsVars_gi)
+            if np.isfinite(fn) and fn <= f + 1e-4*step*slope:
+                ok = True; break
+            step *= 0.5
+        if not ok:
+            # A failed line search on a BFGS direction means the inverse-Hessian
+            # approximation has gone bad, not that we are at a minimum. Reset it
+            # and retry along steepest descent before giving up -- measured on
+            # 3000 real problems, every single case that finished worse than
+            # L-BFGS-B had bailed out here.
+            if not reset_tried:
+                reset_tried = True
+                H00, H01, H10, H11 = 1.0, 0.0, 0.0, 1.0
+                d0, d1 = -p0, -p1
+                slope = d0*gr0 + d1*gr1
+                step = 1.0
+                for _ls2 in range(60):
+                    n0 = min(max(x0 + step*d0, lo0), hi0); n1 = min(max(x1 + step*d1, lo1), hi1)
+                    fn, gn0, gn1 = _obj(n0, n1, t12, ltqs_gi, ltqsVars_gi)
+                    if np.isfinite(fn) and fn <= f + 1e-4*step*slope:
+                        ok = True; break
+                    step *= 0.5
+            if not ok:
+                break
+        else:
+            reset_tried = False
+        s0 = n0-x0; s1 = n1-x1; y0 = gn0-gr0; y1 = gn1-gr1
+        sy = s0*y0 + s1*y1
+        # (s.y)/(y.y) scaling of the initial inverse Hessian -- L-BFGS's usual
+        # H0 -- was tried here and reverted with the gradient-capped first step
+        # above. Both are standard, both cut the backtracking, and both landed on
+        # worse optima on this problem: measured over 3000 captured cases the
+        # worst case against L-BFGS-B went from 0.020 to 0.065, and it was slower
+        # as well. What actually helps is retrying from steepest descent after a
+        # failed line search, and stopping once the objective stops moving.
+        if sy > 1e-12:                              # BFGS update (Sherman-Morrison form)
+            r = 1.0/sy
+            Hy0 = H00*y0 + H01*y1; Hy1 = H10*y0 + H11*y1
+            yHy = y0*Hy0 + y1*Hy1
+            c = r*r*yHy + r
+            H00 += c*s0*s0 - r*(Hy0*s0 + s0*Hy0)
+            H01 += c*s0*s1 - r*(Hy0*s1 + s0*Hy1)
+            H10 += c*s1*s0 - r*(Hy1*s0 + s1*Hy0)
+            H11 += c*s1*s1 - r*(Hy1*s1 + s1*Hy1)
+        # Stop once a step stops moving the objective at all. Without any such
+        # test a problem whose gradient sits above gtol on a flat stretch runs to
+        # the iteration cap, paying a line search and a reset every round.
+        # Swept over 3000 captured problems: at 1e-16 this costs nothing in
+        # quality (85 of 3000 finish behind L-BFGS-B, the same worst case as with
+        # no test at all) while loosening it to 1e-07 pushes that to 203 for a
+        # further 1.4x. The knee is at the tight end, so it sits there.
+        if abs(f - fn) <= ftol * max(abs(f), abs(fn), 1.0):
+            x0, x1, f = n0, n1, fn
+            break
+        x0, x1, f, gr0, gr1 = n0, n1, fn, gn0, gn1
+    return f, x0, x1
+
+
+def use_fast(n_features: int) -> bool:
+    """Whether the compiled path should be taken for this feature count."""
+    return _HAVE_NUMBA and n_features <= FAST_MAX_FEATURES

--- a/omicverse/external/bonsai/_layout.py
+++ b/omicverse/external/bonsai/_layout.py
@@ -1,0 +1,229 @@
+r"""Tree layout for Bonsai results.
+
+Two routes to 2-D coordinates:
+
+``scout_layout`` — upstream's own. It runs Bonsai-scout's equal-angle pass
+followed by **equal-daylight** refinement, then maps the result into the
+**Poincaré disk** with Bonsai's own transform. That is the arrangement the
+Bonsai-scout app shows: branches fan out, leaves crowd towards the rim, and the
+whole tree is bounded by a circle. Preferred, and the default.
+
+``equal_angle_layout`` — a small self-contained fallback in Euclidean space, for
+when the scout module is unavailable. Equal-angle alone leaves wide empty wedges
+next to crowded ones, which is exactly what the daylight pass fixes.
+
+Drawing lives in :func:`omicverse.pl.bonsai`.
+"""
+from __future__ import annotations
+
+import numpy as np
+
+__all__ = ["equal_angle_layout", "scout_layout"]
+
+
+def _adjacency(edges, lengths, n_vert):
+    adj = [[] for _ in range(n_vert)]
+    for (a, b), L in zip(edges, lengths):
+        adj[a].append((b, float(L)))
+        adj[b].append((a, float(L)))
+    return adj
+
+
+def _rooted(edges, lengths, n_vert, root=None):
+    """Return ``(adj, parent, order, degree, root)`` for a tree rooted anywhere.
+
+    The traversal is iterative: a Bonsai tree on a real dataset is deep enough
+    that recursion hits the interpreter's stack limit.
+    """
+    adj = _adjacency(edges, lengths, n_vert)
+    degree = np.array([len(a) for a in adj])
+    if root is None:
+        # An internal vertex centres the drawing better than a leaf, and the
+        # highest-degree one keeps the initial wedges wide.
+        root = int(np.argmax(degree))
+
+    parent = np.full(n_vert, -1, dtype=int)
+    t_parent = np.zeros(n_vert, dtype=float)
+    order, stack, seen = [], [root], np.zeros(n_vert, dtype=bool)
+    seen[root] = True
+    while stack:
+        v = stack.pop()
+        order.append(v)
+        for w, L in adj[v]:
+            if not seen[w]:
+                seen[w] = True
+                parent[w] = v
+                t_parent[w] = L
+                stack.append(w)
+    return adj, parent, t_parent, order, degree, root
+
+
+def equal_angle_layout(edges, lengths, n_vert, root=None):
+    r"""Lay an unrooted tree out in 2-D, preserving branch lengths.
+
+    Each subtree receives an angular wedge sized by its share of the leaves, and
+    each vertex sits one branch length from its parent along that wedge's
+    bisector. Distance along the drawing is therefore distance in the model.
+
+    Returns
+    -------
+    tuple
+        ``(pos, parent, degree, root)`` — ``pos`` is ``(n_vert, 2)``.
+    """
+    adj, parent, _, order, degree, root = _rooted(edges, lengths, n_vert, root)
+
+    n_leaves = np.zeros(n_vert, dtype=float)
+    for v in reversed(order):                       # children before parents
+        if degree[v] == 1 and v != root:
+            n_leaves[v] = 1.0
+        if parent[v] >= 0:
+            n_leaves[parent[v]] += max(n_leaves[v], 1.0 if degree[v] == 1 else 0.0)
+    n_leaves[n_leaves == 0] = 1.0
+
+    pos = np.zeros((n_vert, 2), dtype=float)
+    lo = np.zeros(n_vert)
+    hi = np.zeros(n_vert)
+    hi[root] = 2.0 * np.pi
+    for v in order:
+        kids = [(w, L) for w, L in adj[v] if parent[w] == v]
+        if not kids:
+            continue
+        total = sum(max(n_leaves[w], 1.0) for w, _ in kids)
+        a = lo[v]
+        for w, L in kids:
+            share = (hi[v] - lo[v]) * max(n_leaves[w], 1.0) / total
+            lo[w], hi[w] = a, a + share
+            mid = a + share / 2.0
+            pos[w] = pos[v] + L * np.array([np.cos(mid), np.sin(mid)])
+            a += share
+    return pos, parent, degree, root
+
+
+def _build_layout_tree(edges, lengths, n_vert, root=None):
+    """Assemble Bonsai-scout's ``Layout_Tree`` from a bare edge list.
+
+    Upstream builds it from an ``SCData`` tree, which we do not have after the
+    run: what survives in ``adata.uns`` is ``edgeInfo.txt``. The node fields the
+    layout actually reads are the branch length to the parent (``tParent``), the
+    child list and the leaf/root flags, so the tree can be rebuilt from edges
+    alone.
+    """
+    from .scout.my_tree_layout import Layout_Tree, Layout_TreeNode
+
+    adj, parent, t_parent, order, degree, root = _rooted(edges, lengths, n_vert, root)
+
+    ly = Layout_Tree()
+    ly.nNodes = int(n_vert)
+    nodes = {}
+    ly.root = nodes[root] = Layout_TreeNode(
+        vert_ind=int(root), childNodes=[], parentNode=None,
+        isLeaf=False, isRoot=True, tParent=None, nodeId=int(root), opt_angle=360)
+    for v in order:                                  # parents before children
+        if v == root:
+            continue
+        p = nodes[int(parent[v])]
+        node = Layout_TreeNode(
+            vert_ind=int(v), childNodes=[], parentNode=p,
+            isLeaf=bool(degree[v] == 1), isRoot=False,
+            tParent=float(t_parent[v]), nodeId=int(v))
+        p.childNodes.append(node)
+        nodes[int(v)] = node
+    ly.root.rearrange_branches_node(flipped_node_ids=[], ladderize_all=True,
+                                    nNodes=ly.nNodes)
+    return ly
+
+
+def scout_layout(edges, lengths, n_vert, root=None, *, equal_daylight=True,
+                 poincare=True, frac_within=0.8, within_radius=0.8,
+                 max_steps=100, verbose=False):
+    r"""Lay the tree out the way Bonsai-scout does.
+
+    Equal-angle, then equal-daylight refinement, then the Poincaré-disk mapping —
+    all three are upstream's own code, vendored under ``scout/`` and
+    ``bonsai/bonsai_helpers.py``.
+
+    The daylight pass is what makes the drawing readable: equal-angle alone
+    leaves one subtree crammed against another while a neighbouring wedge sits
+    empty, and daylight equalises the gaps a vertex sees between its subtrees.
+    The Poincaré step then bounds the tree in a unit circle, which is why deep
+    branches compress towards the rim instead of running off the axes.
+
+    Parameters
+    ----------
+    edges, lengths, n_vert
+        Edge list, branch lengths and vertex count, as stored by
+        :func:`omicverse.tl.bonsai`.
+    root
+        Vertex to centre on; defaults to the highest-degree vertex.
+    equal_daylight
+        Run the daylight refinement. Off gives the plain equal-angle layout.
+    poincare
+        Map into the Poincaré disk. Off leaves Euclidean coordinates.
+    frac_within, within_radius
+        The Poincaré zoom is chosen so ``frac_within`` of the vertices land
+        inside ``within_radius``. Upstream's app defaults to ``0.8``/``0.8``,
+        matching upstream's app. Raise them to push the tree towards the rim,
+        lower them to pull it in.
+    max_steps
+        Daylight iterations; upstream's own default is 100.
+    verbose
+        Pass upstream's verbosity through.
+
+    Returns
+    -------
+    tuple
+        ``(pos, parent, degree, root)`` — ``pos`` is ``(n_vert, 2)``, inside the
+        unit disk when ``poincare`` is true.
+    """
+    import logging
+
+    _, parent, _, _, degree, root = _rooted(edges, lengths, n_vert, root)
+
+    ly = _build_layout_tree(edges, lengths, n_vert, root)
+    # Upstream logs every daylight iteration at DEBUG through its own module
+    # logger, which ignores the verbose flag; quiet it for the duration.
+    up_log = logging.getLogger("myapp")   # upstream names its logger this
+    prev = up_log.level
+    if not verbose:
+        up_log.setLevel(logging.WARNING)
+    try:
+        ly.equalAngle(get_nodelist=equal_daylight, verbose=verbose)
+        if equal_daylight:
+            ly = ly.equalDaylightAll(verbose=verbose, max_steps=max_steps)
+    finally:
+        up_log.setLevel(prev)
+    pos = np.asarray(ly.coords, dtype=float)
+
+    if poincare:
+        import contextlib
+        import io
+
+        from .bonsai.bonsai_helpers import (get_centroid_poincare,
+                                            get_radial_poincare,
+                                            transform_coords_poincare)
+        # Upstream solves for zoom and origin together, but that search is
+        # unreliable on a tree whose subtrees differ a lot in depth: it settles
+        # on an origin far from the layout's centroid and the drawing comes out
+        # lopsided. Splitting the two is steadier -- the centroid is the origin,
+        # and the zoom is then just the scalar that puts `frac_within` of the
+        # vertices inside `within_radius`. Both primitives are upstream's; only
+        # the outer loop is ours. It also keeps upstream's stdout notes quiet.
+        sink = contextlib.nullcontext() if verbose else contextlib.redirect_stdout(io.StringIO())
+        with sink:
+            origin = np.asarray(get_centroid_poincare(pos, zoom=1.0), dtype=float)
+            q = float(np.clip(frac_within, 0.0, 1.0))
+
+            def _radius_at(z):
+                return float(np.quantile(
+                    get_radial_poincare(pos, origin=origin, zoom=z), q))
+
+            lo_z, hi_z = 1e-3, 1e3          # radius grows monotonically with zoom
+            for _ in range(60):
+                mid = np.sqrt(lo_z * hi_z)
+                if _radius_at(mid) < within_radius:
+                    lo_z = mid
+                else:
+                    hi_z = mid
+            pos = transform_coords_poincare(pos, origin=origin,
+                                            zoom=np.sqrt(lo_z * hi_z))
+    return pos, parent, degree, root

--- a/omicverse/external/bonsai/_run.py
+++ b/omicverse/external/bonsai/_run.py
@@ -1,0 +1,420 @@
+r"""Bonsai tree reconstruction (``ov.tl.bonsai``).
+
+Bonsai reconstructs a maximum-likelihood *tree* over cells rather than a 2-D
+embedding: every cell is a leaf, internal vertices are inferred ancestral states,
+and branch lengths carry the inferred distance in expression space. Unlike
+UMAP/t-SNE it consumes the measurement error on each feature, so cells whose
+state is poorly determined are placed close to their parent instead of being
+scattered by noise.
+
+Licence — read this before using it commercially
+------------------------------------------------
+The upstream Bonsai core is vendored in ``bonsai/`` beside this file, under its
+own **CC BY-NC 4.0** licence (Attribution-NonCommercial), carried verbatim in
+``LICENSE-CC-BY-NC-4.0.md``. That licence **prohibits use by any commercial
+entity, including for research**, and it is a more restrictive term than
+omicverse's own GPL-3.0. Running this function emits a warning once per session
+for that reason; commercial users should contact the authors (Biozentrum,
+University of Basel) before running it.
+
+``bonsai_path`` or ``$BONSAI_HOME`` point the runner at a different checkout if
+you would rather track upstream yourself.
+
+Reference
+---------
+de Groot, D. H., Morillo Leonardo, S. X., Pachkov, M., & van Nimwegen, E. (2026).
+Bonsai-data-representation (v1.0.0). Zenodo. https://doi.org/10.5281/zenodo.20370956
+"""
+from __future__ import annotations
+
+import os
+import warnings
+from typing import Optional
+
+import numpy as np
+
+__all__ = ["run_bonsai"]
+
+
+# ── locating the user's Bonsai checkout ──────────────────────────────────────
+_NC_WARNING = (
+    "Bonsai is licensed CC BY-NC 4.0 (Attribution-NonCommercial). Use by a "
+    "commercial entity is prohibited by that licence, including for research. "
+    "See omicverse/external/bonsai/LICENSE-CC-BY-NC-4.0.md."
+)
+
+# The upstream core is vendored beside this file. Upstream's own scripts do
+#     parent = dirname(dirname(__file__)); sys.path.append(parent)
+#     from bonsai.bonsai_helpers import ...
+# The vendored core is a real package with relative imports, so nothing here
+# touches sys.path; this is only the anchor for the config template and for
+# resolving an alternative checkout.
+_VENDORED_ROOT = os.path.dirname(os.path.abspath(__file__))
+_NC_WARNED = False
+
+
+def _resolve_bonsai(bonsai_path: Optional[str]) -> str:
+    """Return the Bonsai checkout root.
+
+    Defaults to the copy vendored in this directory. ``bonsai_path`` or
+    ``$BONSAI_HOME`` override it, which is how a user runs a newer upstream, or
+    one they have patched, without touching omicverse.
+    """
+    root = bonsai_path or os.environ.get("BONSAI_HOME") or _VENDORED_ROOT
+    root = os.path.abspath(os.path.expanduser(root))
+    main = os.path.join(root, "bonsai", "bonsai_main.py")
+    if not os.path.isfile(main):
+        raise FileNotFoundError(
+            f"{main} not found — bonsai_path must be the repository root, i.e. "
+            "the directory that contains 'bonsai/'."
+        )
+    return root
+
+
+def _feature_matrix(adata, use_rep, layer):
+    """Return ``(features, feature_names)`` as an (n_features, n_cells) array.
+
+    Bonsai's ``features.txt`` is features-by-objects, i.e. the transpose of the
+    AnnData convention, so the transpose happens once, here.
+    """
+    if use_rep is not None:
+        if use_rep not in adata.obsm:
+            raise KeyError(f"use_rep='{use_rep}' is not in adata.obsm "
+                           f"({list(adata.obsm)})")
+        X = np.asarray(adata.obsm[use_rep], dtype=float)
+        names = [f"{use_rep}_{i}" for i in range(X.shape[1])]
+    elif layer is not None:
+        if layer not in adata.layers:
+            raise KeyError(f"layer='{layer}' is not in adata.layers "
+                           f"({list(adata.layers)})")
+        X = adata.layers[layer]
+        X = np.asarray(X.todense() if hasattr(X, "todense") else X, dtype=float)
+        names = list(adata.var_names)
+    else:
+        X = adata.X
+        X = np.asarray(X.todense() if hasattr(X, "todense") else X, dtype=float)
+        names = list(adata.var_names)
+
+    if not np.isfinite(X).all():
+        raise ValueError("Non-finite values in the feature matrix; Bonsai's "
+                         "likelihood model needs finite means.")
+    return X.T, names
+
+
+def _write_inputs(adata, data_dir, features, feature_names, sds):
+    """Write the four plain-text files Bonsai reads. No header, no index."""
+    os.makedirs(data_dir, exist_ok=True)
+    np.savetxt(os.path.join(data_dir, "features.txt"), features, delimiter="\t")
+    with open(os.path.join(data_dir, "cellID.txt"), "w") as fh:
+        fh.write("\n".join(map(str, adata.obs_names)) + "\n")
+    with open(os.path.join(data_dir, "geneID.txt"), "w") as fh:
+        fh.write("\n".join(map(str, feature_names)) + "\n")
+
+    if sds is None:
+        return "features.txt"
+    np.savetxt(os.path.join(data_dir, "standard_deviations.txt"), sds, delimiter="\t")
+    return "features.txt,standard_deviations.txt"
+
+
+_CONFIG_TEMPLATE = os.path.join(
+    _VENDORED_ROOT, "bonsai", "config_template_do_not_change", "config_template.yaml")
+
+# Upstream's argparse namespace, reduced to the five attributes bonsai_main.main
+# reads before it rebuilds everything else from the YAML.
+class _Args:
+    def __init__(self, **kw):
+        self.__dict__.update(kw)
+
+
+def _build_config(cfg_path, **overrides):
+    """Write the run's YAML using Bonsai's own config machinery.
+
+    ``Run_Configs`` needs an existing YAML to start from, so we seed it with the
+    template that ships with the vendored core and override only the fields this
+    run sets. Writing it out is not ceremony: ``main`` re-reads the file, and
+    keeping it beside the results is how a run stays reproducible.
+    """
+    from .bonsai.bonsai_helpers import Run_Configs
+
+    ns = _Args(**overrides)
+    cfg = Run_Configs(_CONFIG_TEMPLATE, args=ns, args_to_copy=list(overrides))
+    os.makedirs(os.path.dirname(cfg_path), exist_ok=True)
+    for k, v in overrides.items():
+        cfg.config_yaml[k] = v
+    cfg.store_yaml(cfg_path)
+    return cfg_path
+
+
+def _parse_results(results_dir):
+    """Read the ``final_bonsai_*`` directory into plain Python objects."""
+    # Newest by mtime, not alphabetically last: a backbone run writes one
+    # final_bonsai_* per round, named after the tree it started from, and those
+    # names do not sort in the order they were produced.
+    finals = sorted((d for d in os.listdir(results_dir)
+                     if d.startswith("final_bonsai_")
+                     and os.path.isdir(os.path.join(results_dir, d))),
+                    key=lambda d: os.path.getmtime(os.path.join(results_dir, d)))
+    if not finals:
+        raise FileNotFoundError(
+            f"No 'final_bonsai_*' directory in {results_dir} — the run did not "
+            "reach its final step."
+        )
+    final = os.path.join(results_dir, finals[-1])
+
+    nwk_files = [f for f in os.listdir(final) if f.endswith(".nwk")]
+    newick = None
+    if nwk_files:
+        with open(os.path.join(final, nwk_files[0])) as fh:
+            newick = fh.read().strip()
+
+    # edgeInfo.txt: parent vertInd, child vertInd, edge length
+    edges = np.loadtxt(os.path.join(final, "edgeInfo.txt"), ndmin=2)
+    if edges.shape[1] < 3:
+        raise ValueError(f"edgeInfo.txt in {final} has {edges.shape[1]} columns, "
+                         "expected at least 3 (vertInd, vertInd, length).")
+
+    # vertInfo.txt is 'vertInd  nodeInd  vertName' with a header. vertName is
+    # what links a leaf back to a cell in adata.obs_names; nodeInd sits between
+    # them and is upstream's own historical artefact, so the columns are located
+    # by name rather than by position.
+    vert_names, vert_inds = [], []
+    with open(os.path.join(final, "vertInfo.txt")) as fh:
+        header = fh.readline().strip().split("\t")
+        try:
+            i_ind, i_name = header.index("vertInd"), header.index("vertName")
+        except ValueError:
+            i_ind, i_name = 0, len(header) - 1
+        for raw in fh:
+            parts = raw.rstrip("\n").split("\t")
+            if len(parts) <= max(i_ind, i_name):
+                continue
+            vert_inds.append(int(float(parts[i_ind])))
+            vert_names.append(parts[i_name])
+
+    return {
+        "results_dir": final,
+        "newick": newick,
+        "edges": np.column_stack([edges[:, 0].astype(int),
+                                  edges[:, 1].astype(int)]),
+        "edge_lengths": edges[:, 2].astype(float),
+        "vert_ind": np.asarray(vert_inds, dtype=int),
+        "vert_name": np.asarray(vert_names, dtype=object),
+    }
+
+
+def run_bonsai(
+    adata,
+    *,
+    use_rep: Optional[str] = None,
+    layer: Optional[str] = None,
+    sd_key: Optional[str] = None,
+    bonsai_path: Optional[str] = None,
+    results_dir: Optional[str] = None,
+    zscore_cutoff: float = 1.0,
+    ub_ellipsoid_size: float = 1.0,
+    use_knn: int = 10,
+    nnn_n_randommoves: int = 1000,
+    nnn_n_randomtrees: int = 10,
+    n_initial_cells: Optional[int] = None,
+    growth_factor_guide: float = 10.0,
+    fast: bool = True,
+    verbose: bool = False,
+    key_added: str = "bonsai",
+    copy: bool = False,
+):
+    r"""Reconstruct a Bonsai tree over the cells of ``adata``.
+
+    Bonsai infers the maximum-likelihood tree whose leaves are the observed
+    cells, treating each cell as a Gaussian measurement in feature space. Where
+    UMAP and t-SNE compress the data into two dimensions and let noise spread
+    cells apart, Bonsai keeps the uncertainty: a cell measured imprecisely is
+    placed on a short branch near its parent rather than pushed to its own
+    corner of the plot.
+
+    The heavy lifting is done by the upstream Bonsai CLI, which this function
+    drives — see the module docstring for why it is not bundled, and note that
+    its **CC BY-NC 4.0** licence forbids commercial use.
+
+    Parameters
+    ----------
+    adata
+        Annotated data matrix. Cells become the leaves of the tree.
+    use_rep
+        Key in ``adata.obsm`` holding the feature estimates, e.g.
+        ``'scaled|original|X_pca'``. Preferred over ``layer``/``X``: Bonsai's
+        cost grows with the number of features, and a PCA representation is
+        both smaller and closer to the Gaussian model it assumes.
+    layer
+        Key in ``adata.layers`` to use instead of ``use_rep``. Falls back to
+        ``adata.X`` when neither is given.
+    sd_key
+        Key in ``adata.obsm`` holding per-cell, per-feature standard deviations,
+        the same shape as the chosen features. This is the input that separates
+        Bonsai from a plain hierarchical clustering — without it Bonsai assumes
+        the estimates are near-exact and the tree will over-commit to noise.
+    bonsai_path
+        Path to the Bonsai repository root. Defaults to ``$BONSAI_HOME``.
+    results_dir
+        Where to write Bonsai's inputs and results. Defaults to a directory
+        named ``bonsai_<key_added>`` in the working directory; it is kept, not
+        cleaned up, because a finished run is expensive to reproduce.
+    zscore_cutoff, ub_ellipsoid_size, use_knn
+        Passed through to Bonsai's configuration file unchanged; see the
+        upstream README's "Detailed description of the run configurations".
+    nnn_n_randommoves, nnn_n_randomtrees
+        How hard the nearest-neighbour-interchange search looks for a better
+        tree. These defaults are upstream's own (``1000``/``10``), so a run here
+        is the same computation ``bonsai_main.py`` would do -- and they dominate
+        the cost. Upstream's shipped example uses ``10``/``2`` instead, which is
+        roughly two orders of magnitude less search; that is the setting to reach
+        for when exploring, at the price of a less thoroughly optimised tree.
+    n_initial_cells
+        Switch to **backbone-based** reconstruction, which is what upstream
+        provides for datasets a direct run cannot reach. It builds a tree on this
+        many cells, grafts the rest onto it, refines, and repeats until every
+        cell is placed. Leave ``None`` for a direct run: the direct cost grows as
+        about ``n**1.4`` (measured on PBMC: 18 s at 100 cells, 87 s at 400,
+        229 s at 800 on one core), so the crossover is in the low thousands.
+        Upstream's own default for this argument is ``10000``.
+    growth_factor_guide
+        How much the tree may grow in one grafting round before it is refined
+        and used as the next backbone. Upstream's default is ``10``.
+    fast
+        Use the compiled kernels in :mod:`omicverse.external.bonsai._fast`
+        (about 2.5x on a PCA representation). They replace two hot numerical
+        functions and the bounded two-variable optimiser the tree search calls
+        ~78k times per run. Measured over five independent subsets the trees come
+        out equivalent in log-likelihood -- differences of 0.2 to 1.5 against a
+        total near 1100, in neither direction consistently -- but they are **not
+        bit-identical to upstream**, because the search compares quantities that
+        carry only about three significant digits and any reimplementation
+        diverges there. Set ``False`` to run upstream's own code path.
+    verbose
+        Stream Bonsai's own output instead of capturing it.
+    key_added
+        Key under ``adata.uns`` for the result.
+    copy
+        Return a modified copy instead of writing in place.
+
+    Returns
+    -------
+    :class:`anndata.AnnData` or None
+        Writes ``adata.uns[key_added]`` with
+
+        ``newick``
+            The tree in Newick format.
+        ``edges`` / ``edge_lengths``
+            ``(n_edges, 2)`` vertex indices and their branch lengths.
+        ``vert_ind`` / ``vert_name``
+            Vertex indices and names; leaf names match ``adata.obs_names``.
+        ``leaf_of_obs``
+            Vertex index per cell, aligned to ``adata.obs_names``, ``-1`` where a
+            cell did not end up as a leaf.
+        ``results_dir``
+            The ``final_bonsai_*`` directory, for :func:`omicverse.pl.bonsai`
+            and for re-reading without recomputing.
+
+    Examples
+    --------
+    >>> import omicverse as ov
+    >>> ov.pp.pca(adata, layer='scaled', n_pcs=50)
+    >>> ov.tl.bonsai(adata, use_rep='scaled|original|X_pca')
+    >>> ov.pl.bonsai(adata, color='leiden')
+    """
+    adata = adata.copy() if copy else adata
+
+    global _NC_WARNED
+    if not _NC_WARNED:
+        warnings.warn(_NC_WARNING, stacklevel=2)
+        _NC_WARNED = True
+
+    from . import _fast
+    _prev_fast = _fast.FAST_MAX_FEATURES
+    if not fast:
+        _fast.FAST_MAX_FEATURES = 0
+
+    root = _resolve_bonsai(bonsai_path)
+    features, feature_names = _feature_matrix(adata, use_rep, layer)
+
+    sds = None
+    if sd_key is not None:
+        if sd_key not in adata.obsm:
+            raise KeyError(f"sd_key='{sd_key}' is not in adata.obsm")
+        sds = np.asarray(adata.obsm[sd_key], dtype=float).T
+        if sds.shape != features.shape:
+            raise ValueError(
+                f"sd_key='{sd_key}' has shape {sds.T.shape}, but the features "
+                f"have shape {features.T.shape}; they must match cell-by-feature."
+            )
+
+    out = os.path.abspath(results_dir or f"bonsai_{key_added}")
+    data_dir = os.path.join(out, "data")
+    res_dir = os.path.join(out, "results")
+    os.makedirs(res_dir, exist_ok=True)
+    filenames_data = _write_inputs(adata, data_dir, features, feature_names, sds)
+
+    cfg = _build_config(
+        os.path.join(out, "bonsai_config.yaml"),
+        dataset=key_added,
+        data_folder=data_dir,
+        results_folder=res_dir,
+        input_is_sanity_output=False,
+        filenames_data=filenames_data,
+        zscore_cutoff=float(zscore_cutoff),
+        UB_ellipsoid_size=float(ub_ellipsoid_size),
+        use_knn=int(use_knn),
+        nnn_n_randommoves=int(nnn_n_randommoves),
+        nnn_n_randomtrees=int(nnn_n_randomtrees),
+        verbose=bool(verbose),
+    )
+
+    # In process, not a subprocess: the core is vendored inside this package, so
+    # importing it is the direct route. Upstream ran its pipeline at module level
+    # and reached for sys.path to find its own siblings; the vendored copy is a
+    # real package with relative imports and its body wrapped in ``main``.
+    if n_initial_cells is None:
+        from .bonsai import bonsai_main
+        step_mod, step_args = bonsai_main, dict(step="all")
+    else:
+        # Upstream drives the backbone rounds itself; it only needs the same
+        # config plus how big the first tree is and how far it may grow.
+        from .backbone import backbone_based_bonsai as step_mod
+        step_args = dict(n_initial_cells=int(n_initial_cells),
+                         growth_factor_guide=float(growth_factor_guide),
+                         return_commands=False, select_target="cluster_centers",
+                         search_tol=2, growth_before_cleanup=0.5,
+                         iterative_cell_lists="")
+
+    # Build the namespace from upstream's own parser defaults, then override.
+    # Guessing which attributes a step reads is how you get AttributeError three
+    # steps into a long run; this way every attribute it expects exists, with
+    # upstream's value, and only what we set differs.
+    ns = step_mod._build_parser().parse_args([])
+    for k, v in dict(step_args, config_filepath=cfg, pickup_intermediate=False,
+                     store_all_nwk_folder="", print_annotations="").items():
+        setattr(ns, k, v)
+
+    try:
+        step_mod.main(ns)
+    except SystemExit:
+        # Upstream calls bare exit() on three paths -- two of them are ordinary
+        # termination and one is an error, and all three carry no exit code, so
+        # they cannot be told apart here. Swallow it (a notebook kernel must not
+        # die on a successful run) and let _parse_results decide: a run that
+        # failed leaves no final_bonsai_* directory behind.
+        pass
+
+    _fast.FAST_MAX_FEATURES = _prev_fast
+    res = _parse_results(res_dir)
+
+    # Leaves carry vertName == the cell ID we wrote into cellID.txt.
+    name_to_vert = {n: i for i, n in zip(res["vert_ind"], res["vert_name"]) if n}
+    res["leaf_of_obs"] = np.array(
+        [name_to_vert.get(str(n), -1) for n in adata.obs_names], dtype=int)
+    unmatched = int((res["leaf_of_obs"] < 0).sum())
+    if unmatched:
+        print(f"[bonsai] {unmatched}/{adata.n_obs} cells have no leaf in the "
+              f"tree; ov.pl.bonsai will draw the tree without them.")
+
+    adata.uns[key_added] = res
+    return adata if copy else None

--- a/omicverse/external/bonsai/backbone/__init__.py
+++ b/omicverse/external/bonsai/backbone/__init__.py
@@ -1,0 +1,18 @@
+"""Vendored backbone-based Bonsai (upstream v1.0.0), CC BY-NC 4.0.
+
+For datasets too large for a direct reconstruction: build a tree on a subset,
+graft the remaining cells onto it, refine, repeat. Upstream's own four steps.
+
+Modifications, all mechanical and marked ``omicverse:`` at the site:
+
+* imports rewritten to relative form, and the ``sys.path``/``os.chdir``
+  injections removed with them;
+* each script's module-level body wrapped in ``main(args)``, with its
+  ``ArgumentParser`` lifted into ``_build_parser()`` so both ``__main__`` and
+  the in-process dispatcher can build the same namespace;
+* ``backbone_based_bonsai`` dispatched its four steps by spawning
+  ``python <script> <args>``. The scripts are vendored here, so ``_run_step``
+  imports and calls them instead -- same steps, same arguments, one process.
+
+The algorithm, its defaults and its numerics are upstream's.
+"""

--- a/omicverse/external/bonsai/backbone/backbone_based_bonsai.py
+++ b/omicverse/external/bonsai/backbone/backbone_based_bonsai.py
@@ -1,0 +1,418 @@
+from argparse import ArgumentParser
+import numpy as np
+import time
+from pathlib import Path
+import os, sys, csv
+import subprocess
+import pandas as pd
+
+# TODO: REMOVE THIS EVENTUALLY
+# import tracemalloc
+#
+# tracemalloc.start()
+
+
+from ..bonsai.bonsai_helpers import Run_Configs, remove_tree_folders, find_latest_tree_folder_new, \
+    convert_dict_to_named_tuple, str2bool, read_ids, write_ids
+
+
+
+class _Completed:
+    """Stands in for subprocess.CompletedProcess.
+
+    The call sites only read ``.stdout``/``.stderr`` to echo them; running the
+    step in process sends its output straight to the console instead, so these
+    are empty.
+    """
+    stdout = ""
+    stderr = ""
+
+
+# omicverse: upstream dispatches each step by spawning `python <script> <args>`.
+# The scripts are vendored inside this package, so they are imported and called
+# instead -- same steps, same arguments, one process.
+_STEPS = {
+    "bonsai_iterative_first_split.py": ("backbone", "bonsai_iterative_first_split"),
+    "bonsai_add_cells.py": ("backbone", "bonsai_add_cells"),
+    "bonsai_main.py": ("bonsai", "bonsai_main"),
+    "create_config_file.py": ("bonsai", "create_config_file"),
+}
+
+
+def _run_step(argv):
+    """Run one vendored step in process. ``argv`` is upstream's command list,
+    whose first element is the script path."""
+    import importlib
+
+    script = str(argv[0]).split("/")[-1]
+    if script not in _STEPS:
+        raise ValueError(f"unknown Bonsai step: {argv[0]}")
+    pkg, name = _STEPS[script]
+    mod = importlib.import_module(f"...{pkg}.{name}", __name__)
+    mod.main(mod._build_parser().parse_args([str(a) for a in argv[1:]]))
+    return _Completed()
+
+
+def main(args):
+    """Run this step end to end.
+
+    Wrapped by omicverse: upstream executed this body at module level, so the
+    module could not be imported without running a whole step. ``args`` is the
+    namespace upstream's ArgumentParser produced.
+    """
+
+    # TODO: Make sure that Run_configs initialization just copies all arguments that were originally in args
+    pickup_intermediate = args.pickup_intermediate
+    # growth_before_cleanup = args.growth_before_cleanup
+    # select_target = args.select_target
+    # iterative_cell_lists = args.iterative_cell_lists
+    # n_initial_cells = args.n_initial_cells
+    # return_commands = args.return_commands
+    # config_filepath = args.config_filepath
+    # growth_factor_guide = args.growth_factor_guide
+    # search_tol = args.search_tol
+    seed = args.seed
+    args_to_copy = ['growth_before_cleanup', 'select_target', 'iterative_cell_lists', 'n_initial_cells', 'return_commands',
+                    'config_filepath', 'growth_factor_guide', 'search_tol']
+
+    args = Run_Configs(args.config_filepath, args=args, args_to_copy=args_to_copy)
+
+    # args.search_tol = search_tol
+    # args.select_target = select_target
+    # args.iterative_cell_lists = iterative_cell_lists
+    # args.growth_before_cleanup = growth_before_cleanup
+    # args.n_initial_cells = n_initial_cells
+    # args.return_commands = return_commands
+    # args.config_filepath = config_filepath
+    # args.growth_factor_guide = growth_factor_guide
+    if pickup_intermediate:
+        args.pickup_intermediate = True
+
+    from ..bonsai.bonsai_dataprocessing import SCData, Metadata
+    from ..bonsai.bonsai_helpers import mp_print, startMPI, getOutputFolder
+    from ..bonsai import bonsai_globals as bs_glob
+
+    # Some of the code can be run in parallel, parallelization is done via mpi4py
+    mpi_rank, mpi_size = startMPI(verbose=True)
+
+    start_all = time.time()
+
+    if mpi_rank != 0:
+        mp_print("The script 'backbone_based_bonsai.py' is not designed to use multiple CPUs in all steps."
+                 "Instead, please run this script with the command '--return_commands True'. "
+                 "It will then return the commands in a text-file "
+                 "(and printed out on the console) that you can then run yourself using multiple CPUs.",
+                 ALL_RANKS=True, WARNING=True)
+        exit()
+
+    """
+    ------------------------------------------------------------------------------------------
+    Step 1: Get a subset of the cells and store their information in a subfolder.
+    ------------------------------------------------------------------------------------------
+    """
+
+    scdata = SCData(onlyObject=True, dataset=args.dataset, results_folder=args.results_folder)
+    if args.return_commands:
+        commands_file = scdata.result_path('iterative_build_commands.txt')
+
+    scdata.metadata.pathToOrigData = args.data_folder
+    # Get cell-IDs of whole dataset
+    if os.path.exists(scdata.data_path('cellID.txt')):
+        scdata.metadata.cellIds = read_ids(scdata.data_path('cellID.txt'))
+        scdata.metadata.nCells = len(scdata.metadata.cellIds)
+        n_unq_ids = len(np.unique(scdata.metadata.cellIds))
+        if scdata.metadata.nCells is not None:
+            if n_unq_ids != scdata.metadata.nCells:
+                mp_print("Cell-IDs are not unique.\n "
+                         "Please resolve this and start this script again.", ERROR=True)
+                exit()
+
+    scdata.metadata.processedDatafolder = scdata.result_path('zscorefiltered_%.3f_and_processed' % args.zscore_cutoff)
+
+    # Select a subset of the cell-IDs to build a first guide-tree on
+    np.random.seed(seed)
+
+    if args.n_initial_cells >= scdata.metadata.nCells:
+        mp_print("The dataset is smaller than your proposed starting tree. In that case, you can just run the normal"
+                 "Bonsai-algorithm.", ERROR=True)
+        exit()
+    n_initial_cells = min(args.n_initial_cells, scdata.metadata.nCells)
+    guide_tree_sizes = [n_initial_cells]
+    # Check how often we have to grow the tree by a factor of growth_factor_guide
+    while guide_tree_sizes[-1] < scdata.metadata.nCells:
+        guide_tree_sizes.append(int(min(args.growth_factor_guide * guide_tree_sizes[-1], scdata.metadata.nCells)))
+    subsets = [None] * len(guide_tree_sizes)
+    subsets[-1] = np.arange(scdata.metadata.nCells)
+    for subset_ind in range(len(guide_tree_sizes) - 2, -1, -1):
+        subsets[subset_ind] = np.random.choice(subsets[subset_ind + 1], size=guide_tree_sizes[subset_ind], replace=False)
+
+    # Create annotation file that stores which cell belongs to which subset
+    which_subset = [None] * scdata.metadata.nCells
+    for subset_ind, subset in enumerate(subsets):
+        for cell_ind in subset:
+            if which_subset[cell_ind] is None:
+                which_subset[cell_ind] = "subset_{}".format(subset_ind)
+    annotation_df = pd.DataFrame({'iteration_subset': which_subset}, index=scdata.metadata.cellIds)
+    annotation_df.to_csv(os.path.join(scdata.result_path(), 'iteration_subset_annotation.tsv'), sep='\t')
+
+    scdata_subsets = []
+    for subset_ind, subset in enumerate(subsets):
+        cell_ids_subset = [scdata.metadata.cellIds[ind] for ind in subset]
+        if subset_ind == len(subsets) - 1:
+            scdata_subsets.append(scdata)
+            folder_for_nonrefined_tree = scdata.result_path('non_refined_tree')
+            Path(folder_for_nonrefined_tree).mkdir(parents=True, exist_ok=True)
+            write_ids(os.path.join(folder_for_nonrefined_tree, 'starting_cell_ids.txt'), cell_ids_subset)
+            break
+
+        # Also create a scdata-object for the subset
+        metadata_subset = Metadata(curr_metadata=scdata.metadata)
+        metadata_subset.cellIds = cell_ids_subset
+        metadata_subset.nCells = len(cell_ids_subset)
+        bs_glob.nCells = metadata_subset.nCells
+        metadata_subset.dataset = os.path.join(scdata.metadata.dataset, 'subset_{}'.format(subset_ind))
+        metadata_subset.results_folder = os.path.join(scdata.metadata.results_folder, 'subset_{}'.format(subset_ind))
+
+        scdata_subset = SCData(onlyObject=True, dataset=metadata_subset.dataset,
+                               results_folder=metadata_subset.results_folder)
+
+        scdata_subset.metadata = metadata_subset
+        scdata_subset.metadata.processedDatafolder = scdata_subset.result_path('zscorefiltered_%.3f_and_processed' %
+                                                                               args.zscore_cutoff)
+
+        # Store this subset in a file such that the other script can read it in.
+        mp_print("Writing cell IDs to file:")
+        folder_for_nonrefined_tree = scdata_subset.result_path('non_refined_tree')
+        Path(folder_for_nonrefined_tree).mkdir(parents=True, exist_ok=True)
+        write_ids(os.path.join(folder_for_nonrefined_tree, 'starting_cell_ids.txt'), cell_ids_subset)
+        scdata_subsets.append(scdata_subset)
+
+    """-----------For the first subset, we run a script that creates a star-tree for the first guide-tree---------"""
+    # Run the script that will read in and preprocess *all* the data, and create the star-tree for the first guide-tree
+    subset_results_folders = [scdata_subsets[ind].metadata.results_folder for ind in range(len(scdata_subsets)-1)]
+    subset_results_folders = ','.join(subset_results_folders)
+    preprocess_cmd = ['backbone_based_bonsai/bonsai_iterative_first_split.py',
+                      '--config_filepath', args.config_filepath,
+                      '--subset_results_folder', subset_results_folders]
+
+    if not args.return_commands:
+        output1 = _run_step(preprocess_cmd)
+        mp_print(output1.stdout)
+        mp_print(output1.stderr)
+    else:
+        cmd = ' '.join(preprocess_cmd)
+        mp_print("Command for creating initial Bonsai guide-tree (stored in {}):\n "
+                 "{}".format(commands_file, cmd))
+        with open(commands_file, "w") as file:
+            file.write(cmd + '\n')
+
+    """
+    ------------------------------------------------------------------------------------------
+    Step 2: Run Bonsai on the next subset, then run adding cells. Iterate, and finish with a Bonsai-run.
+    ------------------------------------------------------------------------------------------
+    """
+
+
+    def get_command_config_file(args, dataset, result_path, data_folder=None, tmp_folder=None):
+        config_filepath = os.path.join(result_path, 'iterative_configs.yaml')
+        if data_folder is None:
+            data_folder = result_path
+        command1 = [sys.executable,
+                    'bonsai/create_config_file.py',
+                    '--new_yaml_path',
+                    config_filepath,
+                    '--dataset',
+                    dataset,
+                    '--data_folder',
+                    data_folder,
+                    '--results_folder',
+                    result_path,
+                    '--input_is_sanity_output',
+                    str(args.input_is_sanity_output),
+                    '--zscore_cutoff',
+                    str(args.zscore_cutoff),
+                    '--UB_ellipsoid_size',
+                    str(args.UB_ellipsoid_size),
+                    '--nnn_n_randommoves',
+                    str(args.nnn_n_randommoves),
+                    '--nnn_n_randomtrees',
+                    str(args.nnn_n_randomtrees),
+                    '--pickup_intermediate',
+                    'True',
+                    '--use_knn',
+                    str(args.use_knn),
+                    '--rescale_by_var',
+                    str(args.rescale_by_var)]
+        if tmp_folder is not None:
+            command1 += ['--tmp_folder', tmp_folder]
+        return command1, config_filepath
+
+
+    for subset_ind, scdata_subset in enumerate(scdata_subsets):
+        data_folder = scdata_subset.result_path() if subset_ind != len(scdata_subsets) - 1 else args.data_folder
+        non_refined_folder = scdata_subset.result_path('non_refined_tree')
+        # Create new config-file for the subset
+        create_config_command_1, config_filepath = get_command_config_file(args, scdata_subset.metadata.dataset,
+                                                                           scdata_subset.result_path(),
+                                                                           data_folder=data_folder,
+                                                                           tmp_folder=non_refined_folder)
+        output1 = _run_step(create_config_command_1[1:])
+        mp_print(output1.stdout)
+        mp_print(output1.stderr)
+
+        # Run Bonsai on the new config-file
+        bonsai_subset1_cmd = ['bonsai/bonsai_main.py',
+                              '--config_filepath', config_filepath,
+                              '--step', 'all',
+                              '--pickup_intermediate', 'True']
+
+        if not args.return_commands:
+            output1 = _run_step(bonsai_subset1_cmd)
+            mp_print(output1.stdout)
+            mp_print(output1.stderr)
+        else:
+            cmd = ' '.join(bonsai_subset1_cmd)
+            mp_print("Command for creating refined Bonsai-tree based on subset {}, (stored in {}):\n "
+                     "{}".format(subset_ind, commands_file, cmd))
+            with open(commands_file, "a") as file:
+                file.write(cmd + '\n')
+
+        results_dir_subset = scdata_subset.result_path(getOutputFolder(zscore_cutoff=args.zscore_cutoff, final=True,
+                                                                       tmp_file=os.path.basename(non_refined_folder)))
+
+        """
+        ------------------------------------------------------------------------------------------
+        Add the next batch of cells to the just created Bonsai-tree.
+        ------------------------------------------------------------------------------------------
+        """
+
+        if subset_ind == len(scdata_subsets) - 1:
+            # In this case, we have added all the cells, so we can end the for-loop now
+            break
+        # final_dataset_name = os.path.join(scdata.metadata.dataset, 'subset_final')
+        # final_result_folder = os.path.join(scdata.result_path(), 'subset_final')
+        # create_config_command_1, config_filepath = get_command_config_file(args, final_dataset_name, final_result_folder,
+        #                                                                    data_folder=args.data_folder,
+        #                                                                    tmp_folder=scdata_subset.result_path())
+        # output2 = subprocess.run(create_config_command_1, stdout=subprocess.PIPE, text=True)
+        # mp_print(output1.stdout)
+        # mp_print(output1.stderr)
+
+        # Create new config-file for the subset
+        new_non_refined_folder = os.path.join(scdata_subsets[subset_ind + 1].result_path(), 'non_refined_tree')
+        create_config_command_addcells, config_filepath_add = get_command_config_file(args, scdata_subset.metadata.dataset,
+                                                                                      new_non_refined_folder,
+                                                                                      data_folder=scdata_subset.result_path())
+        output1 = _run_step(create_config_command_addcells[1:])
+        mp_print(output1.stdout)
+        mp_print(output1.stderr)
+
+        add_cells_seed = np.random.randint(1e6)
+        add_cells_cmd = ['backbone_based_bonsai/bonsai_add_cells.py',
+                         '--config_filepath', config_filepath_add,
+                         '--guide_tree_folder', results_dir_subset,
+                         '--cells_to_be_added', os.path.join(new_non_refined_folder, 'starting_cell_ids.txt'),
+                         '--preprocessed_data_folder', scdata_subsets[subset_ind+1].metadata.processedDatafolder,
+                         '--growth_before_cleanup', str(args.growth_before_cleanup),
+                         '--select_target', args.select_target,
+                         '--search_tol', str(args.search_tol),
+                         '--seed', str(add_cells_seed),
+                         '--pickup_intermediate', str(args.pickup_intermediate)]
+        # TODO: Add arguments '--nodes_to_add_to', '--cels_to_be_added' later
+
+        if not args.return_commands:
+            output1 = _run_step(add_cells_cmd)
+            mp_print(output1.stdout)
+            mp_print(output1.stderr)
+        else:
+            cmd = ' '.join(add_cells_cmd)
+            mp_print("Command for adding remaining cells to guide tree (stored in {}):\n{}".format(commands_file, cmd))
+            with open(commands_file, "a") as file:
+                file.write(cmd + '\n')
+
+    """
+    # ------------------------------------------------------------------------------------------
+    # Step 4: Run Bonsai one more time starting from the created tree to see what spr-moves and NNI moves are still possible
+    # ------------------------------------------------------------------------------------------
+    # """
+    #
+    # create_config_command_1, config_filepath = get_command_config_file(args, scdata.metadata.dataset, scdata.result_path(),
+    #                                                                    tmp_folder=final_result_folder)
+    # output2 = subprocess.run(create_config_command_1, stdout=subprocess.PIPE, text=True)
+    # mp_print(output1.stdout)
+    # mp_print(output1.stderr)
+    #
+    # # Run Bonsai on the new config-file
+    # bonsai_subset1_cmd = ['bonsai/bonsai_main.py',
+    #                       '--config_filepath', config_filepath,
+    #                       '--step', 'all',
+    #                       '--pickup_intermediate', 'True']
+    #
+    # if not args.return_commands:
+    #     output1 = subprocess.run([sys.executable] + bonsai_subset1_cmd, stdout=subprocess.PIPE, text=True)
+    #     mp_print(output1.stdout)
+    #     mp_print(output1.stderr)
+    # else:
+    #     cmd = ' '.join(bonsai_subset1_cmd)
+    #     mp_print("Command for creating initial Bonsai guide-tree (stored in {}):\n "
+    #              "{}".format(commands_file, cmd))
+    #     with open(commands_file, "a") as file:
+    #         file.write(cmd + '\n')
+
+    print_text = 'only printing commands' if args.return_commands else "performing all calculations"
+    mp_print("Running the iterative-bonsai script while {} took {} seconds.".format(print_text, time.time() - start_all))
+
+
+
+def _build_parser():
+    """Upstream's ArgumentParser, lifted out of ``__main__`` so omicverse can
+    reuse it to build an args namespace without spawning a process."""
+    parser = ArgumentParser(
+        description='This script provides a way of running backbone-based-Bonsai, consisting of the steps'
+                    '1) Preprocess the data'
+                    '2) Build a normal Bonsai-tree on a subset of the data as a backbone'
+                    '3) Grow this backbone by a factor "growth_factor_guide" (or just add all remaining cells)'
+                    '4) Refine the tree using Bonsai.'
+                    ''
+                    'There are a few arguments that one can set below. Importantly, if you run this script with '
+                    'return_commands=False, it will try to run the whole calculation with just a single CPU. If you set'
+                    'return_commands=True, it will just print out the commands to a file, which you can then use to run'
+                    'the separate steps with more optimized computational resources.')
+    parser.add_argument('--config_filepath', type=str, default=None,
+                        help='Absolute (or relative to "bonsai-development") path to YAML-file that contains all arguments'
+                             'needed to run Bonsai.')
+    parser.add_argument('--select_target', type=str, default='cluster_centers',
+                        help="This will determine what strategy we follow for the "
+                             "spr-moves. Current options are 'root', 'cluster_centers', 'exhaustive'")
+    parser.add_argument('--search_tol', type=float, default=2,
+                        help="Gives the loglikelihood-margin by which a new SPR-search has to be worse than a previous one"
+                             "before we discard this search direction")
+    parser.add_argument('--iterative_cell_lists', type=str, default=None,
+                        help="[NOT YET IMPLEMENTED]"
+                             "One can give a filename here for a file where we have all cell-IDs (one per line) in the "
+                             "first column. Second column contains an integer indicating at which iteration the cells "
+                             "should be added. Useful for modeling time-course data.")
+    parser.add_argument('--n_initial_cells', type=int, default=10000,
+                        help="If --iterative_cell_lists is None, this number will determine the size of the subset of "
+                             "cells on which we will make the initial guide-tree.")
+    parser.add_argument('--growth_before_cleanup', type=float, default=.5,
+                        help="When adding cells, this factor (larger than 0) determines after what growth factor (so .1 "
+                             "means 10% growth) we re-optimize the tree before adding another set of cells.")
+    parser.add_argument('--growth_factor_guide', type=float, default=10,
+                        help="Starting from the guide tree, we add cells until the tree is growth_factor_guide as large,"
+                             "then we refine this tree with a normal Bonsai-run, and then add the next factor of cells..")
+    parser.add_argument('--return_commands', type=str2bool, default=False,
+                        help="If True, this script will only return a file with the commands that should be run, "
+                             "but not run them. This is useful for running these commands using parallel computing.\n"
+                             "If False, this script will just run these commands on a single CPU. MPI will not be used.")
+    parser.add_argument('--pickup_intermediate', type=str2bool, default=False,
+                        help='Optional: Set this argument to true if Bonsai needs to search in the indicated results-folder'
+                             'for the furthest developed tree reconstruction, and pick it up from there. If this argument'
+                             'is True, it over-rules the same argument in bonsai_config.yaml, and the other way around.')
+    parser.add_argument('--seed', type=int, default=1231,
+                        help="Sets the random seed necessary for getting the subset of cells.")
+    return parser
+
+
+if __name__ == "__main__":
+    main(_build_parser().parse_args())

--- a/omicverse/external/bonsai/backbone/bonsai_add_cells.py
+++ b/omicverse/external/bonsai/backbone/bonsai_add_cells.py
@@ -1,0 +1,266 @@
+from argparse import ArgumentParser
+import numpy as np
+import time
+import os, sys, csv
+from pathlib import Path
+
+# import tracemalloc
+#
+# tracemalloc.start()
+
+
+from ..bonsai.bonsai_helpers import Run_Configs, remove_tree_folders, find_latest_tree_folder_new, \
+    convert_dict_to_named_tuple, str2bool, get_latest_intermediate
+
+
+def main(args):
+    """Run this step end to end.
+
+    Wrapped by omicverse: upstream executed this body at module level, so the
+    module could not be imported without running a whole step. ``args`` is the
+    namespace upstream's ArgumentParser produced.
+    """
+    np.random.seed(args.seed)
+
+    # args = Run_Configs(args.config_filepath)
+    args_to_copy = ['preprocessed_data_folder', 'growth_before_cleanup', 'select_target', 'guide_tree_folder',
+                    'cells_to_be_added', 'pickup_intermediate', 'search_tol']
+    args = Run_Configs(args.config_filepath, args=args, args_to_copy=args_to_copy)
+
+    from ..bonsai.bonsai_dataprocessing import initializeSCData, loadReconstructedTreeAndData, SCData, \
+        OriginalData, Metadata
+    from ..bonsai.bonsai_helpers import mp_print, startMPI
+    from ..bonsai import bonsai_globals as bs_glob
+
+    if args.guide_tree_folder is None:
+        mp_print("Cannot add cells if 'guide_tree_folder' is not defined, don't know where to find the guide tree.",
+                 ERROR=True)
+        exit()
+
+    # Some of the code can be run in parallel, parallelization is done via mpi4py
+    mpiRank, mpiSize = startMPI(args.verbose)
+    origEllipsoidSize = None
+
+    start_all = time.time()
+
+    # Read in the tree that was created on a subset of the data (read in without data)
+    # scdata_tmp = SCData(onlyObject=True, dataset=args.dataset, results_folder=args.results_folder)
+    # results_folder = scdata_tmp.result_path()
+
+    all_genes = False
+
+    # Now try to find if some cells were already added in an earlier (aborted) run
+    scdata_tmp = SCData(onlyObject=True, dataset=args.dataset, results_folder=args.results_folder)
+    tmp_folder = scdata_tmp.result_path('tmp_added')
+    Path(tmp_folder).mkdir(parents=True, exist_ok=True)
+    tmp_found = False
+    if (mpiRank == 0) and args.pickup_intermediate and os.path.exists(tmp_folder):
+        try:
+            intermediateFolders = os.listdir(tmp_folder)
+            if len(intermediateFolders):
+                intermediateFolder, tmp_tree_ind = get_latest_intermediate(intermediateFolders, base='added')
+                if intermediateFolder is not None:
+                    # scdata_guide = loadReconstructedTreeAndData(args, os.path.join(tmp_folder, intermediateFolder),
+                    #                                             reprocess_data=False, all_genes=False, get_cell_info=False,
+                    #                                             all_ranks=False, rel_to_results=False, calc_loglik=True)
+                    scdata_guide = loadReconstructedTreeAndData(args, os.path.join(tmp_folder, intermediateFolder),
+                                                                all_genes=all_genes, get_cell_info=False,
+                                                                reprocess_data=False, all_ranks=False, rel_to_results=False,
+                                                                get_data=False, no_data_needed=True,
+                                                                get_posterior_ltqs=False, otherRanksMinimalInfo=True)
+                    tmp_found = True
+        except:
+            mp_print("Tried to find intermediate results in {}, but could not find any. "
+                     "Starting from guide tree.".format(tmp_folder))
+
+    if not tmp_found:
+        # If no intermediate result is present, take the guide tree here. Otherwise take the intermediate result.
+        tmp_tree_ind = 0
+        scdata_guide = loadReconstructedTreeAndData(args, args.guide_tree_folder, all_genes=all_genes, get_cell_info=False,
+                                                    reprocess_data=False, all_ranks=True, rel_to_results=True,
+                                                    get_data=False, no_data_needed=True, get_posterior_ltqs=False,
+                                                    otherRanksMinimalInfo=True)
+
+    # Read in the data for all cells
+    if args.preprocessed_data_folder is not None:
+        scdata_all_cells = SCData(onlyObject=True, dataset=args.dataset, results_folder=args.results_folder)
+        scdata_all_cells.metadata = Metadata(json_filepath=os.path.join(args.preprocessed_data_folder, 'metadata.json'),
+                                             curr_metadata=scdata_all_cells.metadata)
+
+        scdata_all_cells.originalData = OriginalData()
+        scdata_all_cells.originalData.ltqs = np.load(os.path.join(args.preprocessed_data_folder, 'delta.npy'),
+                                                     allow_pickle=False, mmap_mode='r')
+        scdata_all_cells.originalData.ltqsVars = np.load(os.path.join(args.preprocessed_data_folder, 'delta_vars.npy'),
+                                                         allow_pickle=False, mmap_mode='r')
+    else:
+        scdata_all_cells = initializeSCData(args, createStarTree=False, getOrigData=False, otherRanksMinimalInfo=True)
+
+    cell_id_to_ind = {cell_id: ind for ind, cell_id in enumerate(scdata_all_cells.metadata.cellIds)}
+
+    # Create list of cells that is already on the tree, and get cell-ID to node dictionary to be able to add ltq-info
+    nodes_list = scdata_guide.tree.root.getNodeList([], returnRoot=True, returnLeafs=True)
+
+    # The gene-selection will be based on all cells, so we copy the metadata based on scdata_all_cells
+    scdata_guide.metadata.geneIds = scdata_all_cells.metadata.geneIds
+    scdata_guide.metadata.nGenes = len(scdata_guide.metadata.geneIds)
+    # Note that we call only the original cells on the guide-tree "cells" at the moment. This is for technical reasons,
+    # for numbering the nodes
+    bs_glob.nCells = scdata_guide.metadata.nCells
+    bs_glob.nGenes = scdata_guide.metadata.nGenes
+
+    scdata_guide.metadata.geneVariances = scdata_all_cells.metadata.geneVariances
+    scdata_guide.metadata.loglikVarCorr = scdata_all_cells.metadata.loglikVarCorr
+    scdata_guide.metadata.pathToOrigData = scdata_all_cells.metadata.pathToOrigData
+    scdata_guide.metadata.processedDatafolder = scdata_all_cells.metadata.processedDatafolder
+    scdata_guide.metadata.results_folder = args.results_folder
+
+    # Add data to guide-tree, take signal-to-noise genes based on all cells
+    guide_cell_inds = []
+    for node in nodes_list:
+        if node.nodeId in cell_id_to_ind:
+            # In this case, the node corresponds to a cell. We're assuming that each node has max 1 cell
+            cell_ind = cell_id_to_ind[node.nodeId]
+            guide_cell_inds.append(cell_ind)
+            node.ltqs = scdata_all_cells.originalData.ltqs[:, cell_ind]
+            node.setLtqsVarsOrW(ltqsVars=scdata_all_cells.originalData.ltqsVars[:, cell_ind])
+            node.isCell = True
+
+    guide_cell_inds = np.unique(guide_cell_inds)
+    non_guide_cell_inds = np.setdiff1d(np.arange(scdata_all_cells.metadata.nCells), guide_cell_inds)
+    # Select subset of non_guide-cells that we want to add based on the "cells_to_be_added"-argument
+    cell_id_list_after_adding = []
+    if (args.cells_to_be_added is not None) and os.path.exists(os.path.abspath(args.cells_to_be_added)):
+        cells_to_be_added = os.path.abspath(args.cells_to_be_added)
+        # cell_ids_to_be_added = []
+        cell_inds_to_add = []
+        with open(cells_to_be_added, 'r') as file:
+            reader = csv.reader(file, delimiter="\t")
+            for row in reader:
+                cell_id_list_after_adding.append(row[0])
+                cell_inds_to_add.append(cell_id_to_ind[row[0]])
+        cell_inds_to_add = np.array(cell_inds_to_add)
+        cell_inds_to_add = np.intersect1d(cell_inds_to_add, non_guide_cell_inds)
+    else:
+        cell_inds_to_add = non_guide_cell_inds
+
+    # Create random order of cells to be added
+    np.random.shuffle(cell_inds_to_add)
+    # ltqs_to_add = scdata_all_cells.originalData.ltqs[:, cell_inds_to_add]
+    # ltqsvars_to_add = scdata_all_cells.originalData.ltqsVars[:, cell_inds_to_add]
+
+    # Store ltqs to be added in a file, such that they can be memory-mapped when reading in
+    n_to_add = len(cell_inds_to_add)
+    ltqs_file = os.path.join(tmp_folder, 'ltqs_to_add_cell_by_gene.npy')
+    ltqsvars_file = os.path.join(tmp_folder, 'ltqsvars_to_add_cell_by_gene.npy')
+    ltqs_to_add = np.lib.format.open_memmap(ltqs_file, dtype='float64', mode='w+',
+                                            shape=(n_to_add, bs_glob.nGenes))
+    ltqsvars_to_add = np.lib.format.open_memmap(ltqsvars_file, dtype='float64', mode='w+',
+                                                shape=(n_to_add, bs_glob.nGenes))
+    for out_row, orig_col in enumerate(cell_inds_to_add):
+        ltqs_to_add[out_row, :] = scdata_all_cells.originalData.ltqs[:, orig_col]
+        ltqsvars_to_add[out_row, :] = scdata_all_cells.originalData.ltqsVars[:, orig_col]
+
+    # Flush to disk
+    ltqs_to_add.flush()
+    ltqsvars_to_add.flush()
+    del ltqs_to_add
+    del ltqsvars_to_add
+    ltqs_to_add_cg = np.load(ltqs_file, allow_pickle=False, mmap_mode='r')
+    ltqsvars_to_add_cg = np.load(ltqsvars_file, allow_pickle=False, mmap_mode='r')
+    cell_ids_to_add = [scdata_all_cells.metadata.cellIds[ind] for ind in cell_inds_to_add]
+
+    # Make sure that all ltqs are calculated at all nodes (automatically done when calculating a loglikelihood)
+    scdata_guide.metadata.loglik = scdata_guide.tree.calcLogLComplete(mem_friendly=True,
+                                                                      loglikVarCorr=scdata_guide.metadata.loglikVarCorr)
+    mp_print("Loglikelihood of guide tree before adding cells: " + str(scdata_guide.metadata.loglik))
+
+    """
+    This is the core of the script, the cells will be added iteratively to the guide-tree
+    """
+    if args.select_target == 'root':
+        n_centers = 1
+        args.select_target = 'cluster_centers'
+    else:
+        n_centers = None
+
+    scdata_guide.tree.add_cells(ltqs_to_add_cg, ltqsvars_to_add_cg, cell_ids_to_add,
+                                growth_before_cleanup=args.growth_before_cleanup,
+                                select_target=args.select_target,
+                                scdata=scdata_guide, tmp_folder=tmp_folder, tmp_tree_ind=tmp_tree_ind,
+                                search_tol=args.search_tol, n_centers=n_centers, only_count_search_moves=False)
+
+    # Make node-indices nice again: The cells have the node-ind matching position in the input cell-ID list. Root has -1,
+    # Internal nodes start at nCells and increase in depth-first manner.
+    scdata_guide.metadata.cellIds = cell_id_list_after_adding
+    scdata_guide.metadata.nCells = len(scdata_guide.metadata.cellIds)
+    bs_glob.nCells = scdata_guide.metadata.nCells
+    scdata_guide.cleanup_node_inds()
+
+    """
+    Store the resulting tree in a folder, such that another script can pick it up. In that script, we should then
+    decide (through some arguments) how many tree-moves we still do, or if we just store the information in the final 
+    format.
+    """
+
+    mp_print("Adding cells took " + str(time.time() - start_all) + " seconds.")
+    scdata_guide.metadata.loglik = scdata_guide.tree.calcLogLComplete(mem_friendly=True,
+                                                                      loglikVarCorr=scdata_guide.metadata.loglikVarCorr)
+    mp_print("Loglikelihood of inferred tree after adding cells: " + str(scdata_guide.metadata.loglik))
+
+    mp_print("Storing result after adding all cells in " + scdata_guide.result_path() + "\n\n")
+    scdata_guide.storeTreeInFolder(scdata_guide.result_path(), with_coords=True, verbose=args.verbose)
+
+    if tmp_folder is not None:
+        remove_tree_folders(tmp_folder, removeDir=True, base='added')
+
+    mp_print("Time necessary for the whole calculation was {} seconds.".format(time.time() - start_all))
+    # print_memory("Memory usage after the whole calculation")
+
+
+
+def _build_parser():
+    """Upstream's ArgumentParser, lifted out of ``__main__`` so omicverse can
+    reuse it to build an args namespace without spawning a process."""
+    parser = ArgumentParser(
+        description='Starts from cell-data and a tree on which some of the cells are already placed. Cells that are not on'
+                    'the tree but are in the data will be placed one by one on the tree.')
+    parser.add_argument('--config_filepath', type=str, default=None,
+                        help='Absolute (or relative to "bonsai-development") path to YAML-file that contains all arguments'
+                             'needed to run Bonsai.')
+    parser.add_argument('--guide_tree_folder', type=str, default=None,
+                        help="Path that should point to folder where an existing Bonsai-tree is stored. This folder"
+                             "is typically called 'final_...' in a Bonsai-results folder. Then this script will start "
+                             "adding cells to that 'guide-tree'.")
+    parser.add_argument('--preprocessed_data_folder', type=str, default=None,
+                        help="Folderpath where data is stored that was already preprocessed for all cells.")
+    parser.add_argument('--growth_before_cleanup', type=float, default=.5,
+                        help="When adding cells, this factor (larger than 0) determines after what growth factor (so .1 "
+                             "means 10% growth) we re-optimize the tree before adding another set of cells.")
+    # parser.add_argument('--resolve_polytomies_immediately', type=str2bool, default=True,
+    #                     help="Determines whether, when adding a cell downstream of a node, we immediately test whether it "
+    #                          "wants to merge with one of the other children of that node.")
+    # TODO: To be moved to config-file
+    parser.add_argument('--select_target', type=str, default='cluster_centers',
+                        help="This will determine what strategy we follow for the "
+                             "spr-moves. Current options are 'root', 'cluster_centers', 'exhaustive'.")
+    parser.add_argument('--nodes_to_add_to', type=str, default=None,
+                        help="[NOT YET IMPLEMENTED]"
+                             "One can give a filename to a txt-file containing node-IDs here (one per line). In that case,"
+                             "cells will only be added directly to one of these nodes.")
+    parser.add_argument('--cells_to_be_added', type=str, default=None,
+                        help="One can give a filename to a txt-file containing cell-IDs here (one per line). In that case,"
+                             "only these cell-IDs will be added.")
+    parser.add_argument('--search_tol', type=float, default=2,
+                        help="Gives the loglikelihood-margin by which a new SPR-search has to be worse than a previous one"
+                             "before we discard this search direction")
+    parser.add_argument('--pickup_intermediate', type=str2bool, default=True,
+                        help='Optional: Set this argument to true if Bonsai needs to search in the indicated results-folder'
+                             'for the furthest developed tree reconstruction, and pick it up from there. If this argument'
+                             'is True, it over-rules the same argument in bonsai_config.yaml, and the other way around.')
+    parser.add_argument('--seed', type=int, default=1231,
+                        help="Random seed for order of adding the cells.")
+    return parser
+
+
+if __name__ == "__main__":
+    main(_build_parser().parse_args())

--- a/omicverse/external/bonsai/backbone/bonsai_iterative_first_split.py
+++ b/omicverse/external/bonsai/backbone/bonsai_iterative_first_split.py
@@ -1,0 +1,118 @@
+from argparse import ArgumentParser
+import numpy as np
+import time
+from pathlib import Path
+import os, sys, csv
+import subprocess
+
+
+# import tracemalloc
+# tracemalloc.start()
+
+from ..bonsai.bonsai_helpers import Run_Configs, remove_tree_folders, find_latest_tree_folder_new, \
+    convert_dict_to_named_tuple, str2bool
+
+
+def main(args):
+    """Run this step end to end.
+
+    Wrapped by omicverse: upstream executed this body at module level, so the
+    module could not be imported without running a whole step. ``args`` is the
+    namespace upstream's ArgumentParser produced.
+    """
+
+    start_all = time.time()
+
+    # TODO: Make sure that Run_configs initialization just copies all arguments that were originally in args
+    config_filepath = args.config_filepath
+    subset_results_folders = args.subset_results_folders
+
+    args = Run_Configs(args.config_filepath)
+
+    args.subset_results_folders = subset_results_folders
+    args.config_filepath = config_filepath
+
+    from ..bonsai import mpi_wrapper as mpi_wrapper
+    from ..bonsai.bonsai_dataprocessing import initializeSCData, SCData, Metadata, storeData
+    from ..bonsai.bonsai_helpers import mp_print, startMPI, getOutputFolder, read_ids
+    from ..bonsai.bonsai_treeHelpers import Tree
+    from ..bonsai import bonsai_globals as bs_glob
+
+    # Some of the code can be run in parallel, parallelization is done via mpi4py
+    mpi_rank, mpi_size = startMPI(verbose=True)
+
+    scdata = initializeSCData(args, createStarTree=False, getOrigData=True, otherRanksMinimalInfo=True)
+    orig_cell_id_to_ind = {cell_id: ind for ind, cell_id in enumerate(scdata.metadata.cellIds)}
+
+    if mpi_rank != 0:
+        mp_print("My job here is done.", ALL_RANKS=True)
+        exit()
+
+    subset_folders = args.subset_results_folders.split(',')
+    for ind_subset, subset_folder in enumerate(subset_folders):
+        cell_ids_subset = read_ids(os.path.join(subset_folder, 'non_refined_tree', 'starting_cell_ids.txt'))
+        subset_inds = np.array([orig_cell_id_to_ind[cell_id] for cell_id in cell_ids_subset])
+
+        metadata_subset = Metadata(curr_metadata=scdata.metadata)
+        metadata_subset.cellIds = cell_ids_subset
+        metadata_subset.nCells = len(cell_ids_subset)
+        bs_glob.nCells = metadata_subset.nCells
+        metadata_subset.dataset = os.path.join(scdata.metadata.dataset, os.path.basename(subset_folder))
+        metadata_subset.results_folder = subset_folder
+
+        scdata_subset = SCData(onlyObject=True, dataset=metadata_subset.dataset,
+                               results_folder=metadata_subset.results_folder)
+
+        scdata_subset.metadata = metadata_subset
+        ltqs_subset = scdata.originalData.ltqs[:, subset_inds].copy()
+        ltqsvars_subset = scdata.originalData.ltqsVars[:, subset_inds].copy()
+
+        scdata_subset.metadata.processedDatafolder = scdata_subset.result_path('zscorefiltered_%.3f_and_processed'
+                                                                               % args.zscore_cutoff)
+        storeData(scdata_subset.metadata, ltqs_subset, ltqsvars_subset)
+        mp_print("Storing subset {} with {} cells in folder: {}".format(ind_subset, len(subset_inds),
+                                                                        scdata_subset.metadata.processedDatafolder))
+        # storeData(scdata_subset.metadata, ltqs_subset, ltqsvars_subset)
+
+        if (mpi_rank == 0) and (ind_subset == 0):
+            scdata_subset.metadata.dataset = os.path.join(scdata_subset.metadata.dataset, 'non_refined_tree')
+            results_folder_initial = scdata_subset.result_path('non_refined_tree')
+            Path(results_folder_initial).mkdir(parents=True, exist_ok=True)
+            scdata_subset.tree = Tree()
+            scdata_subset.tree.initialize_star_tree(ltqs_subset, ltqsvars_subset, scdata_subset.metadata,
+                                                    opt_times=True, verbose=args.verbose)
+            # Store tree topology with optimised times, and the data only for selected genes, such that it can be read
+            # in by multiple cores such that the next part of the program can be run in parallel
+            # outputFolder = getOutputFolder(zscore_cutoff=args.zscore_cutoff, greedy=False,
+            #                                redo_starry=False, opt_times=False)
+            mp_print("Storing result of preprocessing in " + results_folder_initial + "\n\n")
+            scdata_subset.storeTreeInFolder(results_folder_initial, with_coords=True, verbose=args.verbose,
+                                            cleanup_tree=False)
+
+    mp_print("Reading, filtering, and storing data took " + str(time.time() - start_all) + " seconds.")
+    mp_print("Time necessary for the whole calculation was {} seconds.".format(time.time() - start_all))
+    # print_memory("Memory usage after the whole calculation")
+
+
+
+def _build_parser():
+    """Upstream's ArgumentParser, lifted out of ``__main__`` so omicverse can
+    reuse it to build an args namespace without spawning a process."""
+    parser = ArgumentParser(
+        description='First script to be called in backbone_based_bonsai.py.'
+                    'Creates a first star-tree on a first subset of the data. Preprocesses all the data to store the'
+                    'preprocessed data in the results-folder of all subsets already.')
+    parser.add_argument('--config_filepath', type=str, default=None,
+                        help='Absolute (or relative to "bonsai-development") path to YAML-file that contains all arguments'
+                             'needed to run Bonsai.')
+    parser.add_argument('--subset_results_folders', type=str, default=None,
+                        help="Comma-separated string containing the results folders where tree for the subsets should "
+                             "eventually be stored. "
+                             "Also folders where we can find 'non_refined_tree/starting_cell_ids.txt' to know from "
+                             "which cells to start."
+                             "NOTE: It is assumed that making a star-tree is only necessary for the FIRST subset.")
+    return parser
+
+
+if __name__ == "__main__":
+    main(_build_parser().parse_args())

--- a/omicverse/external/bonsai/bonsai/__init__.py
+++ b/omicverse/external/bonsai/bonsai/__init__.py
@@ -1,0 +1,15 @@
+"""Vendored Bonsai core (upstream v1.0.0), CC BY-NC 4.0.
+
+Modifications from upstream, all mechanical:
+
+* ``from bonsai.X import ...`` -> ``from .X import ...`` and
+  ``import bonsai.X as Y`` -> ``from . import X as Y``, so the modules import as
+  a package instead of relying on the script's own ``sys.path.append`` of its
+  parent directory. The two ``sys.path`` injections are removed with them.
+* ``bonsai_main`` had its module-level body wrapped in ``main(args)`` and its
+  ``argparse`` block moved under ``__main__``, so omicverse can call it in
+  process rather than spawning a Python subprocess.
+
+Nothing else is touched: the algorithm, its defaults and its numerics are
+upstream's.
+"""

--- a/omicverse/external/bonsai/bonsai/bonsai_approxNN.py
+++ b/omicverse/external/bonsai/bonsai/bonsai_approxNN.py
@@ -1,0 +1,256 @@
+from sklearn.metrics.pairwise import cosine_distances, euclidean_distances
+from sklearn.preprocessing import normalize
+from sklearn.neighbors import NearestNeighbors
+import numpy as np
+import time
+# import faiss
+# from bonsai.bonsai_helpers import time_format
+# from icecream import ic
+
+# ic.configureOutput(prefix=time_format)
+
+
+def getNNsBruteForce(points, k=50):
+    """
+    Code to run this NN-search:
+    nns = getNNsBruteForce(points, k=50)
+    where points is genes x cells
+    """
+    # similarities = cosine_distances(points.T)
+    similarities = euclidean_distances(points.T)
+    knn = np.argsort(similarities, axis=0)[:k]
+    return knn.T
+
+
+def getNNssklearn(pointsT, index=None, k=50, metric='cosine', addPoints=True):
+    """
+    Code to run this NN-search:
+    index, nns = getNNssklearn(points, k=50)
+    where points is genes x cells
+    This function does an exhaustive search, but does build an index. If an index is given as an argument, the
+    data in points is queried with respect to this index. If no index is given, then the points will be used to
+    build an index and query the points themselves.
+    If index is given as argument, this index is not updated with the new points.
+    Metric can currently be 'cosine' or 'euclidean'.
+    """
+    toBeAdded = True
+    if index is None:
+        index = NearestNeighbors(n_neighbors=k, metric=metric)
+        index.fit(pointsT)
+        toBeAdded = False
+
+    # select indices of k nearest neighbors of the vectors in the input list
+    if toBeAdded and addPoints:
+        # Add new points to index
+        indexedPointsT = np.vstack((getattr(index, '_fit_X'), pointsT))
+        index.fit(indexedPointsT)
+    n_neighbors = min(k, index.n_samples_fit_ - 1)
+    neighbors = index.kneighbors(pointsT, n_neighbors=n_neighbors, return_distance=False)
+
+    return index, neighbors
+
+
+def removeNNssklearn(index, inds):
+    pointsT = np.delete(getattr(index, '_fit_X'), inds, axis=0)
+    index.fit(pointsT)
+    if hasattr(index, 'IDs'):
+        index.IDs = np.delete(index.IDs, inds)
+
+
+# def getNNfaissbruteforce(pointsT, index=None, k=50, metric='cosine', addPoints=True):
+#     """
+#     Code to run this NN-search:
+#     index, nns = getNNfaissbruteforce(points, k=50)
+#     where pointsT is cells x genes
+#     This function does an exhaustive search, but does build an index. If an index is given as an argument, the
+#     data in points is queried with respect to this index. If no index is given, then the points will be used to
+#     build an index and query the points themselves.
+#     If index is given as argument, this index is updated with the new points.
+#     """
+#     f = pointsT.shape[1]
+#     if index is None:
+#         addPoints = True
+#         if metric == 'cosine':
+#             index = faiss.IndexFlatIP(f)  # Inner product metric (equivalent but faster on normalized vectors)
+#         else:
+#             index = faiss.IndexFlatL2(f)  # build the index, f=size of vectors
+#     if addPoints:
+#         index.add(pointsT)  # add vectors to the index
+#
+#     D, nns = index.search(pointsT, k)  # actual search
+#     return index, nns
+
+
+def removeVect(index, inds):
+    if index.nnType == 'faissBrute':
+        removeFaiss(index, inds)
+    elif index.nnType == 'faissLSH':
+        print("Removing a vector from LSH-index is not supported.")
+    else:
+        removeNNssklearn(index, inds)
+
+
+def removeFaiss(index, inds):
+    index.remove_ids(inds)
+    if hasattr(index, 'IDs'):
+        index.IDs = np.delete(index.IDs, inds)
+
+
+# def getNNfaissIVF(pointsT, index=None, k=50, nlist_factor=10, nprobe=5, metric='cosine'):
+#     """
+#     Code to run this NN-search:
+#     index, nns = getNNfaissbruteforce(points, k=50)
+#     where points is genes x cells
+#     This function does an exhaustive search, but does build an index. If an index is given as an argument, the
+#     data in points is queried with respect to this index. If no index is given, then the points will be used to
+#     build an index and query the points themselves.
+#     If index is given as argument, this index is updated with the new points.
+#     """
+#     c, f = pointsT.shape
+#     if index is None:
+#         if metric == 'cosine':
+#             quantizer = faiss.IndexFlatIP(f)
+#         else:
+#             quantizer = faiss.IndexFlatL2(f)  # the other index
+#         nlist = int(nlist_factor * np.sqrt(c))
+#         index = faiss.IndexIVFFlat(quantizer, f, nlist)
+#         index.train(pointsT)  # add vectors to the index
+#
+#     index.add(pointsT)
+#     index.nprobe = nprobe
+#     D, nns = index.search(pointsT, k)  # actual search
+#     return index, nns
+
+
+# def getNNsfaissLSH(points, index=None, k=50, n_bits=128, addPoints=True):
+#     pointsT = np.ascontiguousarray(np.float32(points.T))
+#     f = pointsT.shape[1]
+#     if index is None:
+#         addPoints = True
+#         index = faiss.IndexLSH(f, n_bits)
+#         index.train(pointsT)
+#     if addPoints:
+#         index.add(pointsT)
+#     D, nns = index.search(pointsT, k)
+#     return index, nns
+
+
+def getFracCorrectNNs(nns, true_nns):
+    n_correct = 0
+    for cell in range(nns.shape[1]):
+        n_correct += np.sum((nns - true_nns[:, cell][:, None]) == 0)
+    correctFrac = n_correct / np.prod(nns.shape)
+    return correctFrac
+
+
+def getApproxNNs(points, index=None, k=50, n_bits_factor=10, metric='cosine', pointsIds=None, addPoints=True, th1=150000, th2=150000):
+    """
+
+    :param points: (genes(features) x cells)-matrix for which NNs are required. If index=None, points is used to both
+    build the index and then to get NNs between these points. Otherwise, the existing index is used, the new "points"
+    are added, and the NNs for these new points are returned.
+    :param index: trained index that was returned by an earlier run of this function
+    :param k: number of nearest neighbours required
+    :param n_bits_factor: Is multiplied with log(nCells) to get how many projections are used in LSH (large datasets)
+    :param metric: What metric to use for neighbour estimation, currently 'cosine' and 'euclidean' are supported.
+    :return index: index where all points are added
+    :return nns: (cells x k)-matrix with (approximate) nearest neighbours for all cells given in "points"
+    """
+    if index is not None:
+        nnType = index.nnType
+        k = min(index.n_samples_fit_, k)
+    else:  # nCells < th1:
+        nnType = 'sklearn'
+    # elif nCells < th2:
+    #     nnType = 'faissBrute'
+    # else:
+    #     nnType = 'faissLSH'
+
+    # We always require the transpose of the points-matrix and it should often be a contiguous array
+    if nnType != 'sklearn':
+        pointsT = np.ascontiguousarray(np.float32(points.T))
+        # TODO: Try replacing faissLSH by Annoy
+    else:
+        pointsT = points.T
+    nCells, nGenes = pointsT.shape
+
+    # if (metric == 'cosine') and nnType in ['faissBrute', 'faissLSH']:
+    #     # In this case we just normalize all vectors, then use Euclidean distance. This is equivalent.
+    #     faiss.normalize_L2(pointsT)
+
+    if nnType == 'sklearn':
+        index, nns = getNNssklearn(pointsT, k=k, index=index, metric=metric, addPoints=addPoints)
+        index.nnType = 'sklearn'
+    # elif nnType == 'faissBrute':
+    #     index, nns = getNNfaissbruteforce(pointsT, index=index, k=k, metric=metric, addPoints=addPoints)
+    #     index.nnType = 'faissBrute'
+    # else:
+    #     # This point is only reached when we have more than 10000 cells. In that case we do an approximate nn-search
+    #     n_bits = int(n_bits_factor * np.sqrt(nCells))
+    #     index, nns = getNNsfaissLSH(points, index=index, k=k, n_bits=n_bits, addPoints=addPoints)
+    #     index.nnType = 'faissLSH'
+
+    # Update Ids in index by adding new points
+    if addPoints and (pointsIds is not None):
+        if hasattr(index, 'IDs'):
+            index.IDs = np.hstack((index.IDs, pointsIds))
+        else:
+            index.IDs = pointsIds
+
+    return index, nns
+
+
+if __name__ == '__main__':
+    # Load data
+    f = 2000
+    n = 20000
+    np.random.seed(42)
+    points = np.zeros((f, n))
+    points[:, 0] = np.random.normal(loc=0.0, scale=1.0, size=f)
+    for ind in range(1, n):
+        points[:, ind] = points[:, ind - 1] + np.random.normal(loc=0.0, scale=0.1, size=f)
+
+    points += np.random.normal(loc=0.0, scale=.1, size=(f, n))
+    points -= np.mean(points, axis=1)[:, None]
+    points = normalize(points, axis=0)
+
+    K = 50
+
+    # start = time.time()
+    # nns = true_nns = getNNsBruteForce(points, k=K)
+    # correctFrac = getFracCorrectNNs(nns, true_nns)
+    # print("Brute force similarity search took %f seconds, got %f correct." % (time.time() - start, correctFrac))
+    # ic(nns)
+    #
+
+    """sklearn also using brute force"""
+    start = time.time()
+    index, nns = getNNssklearn(points, k=K)
+    true_nns = nns
+    end = time.time()
+    correctFrac = getFracCorrectNNs(nns, true_nns)
+    print("Brute force sklearn search took %f seconds, got %f correct." % (end - start, correctFrac))
+    ic(nns)
+
+    start = time.time()
+    index, nns = getNNfaissbruteforce(points, k=K)
+    end = time.time()
+    correctFrac = getFracCorrectNNs(nns, true_nns)
+    print("Brute force faiss search took %f seconds, got %f correct." % (end - start, correctFrac))
+    ic(nns)
+
+    start = time.time()
+    nprobe = 5
+    index, nns = getNNfaissIVF(points, nlist=100, k=K, nprobe=nprobe)
+    end = time.time()
+    correctFrac = getFracCorrectNNs(nns, true_nns)
+    print("IVF faiss search with %d probes took %f seconds, got %f correct." % (nprobe, end - start, correctFrac))
+    ic(nns)
+
+    start = time.time()
+    n_bits = int(2 * np.log(n))
+    index, nns, getNNsfaissLSH(points, n_bits=n_bits, k=K)
+    end = time.time()
+    correctFrac = getFracCorrectNNs(nns, true_nns)
+    print("LSH forest faiss search with %d bits took %f seconds, got %f correct." % (n_bits, end - start, correctFrac))
+    ic(nns)

--- a/omicverse/external/bonsai/bonsai/bonsai_dataprocessing.py
+++ b/omicverse/external/bonsai/bonsai/bonsai_dataprocessing.py
@@ -1,0 +1,3166 @@
+from .bonsai_helpers import *
+import os
+from scipy.optimize import fminbound
+from scipy.spatial import distance
+import pandas as pd
+import csv
+from .bonsai_treeHelpers import Tree, TreeNode, optimiseTStar
+from . import bonsai_globals as bs_glob
+import copy
+import gc
+import json
+import heapq
+
+import logging
+
+FORMAT = '%(asctime)s %(funcName)s %(levelname)s %(message)s'
+log_level = logging.DEBUG
+logging.basicConfig(format=FORMAT,
+                    datefmt='%m-%d %H:%M:%S',
+                    level=logging.WARNING)  # silence all libraries
+
+# Create your app logger
+logger = logging.getLogger("myapp")
+logger.setLevel(log_level)
+
+
+class Metadata:
+    pathToOrigData = None
+    dataset = None
+    nCells = None
+    nGenes = None
+    cellIds = None
+    geneIds = None
+    loglik = None
+    loglikVarCorr = None
+    geneVariances = None
+    geneDiffusionScaling = None
+    processedDatafolder = None
+    results_folder = None
+
+    def __repr__(self):
+        return "Metadata(\n" \
+               "pathToOrigData = %r \n" \
+               "dataset = %r \n" \
+               "nCells = %r \n" \
+               "nGenes = %r \n" \
+               "cellIds = %r \n" \
+               "geneIds = %r \n" \
+               "loglik = %r \n" \
+               "loglikVarCorr = %r \n" \
+               "geneVariances = %r \n" \
+               "geneDiffusionScaling = %r \n" \
+               "results_folder = %r \n" \
+               "processedDatafolder = %r \n)" \
+               % (self.pathToOrigData, self.dataset, self.nCells, self.nGenes, self.cellIds, self.geneIds, self.loglik,
+                  self.loglikVarCorr, self.geneVariances, self.geneDiffusionScaling,
+                  self.results_folder, self.processedDatafolder)
+
+    def __init__(self, json_filepath=None, curr_metadata=None):
+        attr_list = ['pathToOrigData', 'dataset', 'nCells', 'nGenes', 'cellIds', 'geneIds', 'loglik', 'loglikVarCorr',
+                     'geneVariances', 'geneDiffusionScaling', 'processedDatafolder', 'results_folder']
+        if json_filepath is not None:
+            self.from_json(json_filepath)
+        else:
+            for attr in attr_list:
+                setattr(self, attr, None)
+        if curr_metadata is not None:
+            for attr in attr_list:
+                if getattr(curr_metadata, attr) is not None:
+                    if attr in ['cellIds', 'geneIds', 'geneVariances']:
+                        copied_attr = getattr(curr_metadata, attr).copy()
+                    else:
+                        copied_attr = getattr(curr_metadata, attr)
+                    setattr(self, attr, copied_attr)
+
+        # Check if the stored number-of-cells matches the number of stored cell-IDs
+        if hasattr(self, 'nCells') and (self.nCells is not None) and \
+                hasattr(self, 'cellIds') and (self.cellIds is not None):
+            if self.nCells != len(self.cellIds):
+                mp_print("Number of cell-IDs ({}) stored in metadata, is not equal to value of nCells ({}). "
+                         "Check this! Now exiting.".format(len(self.cellIds), self.nCells), ERROR=True)
+                exit()
+
+    def to_dict(self):
+        self_dict = self.__dict__
+        new_dict = {}
+        for self_label, self_val in self_dict.items():
+            if self_label in ['geneVariances'] and (self_val is not None):
+                new_dict[self_label] = self_val.tolist()
+            elif hasattr(self_val, 'dtype'):
+                if self_val.dtype == 'float64':
+                    new_dict[self_label] = float(self_val)
+                elif self_val.dtype == 'int64':
+                    new_dict[self_label] = int(self_val)
+                else:
+                    new_dict[self_label] = self_val
+            else:
+                new_dict[self_label] = self_val
+        return new_dict
+
+    def from_dict(self, metadata_dict):
+        for md_label, md_val in metadata_dict.items():
+            if md_label in ['geneVariances'] and (md_val is not None):
+                setattr(self, md_label, np.array(md_val))
+            elif isinstance(md_val, float):
+                setattr(self, md_label, np.float64(md_val))
+            else:
+                setattr(self, md_label, md_val)
+
+    def to_json(self, filepath):
+        with open(filepath, "w") as file:
+            json.dump(self.to_dict(), file, indent=4)
+
+    def from_json(self, filepath):
+        with open(filepath, 'r') as file:
+            self.from_dict(metadata_dict=json.load(file))
+
+    def take_subset_genes(self, genes_to_keep):
+        new_nGenes = len(genes_to_keep)
+        if self.nGenes < new_nGenes:
+            logger.error("Trying to take a subset of genes with more genes than original.")
+            exit()
+        elif self.nGenes > new_nGenes:
+            self.geneIds = [self.geneIds[ind] for ind in genes_to_keep]
+            if self.geneVariances is not None:
+                self.geneVariances = self.geneVariances[genes_to_keep]
+            self.nGenes = new_nGenes
+
+
+class OriginalData:
+    umiCounts = None
+    ltqs = None
+    ltqsVars = None
+    geneVariances = None
+    geneDiffusionScaling = None
+    priorVariances = None
+
+    def __repr__(self):
+        return "OriginalData(\numiCounts = %r \nltqs = %r \nltqsVars = %r \n" \
+               "geneVariances = %r \npriorVariances = %r \n)" \
+               % (self.umiCounts, self.ltqs, self.ltqsVars, self.geneVariances, self.priorVariances)
+
+
+class SCData:
+    # Object with useful information about the dataset
+    metadata = None
+
+    # The original data itself
+    originalData = None
+    unscaled = None
+
+    # The tree object
+    tree = None
+    mergers = None  # List of node mergers to recover tree from star-tree
+    nVerts = None
+
+    def __repr__(self):
+        return "SCData(\n metadata = %r \noriginalData = %r \nuncorrected = %r \ntree = %r \nmergers = %r \n)" \
+               % (self.metadata, self.originalData, self.unscaled, self.tree, self.mergers)
+
+    def __init__(self, dataset=None, filenamesData=None, verbose=False, pathToOrigData=None,
+                 zscoreCutoff=-1, onlyObject=False, returnUncorrected=False,
+                 createStarTree=True, optTimes=True, getOrigData=False, results_folder=None,
+                 noDataNeeded=False, sanityOutput=True, mpiInfo=None, rescale_by_var=True, all_genes=False):
+        if all_genes:
+            zscoreCutoff = -1
+        if mpiInfo is None:
+            mpiInfo = mpi_wrapper.get_mpi_info()
+        if onlyObject:
+            self.metadata = Metadata()
+            if dataset:
+                self.metadata.dataset = dataset
+            if results_folder and len(results_folder):
+                self.metadata.results_folder = os.path.abspath(results_folder)
+            if mpiInfo.rank == 0:
+                Path(self.data_path()).mkdir(parents=True, exist_ok=True)
+                Path(self.result_path()).mkdir(parents=True, exist_ok=True)
+            return
+        if not dataset:
+            mp_print("Dataset-ID should be given.")
+            exit()
+
+        self.metadata = Metadata()
+        if results_folder and len(results_folder):
+            self.metadata.results_folder = os.path.abspath(results_folder)
+        if pathToOrigData is not None:
+            self.metadata.pathToOrigData = os.path.abspath(pathToOrigData)
+        self.metadata.dataset = dataset
+        if mpiInfo.rank == 0:
+            Path(self.data_path()).mkdir(parents=True, exist_ok=True)
+            Path(self.result_path()).mkdir(parents=True, exist_ok=True)
+
+        ltqStdsFound, originalData = self.read_in_data(filenamesData=filenamesData, verbose=verbose,
+                                                       noDataNeeded=noDataNeeded, sanityOutput=sanityOutput,
+                                                       getOrigData=getOrigData or (not createStarTree),
+                                                       zscoreCutoff=zscoreCutoff, mpiInfo=mpiInfo, all_genes=all_genes)
+        if mpiInfo.rank != 0:
+            return
+        # if returnUncorrected:
+        #     self.unscaled = copy.deepcopy(originalData)
+
+        self.metadata.geneVariances = originalData.geneVariances
+        if self.metadata.geneVariances is None:
+            self.metadata.geneVariances = np.ones(self.metadata.nGenes)
+
+        # Scale diffusion by estimated gene variance.
+        if rescale_by_var:
+            if originalData.ltqs is not None:
+                originalData.ltqs /= np.sqrt(originalData.geneVariances[:, None])
+                if originalData.ltqsVars is not None:
+                    originalData.ltqsVars /= (originalData.geneVariances[:, None])
+                self.metadata.loglikVarCorr = - (self.metadata.nCells - 1) * np.sum(
+                    np.log(
+                        originalData.geneVariances))  # - self.metadata.nCells * self.metadata.nGenes * np.log(2* np.pi)
+                originalData.geneDiffusionScaling = 'geneVariances'
+                self.metadata.geneDiffusionScaling = 'geneVariances'
+            # elif originalData.ltqs is not None:
+            #     originalData.ltqs /= np.sqrt(originalData.geneVariances[:, None])
+            #     originalData.geneDiffusionScaling = self.metadata.geneVariances
+            #     self.metadata.geneDiffusionScaling = self.metadata.geneVariances
+            #     self.metadata.loglikVarCorr = - (self.metadata.nCells - 1) * np.sum(
+            #         np.log(originalData.geneVariances))  #-self.metadata.nCells*self.metadata.nGenes * np.log(2* np.pi)
+        else:
+            if originalData.ltqs is not None:
+                nVars = self.metadata.nGenes if self.metadata.nGenes is not None else originalData.geneVariances.shape
+                mean_var = np.mean(originalData.geneVariances)
+                originalData.geneDiffusionScaling = mean_var
+                self.metadata.geneDiffusionScaling = originalData.geneDiffusionScaling
+                originalData.ltqs /= np.sqrt(mean_var)
+                if originalData.ltqsVars is not None:
+                    originalData.ltqsVars /= mean_var
+                self.metadata.loglikVarCorr = - (self.metadata.nCells - 1) * nVars * np.log(mean_var)
+
+        if originalData.ltqs is not None:
+            # Store data filtered by zscore
+            self.metadata.processedDatafolder = self.result_path('zscorefiltered_%.3f_and_processed' % zscoreCutoff)
+            storeData(self.metadata, originalData.ltqs, originalData.ltqsVars, verbose=verbose)
+
+        # Some variables are nice to have access to from all functions
+        bs_glob.nCells = self.metadata.nCells
+        bs_glob.nGenes = self.metadata.nGenes
+
+        if (bs_glob.nCells is not None) and (bs_glob.nCells > 25000) and (self.tree is not None):
+            bs_glob.mem_friendly = True
+            self.tree.root.keep_one_ltqsvars_or_W(keep_ltqsvars=True)
+
+        # Update recursion limits so that very deep trees don't create errors
+        set_recursion_limits(int(2 * bs_glob.nCells))
+
+        if getOrigData:
+            self.originalData = originalData
+
+        if createStarTree:
+            self.tree = Tree()
+            self.tree.initialize_star_tree(originalData.ltqs, originalData.ltqsVars, self.metadata,
+                                           opt_times=optTimes, verbose=verbose)
+
+    """----------TREE MANIPULATIONS-------------------------------"""
+
+    # Used
+    def compile_tree_from_mergers(self, mergers=None):
+        if mergers is None:
+            mergers = self.mergers
+        edge_list = []
+        mergers_array = np.array(mergers)
+        orig_vert_names = [self.metadata.cellIds[int(ind)] for ind in
+                           np.setdiff1d(np.arange(self.metadata.nCells), mergers_array[:, 1])]
+        # orig_vert_names = [self.metadata.cellIds[int(mergers[-1][0])]]
+        dist_list = []
+        internal_node_counter = 0
+
+        starryYN = len(orig_vert_names) > 1
+        if starryYN:  # This happens when reading from tmp-file, where root still had multiple children
+            orig_vert_names = ['internal_0'] + orig_vert_names
+            internal_node_counter += 1
+            edge_list = [(0, ind) for ind in range(1, len(orig_vert_names))]
+            dist_list = [1.0] * len(edge_list)
+
+        for split in reversed(mergers):
+            # Find out who the father is
+            left_child = self.metadata.cellIds[int(split[0])]
+            right_child = self.metadata.cellIds[int(split[1])]
+            parent_ind = [ind for ind, vert_name in enumerate(orig_vert_names) if vert_name == left_child][0]
+
+            # Change the name of the parent, this is now an internal node
+            orig_vert_names[parent_ind] = 'internal_' + str(internal_node_counter)
+            internal_node_counter += 1
+
+            # Find out division times of ancestor and dist to children
+            # tdiv_anc, dist_child1, dist_child2 = split[2:]
+            dist_child1, dist_child2 = split[2:]
+
+            # Add two edges for the two children
+            curr_n_vertices = len(orig_vert_names)
+            # curr_fij = fijs[parent_ind]
+            # summed_dist = split[2]
+            edge_list.append((parent_ind, curr_n_vertices))
+            dist_list.append(dist_child1)
+            edge_list.append((parent_ind, curr_n_vertices + 1))
+            dist_list.append(dist_child2)
+
+            # Add both children under their own name
+            orig_vert_names.append(left_child)
+            orig_vert_names.append(right_child)
+        return edge_list, dist_list, orig_vert_names, starryYN
+
+    # Not Used
+    # def buildTreeFromMergers(self, mergers):
+    #     edgeList, distList, origVertNames, starryYN = self.compile_tree_from_mergers(mergers)
+    #     tree = Tree()
+    #     tree.starryYN = starryYN
+    #     rootInd = edgeList[0][0]
+    #     tree.root.nodeInd = rootInd
+    #     tree.root.childNodes = []
+    #     currInds = [rootInd]
+    #     currNodes = [tree.root]
+    #     # Build tree from edgeList, distList
+    #     for ind, edge in enumerate(edgeList):
+    #         dist = distList[ind]
+    #         if edge[0] in currInds:
+    #             parentInd = currInds.index(edge[0])
+    #             childInd = edge[1]
+    #         else:
+    #             parentInd = currInds.index(edge[1])
+    #             childInd = edge[0]
+    #         parent = currNodes[parentInd]
+    #         if dist > 0 or (origVertNames[ind + 1][:8] != 'internal'):
+    #             parent.isLeaf = False
+    #             child = TreeNode(nodeInd=childInd, tParent=dist, childNodes=[], isLeaf=True)
+    #             parent.childNodes.append(child)
+    #             bs_glob.nNodes += 1
+    #             currInds.append(childInd)
+    #             currNodes.append(child)
+    #         else:
+    #             currInds.append(childInd)
+    #             currNodes.append(parent)
+    #
+    #     # Add ltq-information to leafs of the tree
+    #     for cellInd, cellId in enumerate(self.metadata.cellIds):
+    #         nodeInd = origVertNames.index(cellId)
+    #         node = currNodes[nodeInd]
+    #         node.nodeId = cellId
+    #         node.isCell = True
+    #         if self.originalData is not None:
+    #             node.ltqs = self.originalData.ltqs[:, cellInd]
+    #             node.ltqsVars = self.originalData.ltqsVars[:, cellInd]
+    #         node.nodeInd = cellInd
+    #     tree.root.renumberNodes(change_node_inds=False)
+    #     return tree
+
+    # Used
+    def storeTreeInFolder(self, tree_folder, with_coords=False, verbose=False, all_ranks=False, cleanup_tree=True,
+                          nwk=True, store_posterior_ltqs=False):
+        coords_folder = tree_folder if with_coords else None
+        mpiRank = mpi_wrapper.get_process_rank()
+        if cleanup_tree:
+            self.tree.root.mergeZeroTimeChilds()
+            self.cleanup_node_inds()
+            # self.tree.root.renumberNodes(change_node_inds=False)
+            self.tree.nNodes = bs_glob.nNodes
+        if (mpiRank == 0) or all_ranks:
+            Path(tree_folder).mkdir(parents=True, exist_ok=True)
+            self.tree.store_tree_info_and_coords(tree_folder, coords_folder=coords_folder,
+                                                 verbose=False,
+                                                 store_posterior_ltqs=store_posterior_ltqs,
+                                                 geneDiffusionScaling=self.metadata.geneDiffusionScaling,
+                                                 variances=self.metadata.geneVariances)
+
+            self.metadata.to_json(os.path.join(tree_folder, 'metadata.json'))
+            if nwk:
+                self.tree.to_newick(use_ids=True, results_path=os.path.join(tree_folder, 'tree.nwk'))
+
+    def communicate_tree_topology(self):
+        if mpi_wrapper.get_process_rank() == 0:
+            # Make copy of tree
+            tree_copy = self.tree.copy_tree_topology()
+            tree_copy.root.storeParent()
+        else:
+            tree_copy = None
+        tree_copy = mpi_wrapper.bcast(tree_copy, root=0)
+        if mpi_wrapper.get_process_rank() != 0:
+            self.tree = tree_copy
+
+    # Should go to tree layout file
+    # def makeIgraphTreeFromSCData(self, merge_tol=1e-9, from_scData=False):
+    #     if from_scData:
+    #         edge_list, dist_list, orig_vert_names, starryYN, _ = self.compile_tree_from_scData_tree()
+    #     else:
+    #         edge_list, dist_list, orig_vert_names, starryYN = self.compile_tree_from_mergers()
+    #
+    #     # First we define every vertex in the binary tree as being in their own cluster
+    #     # clustering = list(range(len(orig_vert_names)))
+    #     # clustering = {orig_vert_names[nodeInd]: ind for ind, nodeInd in enumerate(orig_vert_names)}
+    #     # # Then merge nodes that have an edge length of 0 between them
+    #     # edges_to_remove = []
+    #     # for ind, edge in enumerate(edge_list):
+    #     #     if dist_list[ind] <= merge_tol:
+    #     #         clustering[orig_vert_names[edge[1]]] = clustering[orig_vert_names[edge[0]]]
+    #     #         edges_to_remove.append(ind)
+    #     #     edge_list[ind] = (clustering[orig_vert_names[edge[0]]], clustering[orig_vert_names[edge[1]]])
+    #     #
+    #     # # This results in a clustering-list where some cells go to the same cluster (vertex on the tree)
+    #     # edge_list = [edge for ind, edge in enumerate(edge_list) if ind not in edges_to_remove]
+    #     # dist_list = [dist for ind, dist in enumerate(dist_list) if ind not in edges_to_remove]
+    #
+    #     # # We number the remaining vertices
+    #     # new_vert_inds = {label: ind for ind, label in enumerate(np.sort(np.unique(clustering)))}
+    #     # # And adjust the edge_list to map to these new indices
+    #     # edge_list = [(new_vert_inds[edge[0]], new_vert_inds[edge[1]]) for edge in edge_list]
+    #
+    #     # We store to which clst every original node in the binary tree went
+    #     self.clustering = np.arange(len(orig_vert_names))
+    #     nodeIndToVertInd = {nodeInd: ind for ind, nodeInd in enumerate(orig_vert_names)}
+    #     # Also, we store how many vertices there are in our final tree
+    #     self.nVert = len(orig_vert_names)
+    #     # And we  make up some names
+    #     self.vertNames = ['vert_' + str(ind) for ind in range(self.nVert)]
+    #
+    #     # If the tree reconstruction is run on cellstates-output, we should first account for mapping the cells to
+    #     # cellstates
+    #     self.cellsToCellstates = {}
+    #     self.cellstatesToVerts = {}
+    #     self.cellsToVerts = {}
+    #     self.cellIndToVertInd = {}
+    #
+    #     for ind in range(self.metadata.nCells):
+    #         cellId = self.metadata.cellIds[ind]
+    #         # We have not yet implemented that we ran it on cs, so now we just map cells to their own cellstate
+    #         cellstateId = cellId
+    #         self.cellsToCellstates[cellId] = cellstateId
+    #
+    #         # Find out which node_ind this cellstate was mapped to
+    #         node_inds = [nodeInd for nodeInd in orig_vert_names if orig_vert_names[nodeInd] == cellId]
+    #         if len(node_inds) != 1:
+    #             print("Couldn't find " + cellId)
+    #             node_ind = -1
+    #         else:
+    #             node_ind = node_inds[0]
+    #         # Find out to which vertex ind this was again mapped
+    #         vert_ind = nodeIndToVertInd[node_ind]
+    #         # Find out to which new vertex this was again send to
+    #         self.cellstatesToVerts[cellstateId] = self.vertNames[vert_ind]
+    #         # Store in cell_assignment to which eventual vertex the original cell was sent
+    #         self.cellsToVerts[cellId] = self.cellstatesToVerts[self.cellsToCellstates[cellId]]
+    #         # Also store a map of which cellInd went to which vertInd
+    #         self.cellIndToVertInd[ind] = vert_ind
+    #
+    #     # Make edge-list between vert_inds instead of between node_inds
+    #     edge_list = [(nodeIndToVertInd[edge[0]], nodeIndToVertInd[edge[1]]) for edge in edge_list]
+    #
+    #     # Build up the tree
+    #     self.mst = igraph.Graph(directed=True)
+    #     self.mst.add_vertices(self.nVert)
+    #
+    #     self.mst.add_edges(edge_list)
+    #     self.mst.es["weight"] = dist_list
+    #     self.mst.vs["name"] = self.vertNames
+    #     self.mst.es["name"] = ['e_' + str(ind) for ind in range(self.nVert - 1)]
+    #     igraph.summary(self.mst)
+    #     self.nCellsPerVert = np.zeros(self.nVert)
+    #     self.vertIndToCellInds = {ind: [] for ind in range(self.nVert)}
+    #     for ind in range(self.metadata.nCells):
+    #         self.vertIndToCellInds[self.cellIndToVertInd[ind]].append(ind)
+    #         self.nCellsPerVert[self.cellIndToVertInd[ind]] += 1
+    #
+    # # Should go to tree layout file
+    # def makeIgraphTree(self, merge_tol=1e-9, from_scData=False):
+    #     if from_scData:
+    #         edge_list, dist_list, orig_vert_names, starryYN, _ = self.compile_tree_from_scData_tree()
+    #     else:
+    #         edge_list, dist_list, orig_vert_names, starryYN = self.compile_tree_from_mergers()
+    #
+    #     # First we define every vertex in the binary tree as being in their own cluster
+    #     clustering = list(range(len(orig_vert_names)))
+    #     # Then merge nodes that have an edge length of 0 between them
+    #     edges_to_remove = []
+    #     for ind, edge in enumerate(edge_list):
+    #         if dist_list[ind] <= merge_tol:
+    #             clustering[edge[1]] = clustering[edge[0]]
+    #             edges_to_remove.append(ind)
+    #         edge_list[ind] = (clustering[edge[0]], clustering[edge[1]])
+    #
+    #     # This results in a clustering-list where some cells go to the same cluster (vertex on the tree)
+    #     edge_list = [edge for ind, edge in enumerate(edge_list) if ind not in edges_to_remove]
+    #     dist_list = [dist for ind, dist in enumerate(dist_list) if ind not in edges_to_remove]
+    #
+    #     # We number the remaining vertices
+    #     new_vert_inds = {label: ind for ind, label in enumerate(np.sort(np.unique(clustering)))}
+    #     # And adjust the edge_list to map to these new indices
+    #     edge_list = [(new_vert_inds[edge[0]], new_vert_inds[edge[1]]) for edge in edge_list]
+    #
+    #     # We store to which clst every original node in the binary tree went
+    #     self.clustering = np.array([new_vert_inds[clst] for clst in clustering])
+    #     # Also, we store how many vertices there are in our final tree
+    #     self.nVert = len(np.unique(self.clustering))
+    #     # And we  make up some names
+    #     self.vertNames = ['vert_' + str(ind) for ind in range(self.nVert)]
+    #
+    #     # Now we would still like to know to which vertex the different cells were mapped
+    #     self.cellsToVerts = []
+    #
+    #     # If the tree reconstruction is run on cellstates-output, we should first account for mapping the cells to
+    #     # cellstates
+    #     self.cellsToCellstates = {}
+    #     self.cellstatesToVerts = {}
+    #     self.cellsToVerts = {}
+    #     self.cellIndToVertInd = {}
+    #
+    #     for ind in range(self.metadata.nCells):
+    #         cellId = self.metadata.cellIds[ind]
+    #         # We have not yet implemented that we ran it on cs, so now we just map cells to their own cellstate
+    #         cellstateId = cellId
+    #         self.cellsToCellstates[cellId] = cellstateId
+    #
+    #         # Find out which original vertex (before merging zero distance pairs) this cellstate was mapped to
+    #         vert_ind = [vert_ind for vert_ind, vert_name in enumerate(orig_vert_names) if vert_name == cellstateId][0]
+    #         # Find out to which new vertex this was again send to
+    #         self.cellstatesToVerts[cellstateId] = self.vertNames[self.clustering[vert_ind]]
+    #         # Store in cell_assignment to which eventual vertex the original cell was sent
+    #         self.cellsToVerts[cellId] = self.cellstatesToVerts[self.cellsToCellstates[cellId]]
+    #         # Also store a map of which cellInd went to which vertInd
+    #         self.cellIndToVertInd[ind] = self.clustering[vert_ind]
+    #
+    #     # Build up the tree
+    #     self.mst = igraph.Graph(directed=True)
+    #     self.mst.add_vertices(self.nVert)
+    #
+    #     self.mst.add_edges(edge_list)
+    #     self.mst.es["weight"] = dist_list
+    #     self.mst.vs["name"] = self.vertNames
+    #     self.mst.es["name"] = ['e_' + str(ind) for ind in range(self.nVert - 1)]
+    #     igraph.summary(self.mst)
+    #     self.nCellsPerVert = np.zeros(self.nVert)
+    #     self.vertIndToCellInds = {ind: [] for ind in range(self.nVert)}
+    #     for ind in range(self.metadata.nCells):
+    #         self.vertIndToCellInds[self.cellIndToVertInd[ind]].append(ind)
+    #         self.nCellsPerVert[self.cellIndToVertInd[ind]] += 1
+
+    # Should go to tree layout file
+    def find_branching_points(self, level=1, verbose=False):
+        # leaves = self.mst.vs.select(_degree_eq=1)
+        # parents = []
+        # dsInds = [leaf.index for leaf in leaves]
+        # allNonBranching = dsInds
+        # for ind in range(level):
+        #     parents.append([])
+        #     for dsInd in dsInds:
+        #         parent_edge = self.mst.es.select(_target=dsInd)
+        #         if len(parent_edge) > 0:
+        #             parents[ind].append(parent_edge[0].source)
+        #     dsInds = parents[ind]
+        #     allNonBranching += dsInds
+        # branching_inds = [vert.index for vert in self.mst.vs if
+        #                   (vert.index not in allNonBranching)]
+        # self.branchingInds = branching_inds
+
+        leaves = self.mst.vs.select(_degree_eq=1)
+        dsInds = [leaf.index for leaf in leaves]
+        levelDict = {}
+        lev = 0
+        for ind in dsInds:
+            levelDict[ind] = lev
+        stillParents = True
+        while stillParents:
+            lev += 1
+            parents = []
+            for dsInd in dsInds:
+                parent_edge = self.mst.es.select(_target=dsInd)
+                if len(parent_edge) > 0:
+                    parents.append(parent_edge[0].source)
+            dsInds = parents.copy()
+            for ind in dsInds:
+                levelDict[ind] = lev
+            stillParents = (len(parents) > 0)
+        allNonBranching = []
+        for ind, lev in levelDict.items():
+            if lev < level:
+                allNonBranching.append(ind)
+        branching_inds2 = [vert.index for vert in self.mst.vs if
+                           (vert.index not in allNonBranching)]
+        self.branchingInds = branching_inds2
+
+    # Should go to tree helpers file
+    def merge_clusters_acc_cellstates(self):
+        cellMask = self.nCellsPerVert != 0
+        summed_counts_vert = np.zeros((bs_glob.nGenes, self.nVerts))
+        if self.umiCounts is None:
+            self.vertUMIs = None
+        else:
+            for cellInd in range(self.metadata.nCells):
+                summed_counts_vert[:, self.cellIndToVertInd[cellInd]] += self.umiCounts[:, cellInd]
+            self.vertUMIs = summed_counts_vert
+        if (self.originalData is None) or (self.originalData.ltqs is None):
+            self.vertLtqs = None
+        else:
+            mean_ltqs_vert = np.zeros((self.originalData.ltqs.shape[0], self.nVerts))
+            for cellInd in range(self.metadata.nCells):
+                mean_ltqs_vert[:, self.cellIndToVertInd[cellInd]] += self.originalData.ltqs[:, cellInd]
+            cellMask = self.nCellsPerVert != 0
+            mean_ltqs_vert[:, cellMask] /= self.nCellsPerVert[cellMask]
+            self.vertLtqs = mean_ltqs_vert
+
+    # Should go to tree visualisation file
+    def set_node_edge_style(self, style_type='default'):
+        from .bonsai_helpers import custom_colors_rgba, gradient_colors, blackish, grey
+
+        counts = self.nCellsPerVert
+        cnt_min, cnt_max = np.min(counts), np.max(counts)
+
+        # non_cell_nodes = [ind for ind in range(self.nVert) if counts[ind] == 0]
+        non_cell_nodes = np.where(counts == 0)[0]
+
+        node_style = {}
+        node_style['s'] = np.ones(self.nVerts) * 4.
+        nonzero_counts = np.where(counts > 0)[0]
+        node_style['s'][nonzero_counts] += 20 * np.sqrt(counts[nonzero_counts])
+        node_style['s'] = list(node_style['s'])
+
+        edge_style = {}
+        edge_style['color'] = blackish
+        edge_style['linewidth'] = .375
+
+        if style_type == 'default':
+            node_style["color"] = [custom_colors_rgba[0]] * self.nVerts
+
+        if style_type == 'umi_counts':
+            summed_umi_counts = np.log(np.sum(self.vertUMIs, axis=0))
+            min_sum = np.min(summed_umi_counts)
+            max_sum = np.max(summed_umi_counts)
+            rescaled_sums = (summed_umi_counts - min_sum) / (max_sum - min_sum)
+            node_style["color"] = [gradient_colors(scaled_sum) for scaled_sum in rescaled_sums]
+
+        node_style['edgecolor'] = [blackish] * self.nVerts
+        node_style['linewidths'] = [.1] * self.nVerts
+
+        for ind in non_cell_nodes:
+            node_style['color'][ind] = grey
+            node_style['edgecolor'][ind] = grey
+        node_style = np.array(node_style)
+
+        return node_style, edge_style
+
+    # Should go to tree visualisation file
+    def get_celltype_annotations(self, celltype_metadata_path=None, vertIndToNodeId=None):
+        create_celltype_metadata = celltype_metadata_path is not None
+        # from helpers_full_gene_expression import celltype_colors, blackish, gradient_colors
+        celltypes_found = False
+
+        allcelltype_files = list(Path(self.data_path()).glob('Celltype*.txt'))
+        allcelltype_files.sort()
+        if create_celltype_metadata:
+            metadata_index = [vertIndToNodeId[vertInd] for vertInd in self.vertIndToCellInds]
+            ct_metadata = {}
+            metadata_labels = []
+        for celltype_file in allcelltype_files:
+            celltypes_input = np.array(pd.read_csv(celltype_file, header=None).iloc[:, 0].tolist())
+            celltypes_input = np.array([str(ct) for ct in celltypes_input])
+            if not celltypes_found:
+                celltypes_found = True
+                self.celltypes = celltypes_input
+                self.celltypesAlts = [self.celltypes]
+            else:
+                self.celltypesAlts.append(celltypes_input)
+            if create_celltype_metadata:
+                metadata_labels.append(os.path.basename(celltype_file).split('.txt')[0])
+        if not celltypes_found:
+            print("No celltype-file was found. Assigning same celltype to all cells")
+            self.celltypesAlts = [np.array(['default'] * self.metadata.nCells)]
+            metadata_labels.append("default")
+
+        self.cellCategoriesAlts = []
+        self.cellstateTypeListAlts = []
+        for ct_alt_ind, celltype_alt in enumerate(self.celltypesAlts):
+            cell_categories = np.unique(celltype_alt)
+            cell_categories = np.append(cell_categories, 'internal_node')
+            cellstate_type_list = ['internal_node'] * self.nVerts
+            for vertInd, cellInds in self.vertIndToCellInds.items():
+                celltypesPresent = np.array([celltype_alt[cellInd] for cellInd in cellInds])
+                if len(celltypesPresent) > 0:
+                    types, counts = np.unique(celltypesPresent, return_counts=True)
+                    n_types = len(types)
+                    if n_types == 1:
+                        cellstate_type_list[vertInd] = types[0]
+                    elif n_types > 1:
+                        types_dec_abundance = types[np.argsort(-counts)]
+                        mixed_type = types_dec_abundance[0]
+                        for ind in range(1, n_types):
+                            cell_type = types_dec_abundance[ind]
+                            mixed_type = mixed_type + '++' + cell_type
+                        cellstate_type_list[vertInd] = mixed_type
+
+            self.cellCategoriesAlts.append(cell_categories)
+            self.cellstateTypeListAlts.append(cellstate_type_list)
+            if create_celltype_metadata:
+                ct_metadata[metadata_labels[ct_alt_ind]] = cellstate_type_list
+
+        self.celltypes = self.celltypesAlts[0]
+        self.cellCategories = self.cellCategoriesAlts[0]
+        self.cellstateTypeList = self.cellstateTypeListAlts[0]
+        if create_celltype_metadata:
+            metadata_df = pd.DataFrame(ct_metadata, index=metadata_index)
+            metadata_df.to_csv(celltype_metadata_path, index=True, index_label='node_id')
+
+    # def get_celltypes_new(self, annotation_path, celltype_metadata_path=None, vertIndToNodeId=None):
+    #     """
+    #     Requires a celltype-file which is a csv with as first column the cell-IDs and as other columns different
+    #     celltype-annotations. A header line should give a label to the type of annotations.
+    #     :param celltype_metadata_path:
+    #     :param vertIndToNodeId:
+    #     :return:
+    #     """
+    #     metadata_index = [vertIndToNodeId[vertInd] for vertInd in self.vertIndToCellInds]
+    #     ct_metadata = {}
+    #
+    #     if os.path.isfile(annotation_path):
+    #         celltypes_input = pd.read_csv(annotation_path, header=0, index_col=0).astype(dtype=str)
+    #         if celltypes_input.shape[0] == (self.metadata.nCells - 1):
+    #             celltypes_input = pd.read_csv(annotation_path, header=None, index_col=0).astype(dtype=str)
+    #             celltypes_input.columns = ['Annotation {}'.format(ind) for ind in range(celltypes_input.shape[1])]
+    #
+    #         self.celltypes = np.array(celltypes_input.iloc[:,0].tolist())
+    #         self.celltypesAlts = [np.array(celltypes_input.iloc[:,ind].tolist()) for ind in range(celltypes_input.shape[1])]
+    #
+    #         metadata_labels = list(celltypes_input.columns)
+    #     else:
+    #         print("No celltype-file was found. Assigning same celltype to all cells")
+    #         self.celltypesAlts = [np.array(['default'] * self.metadata.nCells)]
+    #         self.celltypes = self.celltypesAlts
+    #         metadata_labels = ["default"]
+    #
+    #     self.cellCategoriesAlts = []
+    #     self.cellstateTypeListAlts = []
+    #     for ct_alt_ind, celltype_alt in enumerate(self.celltypesAlts):
+    #         cell_categories = np.unique(celltype_alt)
+    #         cell_categories = np.append(cell_categories, 'internal_node')
+    #         cellstate_type_list = ['internal_node'] * self.nVert
+    #         for vertInd, cellInds in self.vertIndToCellInds.items():
+    #             celltypesPresent = np.array([celltype_alt[cellInd] for cellInd in cellInds])
+    #             if len(celltypesPresent) > 0:
+    #                 types, counts = np.unique(celltypesPresent, return_counts=True)
+    #                 n_types = len(types)
+    #                 if n_types == 1:
+    #                     cellstate_type_list[vertInd] = types[0]
+    #                 elif n_types > 1:
+    #                     types_dec_abundance = types[np.argsort(-counts)]
+    #                     mixed_type = types_dec_abundance[0]
+    #                     for ind in range(1, n_types):
+    #                         cell_type = types_dec_abundance[ind]
+    #                         mixed_type = mixed_type + '++' + cell_type
+    #                     cellstate_type_list[vertInd] = mixed_type
+    #
+    #         self.cellCategoriesAlts.append(cell_categories)
+    #         self.cellstateTypeListAlts.append(cellstate_type_list)
+    #         ct_metadata[metadata_labels[ct_alt_ind]] = cellstate_type_list
+    #
+    #     self.celltypes = self.celltypesAlts[0]
+    #     self.cellCategories = self.cellCategoriesAlts[0]
+    #     self.cellstateTypeList = self.cellstateTypeListAlts[0]
+    #
+    #     metadata_df = pd.DataFrame(ct_metadata, index=metadata_index)
+    #     metadata_df.to_csv(celltype_metadata_path, index=True, index_label='node_id')
+    #     return ct_metadata
+
+    # def get_celltypes_new(self, annotation_path, celltype_metadata_path=None, vertIndToNodeId=None):
+    #     """
+    #     Requires a celltype-file which is a csv with as first column the cell-IDs and as other columns different
+    #     celltype-annotations. A header line should give a label to the type of annotations.
+    #     :param celltype_metadata_path:
+    #     :param vertIndToNodeId:
+    #     :return:
+    #     """
+    #     metadata_index = [vertIndToNodeId[vertInd] for vertInd in self.vertIndToCellInds]
+    #     ct_metadata = {}
+    #
+    #     if os.path.isfile(annotation_path):
+    #         celltypes_input = pd.read_csv(annotation_path, header=0, index_col=0).astype(dtype=str)
+    #         if celltypes_input.shape[0] == (self.metadata.nCells - 1):
+    #             celltypes_input = pd.read_csv(annotation_path, header=None, index_col=0).astype(dtype=str)
+    #             celltypes_input.columns = ['Annotation {}'.format(ind) for ind in range(celltypes_input.shape[1])]
+    #
+    #         self.celltypes = np.array(celltypes_input.iloc[:, 0].tolist())
+    #         self.celltypesAlts = [np.array(celltypes_input.iloc[:, ind].tolist()) for ind in
+    #                               range(celltypes_input.shape[1])]
+    #
+    #         metadata_labels = list(celltypes_input.columns)
+    #     else:
+    #         print("No celltype-file was found. Assigning same celltype to all cells")
+    #         self.celltypesAlts = [np.array(['default'] * self.metadata.nCells)]
+    #         self.celltypes = self.celltypesAlts
+    #         metadata_labels = ["default"]
+    #
+    #     self.cellCategoriesAlts = []
+    #     self.cellstateTypeListAlts = []
+    #     for ct_alt_ind, celltype_alt in enumerate(self.celltypesAlts):
+    #         cell_categories = np.unique(celltype_alt)
+    #         cell_categories = np.append(cell_categories, 'internal_node')
+    #         cellstate_type_list = ['internal_node'] * self.nVerts
+    #         for vertInd, cellInds in self.vertIndToCellInds.items():
+    #             celltypesPresent = np.array([celltype_alt[cellInd] for cellInd in cellInds])
+    #             if len(celltypesPresent) > 0:
+    #                 types, counts = np.unique(celltypesPresent, return_counts=True)
+    #                 n_types = len(types)
+    #                 if n_types == 1:
+    #                     cellstate_type_list[vertInd] = types[0]
+    #                 elif n_types > 1:
+    #                     types_dec_abundance = types[np.argsort(-counts)]
+    #                     mixed_type = types_dec_abundance[0]
+    #                     for ind in range(1, n_types):
+    #                         cell_type = types_dec_abundance[ind]
+    #                         mixed_type = mixed_type + '++' + cell_type
+    #                     cellstate_type_list[vertInd] = mixed_type
+    #
+    #         self.cellCategoriesAlts.append(cell_categories)
+    #         self.cellstateTypeListAlts.append(cellstate_type_list)
+    #         ct_metadata[metadata_labels[ct_alt_ind]] = cellstate_type_list
+    #
+    #     self.celltypes = self.celltypesAlts[0]
+    #     self.cellCategories = self.cellCategoriesAlts[0]
+    #     self.cellstateTypeList = self.cellstateTypeListAlts[0]
+    #
+    #     metadata_df = pd.DataFrame(ct_metadata, index=metadata_index)
+    #     metadata_df.to_csv(celltype_metadata_path, index=True, index_label='node_id')
+    #     return ct_metadata
+
+    def get_celltypes_minim(self, annotation_path):
+        """
+        Requires a celltype-file which is a csv with as first column the cell-IDs and as other columns different
+        celltype-annotations. A header line should give a label to the type of annotations.
+        :param celltype_metadata_path:
+        :param vertIndToNodeId:
+        :return:
+        """
+        # bonvis_data.obs["ct_{}".format(annot)] = pd.Categorical(ct_metadata[annot])
+        if os.path.isfile(annotation_path):
+            celltypes_input = pd.read_csv(annotation_path, header=0, index_col=0).astype(dtype=str)
+            if celltypes_input.shape[0] == (self.metadata.nCells - 1):
+                celltypes_input = pd.read_csv(annotation_path, header=None, index_col=0).astype(dtype=str)
+                celltypes_input.columns = ['Annotation {}'.format(ind) for ind in range(celltypes_input.shape[1])]
+
+            cell_id_to_ind = {cell_id: ind for ind, cell_id in enumerate(self.metadata.cellIds)}
+            cell_inds = np.array([cell_id_to_ind[cell_id] for cell_id in celltypes_input.index])
+            celltype_df = celltypes_input.iloc[cell_inds, :]
+            # Determine which columns are numerical values
+            new_colnames = []
+            for ind, col in enumerate(celltype_df.columns):
+                if np.all(celltype_df[col].apply(is_numeric)):
+                    celltype_df[col] = celltype_df[col].astype(float)
+                    new_colnames.append('annot_num_{}'.format(col))
+                else:
+                    celltype_df[col] = pd.Categorical(celltype_df[col])
+                    new_colnames.append('annot_{}'.format(col))
+            celltype_df.columns = new_colnames
+        else:
+            print("No celltype-file was found. Assigning same celltype to all cells")
+            celltype_df = pd.DataFrame({'annot_default': np.array(['default'] * self.metadata.nCells)},
+                                       index=self.metadata.cellIds)
+            celltype_df['annot_default'] = pd.Categorical(celltype_df['annot_default'])
+        # celltype_df.reset_index(inplace=True)
+        return celltype_df
+
+    def get_annotations(self, annotation_folder):
+        """
+        Requires a path to a folder where files are stored with annotation information. These files should be
+        csvs with as first column the cell-IDs and as other columns different
+        celltype-annotations. A header line should give a label to the type of annotations.
+        :return:
+        """
+        if (annotation_folder is not None) and os.path.isfile(annotation_folder):
+            file_list = [annotation_folder]
+        elif (annotation_folder is not None) and os.path.isdir(annotation_folder):
+            file_list = os.listdir(annotation_folder)
+        else:
+            print("No celltype-file was found. Assigning same celltype to all cells")
+            annotation_df = pd.DataFrame({'annot_default': np.array(['default'] * self.metadata.nCells)},
+                                         index=self.metadata.cellIds)
+            annotation_df['annot_default'] = pd.Categorical(annotation_df['annot_default'])
+            return annotation_df, {}
+
+        file_list = [file for file in file_list if (os.path.splitext(file)[1] == '.csv')]
+        annotation_dfs = []
+        data_matrices = {}
+        for ind_file, filename in enumerate(file_list):
+            filepath = os.path.join(annotation_folder, filename)
+            annot_input = pd.read_csv(filepath, header=0, index_col=0)  # .astype(dtype=str)
+            if annot_input.shape[0] in [self.metadata.nCells - 1, self.metadata.nCells]:
+                if annot_input.shape[0] == (self.metadata.nCells - 1):
+                    annot_input = pd.read_csv(filepath, header=None, index_col=0)
+                    annot_input.columns = ['Annotation {}_{}'.format(ind_file, ind) for ind in
+                                           range(annot_input.shape[1])]
+                cell_id_to_ind = {cell_id: ind for ind, cell_id in enumerate(annot_input.index)}
+                cell_inds = np.array([cell_id_to_ind[cell_id] for cell_id in self.metadata.cellIds])
+                annotation_df = annot_input.iloc[cell_inds, :]
+            # elif hasattr(self.metadata, 'nCss') and (annot_input.shape[0] in [self.metadata.nCss -1, self.metadata.nCss]):
+            #     if annot_input.shape[0] == (self.metadata.nCss - 1):
+            #         annot_input = pd.read_csv(filepath, header=None, index_col=0)
+            #         annot_input.columns = ['Annotation {}_{}'.format(ind_file, ind) for ind in range(annot_input.shape[1])]
+            #     cs_id_to_ind = {cell_id: ind for ind, cell_id in enumerate(annot_input.index)}
+            #     cs_inds = np.array([cs_id_to_ind[cs_id] for cs_id in self.metadata.csIds])
+            #     annotation_df = annot_input.iloc[cs_inds, :]
+            if filename[:4] == 'mat_':
+                mat_label = ''.join(filename[4:].split('.')[:-1])
+                data_matrices[mat_label] = annotation_df.T
+            else:
+                # Determine which columns are numerical values
+                new_colnames = []
+                for ind, col in enumerate(annotation_df.columns):
+                    if np.all(annotation_df[col].apply(is_numeric)):
+                        annotation_df[col] = annotation_df[col].astype(float)
+                        new_colnames.append('annot_num_{}'.format(col))
+                    else:
+                        try:
+                            annotation_df[col] = annotation_df[col].fillna("NaN")
+                        except:
+                            print("Could not convert nans in column {}.".format(col))
+                        annotation_df[col] = pd.Categorical(annotation_df[col])
+                        new_colnames.append('annot_{}'.format(col))
+                annotation_df.columns = new_colnames
+                annotation_dfs.append(annotation_df)
+        annotation_dfs = pd.concat(annotation_dfs, axis=1)
+        # celltype_df.reset_index(inplace=True)
+        return annotation_dfs, data_matrices
+
+    def get_annotations_with_cs(self, annotation_folder):
+        """
+        Requires a path to a folder where files are stored with annotation information. These files should be
+        csvs with as first column the cell-IDs and as other columns different
+        celltype-annotations. A header line should give a label to the type of annotations.
+        :return:
+        """
+        if (annotation_folder is not None) and os.path.isfile(annotation_folder):
+            file_list = [annotation_folder]
+        elif (annotation_folder is not None) and os.path.isdir(annotation_folder):
+            file_list = os.listdir(annotation_folder)
+        else:
+            file_list = []
+            logger.info("No celltype-annotation was found. Assigning same celltype to all cells")
+
+        file_list = [file for file in file_list if (os.path.splitext(file)[1] in ['.csv', '.tsv'])]
+        annotation_dfs_cell = []
+        annotation_dfs_cs = []
+        data_matrices = {}
+        cell_or_cs = None
+        for ind_file, filename in enumerate(file_list):
+            filepath = os.path.join(annotation_folder, filename)
+            ext = os.path.splitext(filepath)[1]
+            annotation_df = None
+            if ext == '.tsv':
+                delim = '\t'
+            elif ext == '.csv':
+                delim = ','
+            else:
+                continue
+            annot_input = pd.read_csv(filepath, header=0, index_col=0, delimiter=delim,
+                                      dtype={0: str})  # .astype(dtype=str)
+            if hasattr(self.metadata, 'nCss') and (
+                    annot_input.shape[0] in [self.metadata.nCss - 1, self.metadata.nCss]):
+                if annot_input.shape[0] == (self.metadata.nCss - 1):
+                    annot_input = pd.read_csv(filepath, header=None, index_col=0, delimiter=delim)
+                    annot_input.columns = ['Annotation {}_{}'.format(ind_file, ind) for ind in
+                                           range(annot_input.shape[1])]
+                cs_id_to_ind = {cell_id: ind for ind, cell_id in enumerate(annot_input.index)}
+                try:
+                    cs_inds = np.array([cs_id_to_ind[cs_id] for cs_id in self.metadata.csIds])
+                    annotation_df = annot_input.iloc[cs_inds, :]
+                    cell_or_cs = 'cs'
+                except KeyError as e:
+                    mp_print("The cell-ID {} was present in the data but not in annotation-file '{}'. "
+                             "Please check this. "
+                             "For now, we are trying to still use this annotation-file.".format(e, filename),
+                             WARNING=True)
+                    annotation_df = None
+            elif annot_input.shape[0] in [self.metadata.nCells - 1, self.metadata.nCells]:
+                if annot_input.shape[0] == (self.metadata.nCells - 1):
+                    annot_input = pd.read_csv(filepath, header=None, index_col=0, delimiter=delim, dtype={0: str})
+                    annot_input.columns = ['Annotation {}_{}'.format(ind_file, ind) for ind in
+                                           range(annot_input.shape[1])]
+                cell_id_to_ind = {cell_id: ind for ind, cell_id in enumerate(annot_input.index)}
+                try:
+                    cell_inds = np.array([cell_id_to_ind[cell_id] for cell_id in self.metadata.cellIds])
+                    annotation_df = annot_input.iloc[cell_inds, :]
+                    cell_or_cs = 'cell'
+                except KeyError as e:
+                    mp_print("The cell-ID {} was present in the data but not in annotation-file '{}'. "
+                             "Please check this. "
+                             "For now, we are trying to still use this annotation-file.".format(e, filename),
+                             WARNING=True)
+            else:
+                mp_print("Annotation-file '{}' has a number of rows that is not equal to the number of cells "
+                         "(or cellstates) in the dataset. Please check this. For now, we are trying to still use this "
+                         "annotation-file".format(filename), WARNING=True)
+            if annotation_df is None:
+                try:
+                    # Try to find out if we can save this annotation-file even though it doesn't have the correct number
+                    # of rows
+                    saved_df = False
+                    annotation_df = annot_input.reindex(self.metadata.csIds)
+                    if annotation_df.shape[0] and annotation_df.notna().any().any():
+                        cell_or_cs = 'cs'
+                        mp_print("Managed to save the annotation in {}. "
+                                 "Do check if results are correct.".format(filename), WARNING=True)
+                        saved_df = True
+                    if not saved_df:
+                        annotation_df = annot_input.reindex(self.metadata.cellIds)
+                        if annotation_df.shape[0] and annotation_df.notna().any().any():
+                            cell_or_cs = 'cell'
+                            mp_print("Managed to save the annotation in {}. "
+                                     "Do check if results are correct.".format(filename), WARNING=True)
+                            saved_df = True
+                    if not saved_df:
+                        mp_print("Annotation-file '{}' has a number of rows that is not equal to the number of cells "
+                                 "(or cellstates) in the dataset. Please check this. For now, we are discarding this "
+                                 "annotation-file".format(filename), WARNING=True)
+                        annotation_df = None
+                except Exception as e:
+                    mp_print("An error occurred: {}".format(e))
+                    mp_print("Annotation-file '{}' can somehow not be mapped to any annotation of the cells or "
+                             "cellstates in the dataset.".format(filename), WARNING=True)
+                    annotation_df = None
+            if annotation_df is not None:
+                if filename[:4] == 'mat_':
+                    mat_label = ''.join(filename[4:].split('.')[:-1])
+                    data_matrices[mat_label] = annotation_df.T
+                else:
+                    # Determine which columns are numerical values
+                    new_colnames = []
+                    cols_to_add = []
+                    colnames_to_add = []
+                    annotation_df = annotation_df.drop(columns=annotation_df.columns[annotation_df.isna().all()])
+                    for ind, col in enumerate(annotation_df.columns):
+                        if np.all(annotation_df[col].apply(is_numeric)):
+                            annotation_df[col] = annotation_df[col].astype(float)
+                            new_colnames.append(
+                                'annot_num_{}'.format(col.replace(' ', '_').replace('-', '_').replace('.', '_')))
+                            if len(np.unique(annotation_df[col])) < 20:
+                                # In this case, add a colname to the annotation that treats these as categorical annotation
+                                cols_to_add.append(['c_{}'.format(orig_annot) for orig_annot in annotation_df[col]])
+                                colnames_to_add.append('annot_categorized_{}'.format(
+                                    col.replace(' ', '_').replace('-', '_').replace('.', '_')))
+                        else:
+                            try:
+                                annotation_df[col] = annotation_df[col].fillna("NaN")
+                            except:
+                                print("Could not convert nans in column {}.".format(col))
+                            annotation_df[col] = pd.Categorical(annotation_df[col])
+
+                            if col.startswith("num_"):
+                                col = col.replace("num_", "usernum_")
+
+                            new_colnames.append(
+                                'annot_{}'.format(col.replace(' ', '_').replace('-', '_').replace('.', '_')))
+                    annotation_df.columns = new_colnames
+                    for name, vector in zip(colnames_to_add, cols_to_add):
+                        annotation_df[name] = vector
+                    if cell_or_cs == 'cell':
+                        annotation_dfs_cell.append(annotation_df)
+                    else:
+                        annotation_dfs_cs.append(annotation_df)
+
+        if len(annotation_dfs_cell) == 0:
+            annotation_dfs_cell = pd.DataFrame({'annot_default': np.array(['default'] * self.metadata.nCells)},
+                                               index=self.metadata.cellIds)
+            annotation_dfs_cell['annot_default'] = pd.Categorical(annotation_dfs_cell['annot_default'])
+        else:
+            annotation_dfs_cell = pd.concat(annotation_dfs_cell, axis=1)
+            if annotation_dfs_cell.columns.has_duplicates:
+                annotation_dfs_cell.columns = [col_name + "{}_".format(ind) for ind, col_name in
+                                               enumerate(annotation_dfs_cell.columns)]
+        if len(annotation_dfs_cs) == 0:
+            annotation_dfs_cs = pd.DataFrame({'annot_default': np.array(['default'] * self.metadata.nCss)},
+                                             index=self.metadata.csIds)
+            annotation_dfs_cs['annot_default'] = pd.Categorical(annotation_dfs_cs['annot_default'])
+        else:
+            annotation_dfs_cs = pd.concat(annotation_dfs_cs, axis=1)
+            if annotation_dfs_cs.columns.has_duplicates:
+                annotation_dfs_cs.columns = [col_name + "_{}".format(ind) for ind, col_name in
+                                             enumerate(annotation_dfs_cs.columns)]
+
+        return annotation_dfs_cell, annotation_dfs_cs, data_matrices
+
+    """---------------------------Reading and writing data---------------------––––-----------------------"""
+
+    def data_path(self, filename=""):
+        if self.metadata.pathToOrigData is None:
+            if not len(filename):
+                if self.metadata.dataset:
+                    return os.path.abspath(os.path.join("../data", self.metadata.dataset))
+                else:
+                    return os.path.abspath(os.path.join("../data", 'tmp_dataset'))
+            else:
+                if self.metadata.dataset:
+                    return os.path.abspath(os.path.join("../data", self.metadata.dataset, filename))
+                else:
+                    return os.path.abspath(os.path.join("../data", 'tmp_dataset', filename))
+        else:
+            if not len(filename):
+                return os.path.abspath(self.metadata.pathToOrigData)
+            else:
+                return os.path.abspath(os.path.join(self.metadata.pathToOrigData, filename))
+
+    def result_path(self, filename=""):
+        if self.metadata.results_folder is None:
+            if not len(filename):
+                if self.metadata.dataset:
+                    return os.path.abspath(os.path.join("../results", self.metadata.dataset))
+                else:
+                    return os.path.abspath(os.path.join("../results", 'tmp_dataset'))
+            else:
+                if self.metadata.dataset:
+                    return os.path.abspath(os.path.join("../results", self.metadata.dataset, filename))
+                else:
+                    return os.path.abspath(os.path.join("../results", 'tmp_dataset', filename))
+        else:
+            if not len(filename):
+                return os.path.abspath(self.metadata.results_folder)
+            else:
+                return os.path.abspath(os.path.join(self.metadata.results_folder, filename))
+
+    # Used
+    def read_in_data(self, filenamesData=None, getOrigData=False, verbose=False, noDataNeeded=False, sanityOutput=False,
+                     zscoreCutoff=-1, mpiInfo=None, all_genes=False):
+        if mpiInfo is None:
+            mpiInfo = mpi_wrapper.get_mpi_info()
+        originalData = OriginalData()
+        # Determine correct filenames
+        if filenamesData is None:
+            filenameMeans = 'delta_vmax.txt'
+            filenameStds = 'd_delta_vmax.txt'
+        else:
+            filenamesData = filenamesData.split(',')
+            filenameMeans = filenamesData[0]
+            if len(filenamesData) > 1:
+                filenameStds = filenamesData[1]
+            else:
+                filenameStds = None
+
+        try:
+            tmp_folder = self.result_path('processed_data_communication')
+            if (mpiInfo.size > 1) and (mpiInfo.rank == 0):
+                Path(tmp_folder).mkdir(parents=True, exist_ok=True)
+            originalData.ltqs, originalData.ltqsVars, originalData.geneVariances, \
+            self.metadata.nCells, \
+            self.metadata.nGenes, genes_to_keep, ltqStdsFound, \
+            n_genes_orig = read_and_filter(self.data_path(), filenameMeans, filenameStds, sanityOutput,
+                                           zscoreCutoff, mpiInfo, tmp_folder=tmp_folder, verbose=verbose,
+                                           all_genes=all_genes)
+
+        except FileNotFoundError:
+            if noDataNeeded:
+                print("filenamesData: {}".format(filenamesData))
+                # mp_print("WARNING: File {} not found.".format(self.data_path(filenameMeans)), WARNING=True)
+                # mp_print("WARNING: File {} not found.".format(self.data_path(filenameStds)), WARNING=True)
+                mp_print("Did not find data-file, but is not (strictly) needed now.", WARNING=True)
+                originalData.ltqs = None
+                originalData.ltqsVars = None
+                self.metadata.nCells = None
+                self.metadata.nGenes = None
+                genes_to_keep = None
+                ltqStdsFound = False
+                n_genes_orig = None
+            else:
+                # mp_print("WARNING: File {} not found.".format(self.data_path(filenameMeans)), WARNING=True)
+                # mp_print("WARNING: File {} not found.".format(self.data_path(filenameStds)), WARNING=True)
+                exit("Data-file was not found!")
+        if mpiInfo.rank != 0:
+            return None, None
+
+        # Reading in gene-identifiers (or other sc-features)
+        made_up_gene_ids = False
+        if os.path.exists(self.data_path("geneID.txt")):
+            self.metadata.geneIds = []
+            with open(self.data_path(os.path.join('geneID.txt')), 'r') as file:
+                reader = csv.reader(file, delimiter="\t")
+                for row in reader:
+                    self.metadata.geneIds.append(row[0])
+            if (n_genes_orig is not None) and (len(self.metadata.geneIds) != n_genes_orig):
+                print("Number of gene-Ids in file geneID.txt does not match number of features in data-matrix!")
+                exit()
+        elif os.path.exists(self.data_path('log_transcription_quotients.txt')):
+            geneIds = pd.read_csv(self.data_path('log_transcription_quotients.txt'), header=None, usecols=[0],
+                                  sep='\t')[1:].values.flatten()
+            self.metadata.geneIds = [ID for ID in geneIds]
+            if (n_genes_orig is not None) and (len(self.metadata.geneIds) != n_genes_orig):
+                print("Number of gene-Ids in file log_transcription_quotients.txt does not match genes in data-matrix!")
+                exit()
+        else:
+            mp_print("No geneID-file was found. Giving generic names.")
+            if originalData.ltqs is None:
+                self.metadata.nGenes = 10  # Make up 10 fake genes, not used anywhere
+            self.metadata.geneIds = ['Gene_' + str(ind) for ind in range(self.metadata.nGenes)]
+            made_up_gene_ids = True
+        if genes_to_keep is not None:
+            self.metadata.geneIds = list(
+                np.array(self.metadata.geneIds)[genes_to_keep]) if not made_up_gene_ids else self.metadata.geneIds
+
+        if self.metadata.nGenes is None:
+            self.metadata.nGenes = len(self.metadata.geneIds)
+
+        self.metadata.cellIds = []
+        forbidden = {":", ",", "(", ")", ";", ' '}  # Otherwise, writing and reading to Nwk-string fails
+        warned = False
+        if os.path.exists(self.data_path('cellID.txt')):
+            with open(self.data_path(os.path.join('cellID.txt')), 'r') as file:
+                reader = csv.reader(file, delimiter="\t")
+                for row in reader:
+                    cell_id = row[0]
+                    if any(c in cell_id for c in forbidden):
+                        logger.error("At least one cell-ID: {} contains a character that is problematic for"
+                                     "writing and reading Nwk-strings: ':', ',' '(', ')',';'.\n"
+                                     "Please replace these characters, for example by underscores: '_'.\n"
+                                     "Note that you should also do these "
+                                     "replacements in potential annotation-files.".format(cell_id))
+                        exit()
+                        # if not warned:
+                        #     logger.warning("At least one cell-ID: {} contains a character that is problematic for"
+                        #                    "writing and reading Nwk-strings: ':', ',' '(', ')',';'.\n"
+                        #                    "We'll replace these characters by underscores in the output.")
+                        #     warned = True
+                        # for c in forbidden:
+                        #     cell_id = cell_id.replace(c, "_")
+                    self.metadata.cellIds.append(cell_id)
+            n_unq_ids = len(np.unique(self.metadata.cellIds))
+            if self.metadata.nCells is not None:
+                if (n_unq_ids != self.metadata.nCells) or (len(self.metadata.cellIds) != self.metadata.nCells):
+                    mp_print("Number of unique object-IDs given in {} does not "
+                             "match the number of columns in your feature"
+                             "matrix.\n "
+                             "Please resolve this and start Bonsai again.".format(self.data_path('cellID.txt')),
+                             ERROR=True)
+                    exit()
+        else:
+            mp_print("No cellID-file was found. Giving generic names.")
+            if self.metadata.nCells is None:
+                self.metadata.cellIds = None
+            else:
+                self.metadata.cellIds = ['Cell_' + str(ind) for ind in range(self.metadata.nCells)]
+        if (self.metadata.nCells is None) and (self.metadata.cellIds is not None):
+            self.metadata.nCells = len(self.metadata.cellIds)
+
+        self.originalData = originalData if getOrigData else None
+        return ltqStdsFound, originalData
+
+    # Used
+    def read_in_data_no_ltqs(self):
+        # Reading in gene-identifiers (or other sc-features)
+        if os.path.exists(self.data_path("geneID.txt")):
+            self.metadata.geneIds = []
+            with open(self.data_path(os.path.join('geneID.txt')), 'r') as file:
+                reader = csv.reader(file, delimiter="\t")
+                for row in reader:
+                    self.metadata.geneIds.append(row[0])
+        elif os.path.exists(self.data_path('log_transcription_quotients.txt')):
+            geneIds = pd.read_csv(self.data_path('log_transcription_quotients.txt'), header=None, usecols=[0],
+                                  sep='\t')[1:].values.flatten()
+            self.metadata.geneIds = [ID for ID in geneIds]
+        self.metadata.nGenes = len(self.metadata.geneIds)
+
+        self.metadata.cellIds = []
+        if os.path.exists(self.data_path('cellID.txt')):
+            with open(self.data_path(os.path.join('cellID.txt')), 'r') as file:
+                reader = csv.reader(file, delimiter="\t")
+                for row in reader:
+                    self.metadata.cellIds.append(row[0])
+        else:
+            mp_print("No cellID-file was found. Giving generic names.")
+            self.metadata.cellIds = ['Cell_' + str(ind) for ind in range(self.metadata.nCells)]
+        self.metadata.nCells = len(self.metadata.cellIds)
+
+    # Should go to tree visualisation file
+    def read_umi_counts(self, filename_data=None):
+        if filename_data is None:
+            filename_data = 'Gene_table.txt'
+        try:
+            tmp = pd.read_csv(self.data_path(filename_data), sep='\t', index_col=0)
+            self.umiCounts = tmp.values.astype(dtype='int')
+            if self.umiCounts.shape[0] != self.metadata.nGenes:
+                self.throw_out_zeros()
+                if self.umiCounts.shape[0] != self.metadata.nGenes:
+                    exit("Umi-count file does not have the same number as genes as the rest of the data.")
+        except FileNotFoundError:
+            print("Warning, not an error: No UMI-count file was found.")
+            self.umiCounts = None
+
+    # Should go to tree visualisation file
+    def throw_out_zeros(self):
+        nonzero_inds = np.sum(self.umiCounts, axis=1) != 0
+        self.umiCounts = self.umiCounts[nonzero_inds, :]
+
+    # Used
+    def getGeneVariances(self, originalData, posterior_data=None, ltqStdsFound=False):
+        if originalData.geneVariances is not None:
+            return
+
+        if posterior_data is None:
+            posterior_data = originalData
+        if ltqStdsFound:
+            originalData.geneVariances = np.var(posterior_data.ltqs, axis=1) + np.mean(posterior_data.ltqsVars,
+                                                                                       axis=1)
+            # Old options for calculating the variances are below
+            # pjotrs = infer_true_var_log(originalData.ltqs, originalData.ltqsVars)
+            # # Infer variance from fixed point procedure
+            # C = self.metadata.nCells
+            # newGeneVars = np.zeros(self.metadata.nGenes)
+            # ltqsSq = originalData.ltqs ** 2
+            # for gene in range(self.metadata.nGenes):
+            #     if gene % 1000 == 0:
+            #         mp_print("Optimising gene variance for gene " + str(gene))
+            #     vg0 = originalData.geneVariances[gene]
+            #     ltqsVarsG = originalData.ltqsVars[gene, :]
+            #     lb = ltqsVarsG.max() + 1e-6
+            #     optRes = minimize(logLGradDepOnV, vg0, args=(C, ltqsSq[gene, :], ltqsVarsG), jac=True,
+            #                       bounds=[(lb, None)])
+            #
+            #     newGeneVars[gene] = optRes.x
+        elif posterior_data.ltqs is not None:
+            originalData.geneVariances = np.var(posterior_data.ltqs, axis=1)
+        else:
+            originalData.geneVariances = None
+
+    def cleanup_node_inds(self):
+        if self.metadata.cellIds is None:
+            mp_print("Cannot cleanup node-indices without defined metadata.cellIds.", WARNING=True)
+            return
+        cell_id_to_ind = {cell_id: ind for ind, cell_id in enumerate(self.metadata.cellIds)}
+        nodes_list = self.tree.root.getNodeList([], returnRoot=True, returnLeafs=True)
+        bs_glob.max_node_ind = -1
+        n_cells = 0
+        for node in nodes_list:
+            if node.nodeId in cell_id_to_ind:
+                n_cells += 1
+                node.nodeInd = cell_id_to_ind[node.nodeId]
+                node.isCell = True
+                bs_glob.max_node_ind = max(node.nodeInd, bs_glob.max_node_ind)
+
+        # bs_glob.max_node_ind = np.max(list(cell_id_to_ind.values()))
+        self.tree.max_node_ind = bs_glob.max_node_ind
+        self.metadata.nCells = n_cells
+        bs_glob.nCells = self.metadata.nCells
+        self.tree.root.renumberNodes(change_node_inds=True)
+
+
+def do_spr_moveset(scdata_path, args, strategy='determ_random_determ', pickup_intermediate=False):
+    """
+
+    :param strategy: Current options are 'large_tree', 'long_branch_sorted', 'super_sure'.
+    This relates to what kind of SPR-moves we propose in what order.
+    :return:
+    """
+    mpi_info = mpi_wrapper.get_mpi_info()
+    # info_dict = None
+    # if (mpi_info.rank == 0) and tracking:
+    #     info_dict = {'steps': [], 'runtimes': [], 'd_loglik': [], 'successes': []}
+    #     orig_loglik = scData.tree.calcLogLComplete(mem_friendly=True)
+    #     orig_time = time.time()
+
+    output_prefixes = ['after_sprmoveset{}'.format(ind) for ind in range(1, 3)]
+    output_present = [False] * len(output_prefixes)
+    if pickup_intermediate:
+        for ind, prefix in enumerate(output_prefixes):
+            # Check whether one of the intermediate paths is already there
+            output_present[ind], scdata_path_new = look_for_output_folder('spr_intermediates',
+                                                                          general_results_folder=args.results_folder,
+                                                                          prefix=prefix)
+            if output_present[ind]:
+                scdata_path = scdata_path_new
+
+    if strategy == 'large_tree':
+        if output_present[0]:
+            mp_print("Found results for first SPR moveset in {}. Skipping first moveset.".format(scdata_path))
+        else:
+            scData = do_spr_moves_with_postprocessing(scdata_path, args=args,
+                                                      select_cand='long_branches_first',
+                                                      select_target='cluster_centers',
+                                                      max_moves=None,
+                                                      min_branch_length=1e-2,
+                                                      large_tree=True)
+
+            scdata_path = store_scdata_and_communicate_path(scData, specific_results_folder='spr_intermediates',
+                                                            general_results_folder=args.results_folder,
+                                                            prefix=output_prefixes[0])
+            scData = None
+            gc.collect()
+
+        scData = do_spr_moves_with_postprocessing(scdata_path, args=args,
+                                                  select_cand='long_branches_first',
+                                                  select_target='cluster_centers',
+                                                  max_moves=None,
+                                                  min_branch_length=1e-2,
+                                                  large_tree=True)
+    else:
+        if mpi_info.rank != 0:
+            mp_print("Can't contribute to doing SPR moves in any other mode than 'large_tree'. "
+                     "Choose --spr_strategy='large_tree' to benefit from parallelization "
+                     "(at the cost of some memory usage) for the SPR-moves."
+                     "Now, this process will wait to see whether it can help in the postprocessing.", ALL_RANKS=True)
+
+    if strategy == 'long_branch_sorted':
+        if output_present[0]:
+            mp_print("Found results for first SPR moveset in {}. Skipping first moveset.".format(scdata_path))
+        else:
+            scData = do_spr_moves_with_postprocessing(scdata_path, args=args,
+                                                      select_cand='long_branches_first',
+                                                      select_target='cluster_centers',
+                                                      max_moves=None,
+                                                      min_branch_length=1e-2)
+
+            scdata_path = store_scdata_and_communicate_path(scData, specific_results_folder='spr_intermediates',
+                                                            general_results_folder=args.results_folder,
+                                                            prefix=output_prefixes[0])
+            scData = None
+            gc.collect()
+
+        # if output_present[1]:
+        #     mp_print("Found results for second SPR moveset in {}. Skipping first moveset.".format(scdata_path))
+        # else:
+        # scData = do_spr_moves_with_postprocessing(scdata_path, args=args,
+        #                                                   select_cand='random',
+        #                                                   select_target='random',
+        #                                                   max_moves=None,
+        #                                                   moves_id='C_random_T_random',
+        #                                                   tracking=tracking, info_dict=info_dict)
+        # scdata_path = store_scdata_and_communicate_path(scData, specific_results_folder='spr_intermediates',
+        #                                                 general_results_folder=args.results_folder,
+        #                                                 prefix=output_prefixes[1])
+        # scData = None
+        # gc.collect()
+        # scData = None
+        # gc.collect()
+
+        scData = do_spr_moves_with_postprocessing(scdata_path, args=args,
+                                                  select_cand='long_branches_first',
+                                                  select_target='cluster_centers',
+                                                  max_moves=None,
+                                                  min_branch_length=1e-2)
+
+    elif strategy == 'super_sure':
+        if output_present[0]:
+            mp_print("Found results for first SPR moveset in {}. Skipping first moveset.".format(scdata_path))
+        else:
+            scData = do_spr_moves_with_postprocessing(scdata_path, args=args,
+                                                      select_cand='long_branches_first',
+                                                      select_target='cluster_centers',
+                                                      max_moves=None)
+
+            scdata_path = store_scdata_and_communicate_path(scData, specific_results_folder='spr_intermediates',
+                                                            general_results_folder=args.results_folder,
+                                                            prefix=output_prefixes[0])
+            scData = None
+            gc.collect()
+
+        if output_present[1]:
+            mp_print("Found results for second SPR moveset in {}. Skipping first moveset.".format(scdata_path))
+        else:
+            scData = do_spr_moves_with_postprocessing(scdata_path, args=args,
+                                                      select_cand='long_branches_first',
+                                                      select_target='all',
+                                                      max_moves=1000)
+
+            scdata_path = store_scdata_and_communicate_path(scData, specific_results_folder='spr_intermediates',
+                                                            general_results_folder=args.results_folder,
+                                                            prefix=output_prefixes[1])
+            scData = None
+            gc.collect()
+
+        scData = do_spr_moves_with_postprocessing(scdata_path, args=args,
+                                                  select_cand='long_branches_first',
+                                                  select_target='cluster_centers',
+                                                  max_moves=None)
+
+    return scData
+
+
+def do_spr_moves_with_postprocessing(scdata_path, args, select_cand, select_target, max_moves=None,
+                                     min_branch_length=-1, large_tree=False, parallel=False):
+    """
+
+    :param args:
+    :param select_cand:
+    :param select_target:
+    :param max_moves:
+    :param min_branch_length:
+    :param large_tree: If True, SPR moves in a sequence are done normally until we drop below 10 successes in 1000
+    attempts. After that, we start scanning all moves without executing successes, because this can be parallelized.
+    Finally, we take only the successes and execute them in order of predicted dLogL
+    :return:
+    """
+    mpi_info = mpi_wrapper.get_mpi_info()
+    if max_moves is None:
+        max_moves = bs_glob.nNodes
+
+    # Just some tracking
+    # if (mpi_info.rank == 0) and tracking:
+    #     start_logl = scData.tree.calcLogLComplete(mem_friendly=True)
+    #     mp_print("Loglikelihood of inferred tree before "
+    #              "{}: {}".format(moves_id, start_logl))
+    #     start = time.time()
+
+    # The actual moves!
+    if not large_tree:
+        if mpi_info.rank != 0:
+            mp_print("This process will only contribute to SPR-postprocessing.", ALL_RANKS=True)
+            scData = None
+        else:
+            scData = loadReconstructedTreeAndData(args, scdata_path,
+                                                  reprocess_data=False, all_genes=False, get_cell_info=False,
+                                                  all_ranks=True, rel_to_results=False, verbose=False)
+
+            successful_moves, total_dlogl, _ = scData.tree.do_spr_moves(max_moves=max_moves,
+                                                                        select_cand=select_cand,
+                                                                        select_target=select_target,
+                                                                        min_branch_length=min_branch_length)
+    else:
+        # In this case, do three phases:
+        # Phase 1: only moves are performed until they occur at low frequency only,
+        # Phase 2: no moves are performed, but we scan all candidates and store successful candidates
+        # Phase 3: the successful candidates are sorted for their predicted loglikelihood and executed
+
+        # Phase 1: only moves are performed until they occur at low frequency only,
+        # intermediate_folder = scData.result_path('spr_intermediate_{}'.format(np.random.randint(1e6)))
+        if mpi_info.rank == 0:
+            scData = loadReconstructedTreeAndData(args, scdata_path,
+                                                  reprocess_data=False, all_genes=False, get_cell_info=False,
+                                                  all_ranks=True, rel_to_results=False, single_process=True,
+                                                  verbose=False)
+
+            # To save on memory, do the preparing tree already here, after that store and load the tree again. The
+            # reason is that ltqs at internal nodes will be mem-mapped in this way, rather than read into RAM
+            orig_loglik = scData.tree.prepare_tree_spr_moves()
+        else:
+            scData = None
+
+        # Store tree again, and communicate tree-folder with all processes.
+        scdata_path = store_scdata_and_communicate_path(scData, specific_results_folder='spr_intermediates')
+        scData = None
+        gc.collect()
+
+        if mpi_info.rank == 0:
+            scData = loadReconstructedTreeAndData(args, scdata_path,
+                                                  reprocess_data=False, all_genes=False, get_cell_info=False,
+                                                  all_ranks=False, rel_to_results=False, single_process=True,
+                                                  verbose=False)
+
+            # Do the first SPR moves (coming at high freq) only at first process
+            successful_moves, total_dlogl, remain_cands = scData.tree.do_spr_moves(max_moves=max_moves,
+                                                                                   select_cand=select_cand,
+                                                                                   select_target=select_target,
+                                                                                   min_branch_length=min_branch_length,
+                                                                                   freq_cutoff=.05, mem_friendly=True,
+                                                                                   skip_prepare_tree=True)
+
+            # Prepare the tree already for the next phase, do this only on Process 0
+            orig_loglik = scData.tree.prepare_tree_spr_moves()
+
+            # Store the resulting tree with coordinates, such that it can be read in by other processes
+            # mp_print("Before storing tree, memory usage is ",
+            #          psutil.Process(os.getpid()).memory_info().rss / 1024 ** 2, " MB.", ALL_RANKS=True)
+            # scData.storeTreeInFolder(os.path.join(intermediate_folder), with_coords=True,
+            #                          verbose=False, nwk=False)
+
+            # Communicate the node indices of the remaining candidates. This also serves as a barrier between
+            # storing the tree and loading it on other processes
+            df_nodes_list = scData.tree.root.getNodeList([], returnRoot=True, returnLeafs=True)
+            remain_cands_set = set(remain_cands)
+            remain_cands_df_sorted = [node.nodeInd for node in df_nodes_list if node.nodeInd in remain_cands_set]
+
+            remain_cands = np.array(remain_cands_df_sorted)
+            remain_cands = mpi_wrapper.bcast(remain_cands, root=0)
+            # intermediate_folder = mpi_wrapper.bcast(intermediate_folder, root=0)
+        else:
+            remain_cands = None
+            # Other processes receive the node-indices that need to be checked
+            remain_cands = mpi_wrapper.bcast(remain_cands, root=0)
+            # intermediate_folder = mpi_wrapper.bcast(intermediate_folder, root=0)
+            # Then they read the tree that was stored from process 0
+
+        scdata_path_parallelphase = store_scdata_and_communicate_path(scData,
+                                                                      specific_results_folder='spr_intermediates')
+
+        # print_memory("Stored the tree before parallel-phase of SPR moves")
+        scData = None
+        if mpi_info.rank == 0:
+            del df_nodes_list
+        gc.collect()
+        # print_memory("Removed old scData-object before parallel-phase of SPR moves")
+
+        scData = loadReconstructedTreeAndData(args, scdata_path_parallelphase,
+                                              reprocess_data=False, all_genes=False, get_cell_info=False,
+                                              all_ranks=True, rel_to_results=False, verbose=False)
+        # scData.tree.root.storeParent()
+        # print_memory("Loaded fresh scData from file before parallel-phase of SPR.")
+
+        # Now, every process should have the full tree-result of the first SPR moves. Ready to start Phase 2
+        # Phase 2: no moves are performed, but we scan all candidates and store successful candidates
+
+        # First, distribute node-inds to check over the cores. We'll do this by cutting a depth-first list up in
+        # blocks. Eventually, this may help keep memory-usage friendly
+        my_tasks = getMyTaskNumbers(len(remain_cands), mpi_info.size, mpi_info.rank, skippingSteps=False)
+        my_tasks = remain_cands[my_tasks]  # This now contains the node-inds for candidates to be treated per proc.
+
+        # Scan over these candidates
+        negdlogl_nodeind_tuples = scData.tree.do_spr_moves(select_cand='list', select_target=select_target,
+                                                           cand_list=my_tasks, only_scan=True, mem_friendly=True,
+                                                           skip_prepare_tree=True)
+        # The variable negdlogl_nodeind_tuples should contain the successful-candidates that were found on this core,
+        # as a list of tuples (-d_log_l, cand_node_ind)
+
+        # Sorting the candidates calculated on this process
+        if len(negdlogl_nodeind_tuples):
+            negdlogl_nodeind_tuples.sort(key=lambda x: x[0], reverse=False)
+        else:
+            negdlogl_nodeind_tuples = []
+
+        # Gather the succesful candidates from all processes
+        if mpi_info.size > 1:
+            all_negdlogl_nodeind_tuples = mpi_wrapper.gather(negdlogl_nodeind_tuples, root=0)
+            if mpi_info.rank != 0:
+                # The memory on these processes can be freed, as they will be idle for a while
+                try:
+                    del negdlogl_nodeind_tuples
+                    del scData
+                    gc.collect()
+                except UnboundLocalError:
+                    pass
+                mp_print("My job in the SPR-moves is done. Will wait to see if I can help in postprocessing.",
+                         ALL_RANKS=True)
+                scData = None
+            else:
+                # So only process zero goes here. It merges all the sorted lists using the heapq.merge algorithm
+                negdlogl_nodeind_tuples = list(heapq.merge(*all_negdlogl_nodeind_tuples))
+
+        if mpi_info.rank == 0:
+            # Phase 3: the successful candidates are sorted for their predicted loglikelihood and executed
+            # OPTIONAL: Re-load tree that was stored as intermediate, because then we the scanning behavior didn't change
+            # the ordering of children, which makes it perfectly comparable when running on different numbers of cores
+            del scData
+            gc.collect()
+            # print_memory('Deleted scData after parallel phase')
+            scData = loadReconstructedTreeAndData(args, scdata_path_parallelphase,
+                                                  reprocess_data=False, all_genes=False, get_cell_info=False,
+                                                  all_ranks=True, rel_to_results=False, single_process=True,
+                                                  verbose=False)
+            # scData.tree.root.storeParent()
+            # print_memory("Loaded tree again after parallel phase")
+
+            my_tasks = [node_ind_dlogl[1] for node_ind_dlogl in negdlogl_nodeind_tuples]
+            successful_moves, total_dlogl, remain_cands = scData.tree.do_spr_moves(select_cand='list',
+                                                                                   select_target=select_target,
+                                                                                   cand_list=my_tasks, only_scan=False,
+                                                                                   mem_friendly=True,
+                                                                                   skip_prepare_tree=True)
+
+    # Just some tracking
+    # if tracking:
+    #     info_dict['steps'].append(moves_id)
+    #     info_dict['runtimes'].append(time.time() - start)
+    #     new_logl = scData.tree.calcLogLComplete(mem_friendly=True)
+    #     info_dict['d_loglik'].append(new_logl - start_logl)
+    #     info_dict['successes'].append(successful_moves)
+    #     mp_print("Loglikelihood of inferred tree after "
+    #              "{} successful SPR-moves: {}".format(successful_moves, new_logl))
+
+    # start = time.time()
+    # start_logl = new_logl
+
+    # All processes should come togethere here.
+    mp_print("Start round of postprocessing after SPR-moves.", ALL_RANKS=True)
+    scData = extensive_spr_postprocessing(args, scData, verbose=large_tree)
+    # print_memory("After round of postprocessing after SPR-moves.")
+
+    # Just some tracking
+    # if tracking:
+    #     info_dict['steps'].append(moves_id + "_postproc")
+    #     info_dict['runtimes'].append(time.time() - start)
+    #     new_logl = scData.tree.calcLogLComplete(mem_friendly=True)
+    #     info_dict['d_loglik'].append(new_logl - start_logl)
+    #     info_dict['successes'].append(0)
+    #     mp_print("Loglikelihood of inferred tree after postprocessing: {}".format(new_logl))
+    return scData
+
+
+def extensive_spr_postprocessing(args, scdata, verbose=False):
+    mpi_info = mpi_wrapper.get_mpi_info()
+    # First do smaller postprocessing just on zero-th process
+    if mpi_info.rank == 0:
+        scdata.tree.do_spr_postprocessing(verbose=verbose, only_cleanup=False, only_time_opt=True)
+
+    # Then communicate the tree-topology (without the data coordinates), necessary to resolve polytomies
+    scdata_path_postproc = store_scdata_and_communicate_path(scdata, specific_results_folder='spr_intermediates')
+    if (mpi_info.size > 1) and (mpi_info.rank != 0):
+        scdata = loadReconstructedTreeAndData(args, scdata_path_postproc, reprocess_data=False, all_genes=False,
+                                              get_cell_info=False, all_ranks=False, rel_to_results=True)
+    else:
+        # Get as-if-root information, necessary for resolving polytomies
+        scdata.tree.root.getAIRootInfo(None, None)
+    # Make sure, node counts are correct on all processes
+    scdata.tree.root.renumberNodes(change_node_inds=False)
+    scdata.tree.nNodes = bs_glob.nNodes
+
+    # Resolve polytomies
+    scdata.tree.root.mergeChildrenRecursive(scdata.tree.root.ltqs, scdata.tree.root.getW(), sequential=False,
+                                            verbose=verbose, ellipsoidSize=1.0, single_process=False,
+                                            mergeDownstream=True, tree=scdata.tree, nChildNN=50, kNN=10)
+    if mpi_info.rank != 0:
+        mp_print("Now, my job in the SPR postprocessing is also done. Returning to main function.", ALL_RANKS=True)
+        del scdata
+        gc.collect()
+        return None
+
+    # Only the first process goes here.
+    scdata.tree.root.renumberNodes(change_node_inds=False)  # Some nodes were merged, need to re-count the nodes
+    scdata.tree.nNodes = bs_glob.nNodes
+    scdata.tree.root.storeParent()
+    scdata.tree.optTimes(verbose=verbose, singleProcess=True, mem_friendly=True, maxiter=100, tol=1e-4)
+
+    return scdata
+
+    # Used
+    # def filter_variable_genes(self, originalData, zscoreCutoff=-1, nGenesToKeep=-1, verbose=False):
+    #     if (zscoreCutoff > 0) or (nGenesToKeep > 0):
+    #         # Compute zscores for all genes.
+    #         # zscores = np.sqrt(np.maximum(np.mean(((originalData.ltqs - np.mean(originalData.ltqs, axis=1)[:,
+    #         #                                                            np.newaxis]) ** 2 - originalData.ltqsVars)
+    #         #                                      / originalData.ltqsVars, axis=1), 1e-12))
+    #         zscores = np.sqrt(np.maximum(np.mean(
+    #             ((originalData.ltqs - np.mean(originalData.ltqs, axis=1)[:, np.newaxis]) ** 2) / originalData.ltqsVars,
+    #             axis=1), 1e-12))
+    #         if zscoreCutoff > 0:
+    #             genesToKeep = np.where(zscores > zscoreCutoff)[0]
+    #             mp_print("Z-score cutoff is: %f, %d genes are kept." % (zscoreCutoff, len(genesToKeep)))
+    #         else:
+    #             nGenesToKeep = min(nGenesToKeep, self.metadata.nGenes)
+    #             ordered_genes = np.argsort(-zscores)
+    #             genesToKeep = ordered_genes[:nGenesToKeep]
+    #         if verbose:
+    #             mp_print("%d genes are kept, gene with lowest z-score becomes %f." % (
+    #                 nGenesToKeep, -np.sort(-zscores)[nGenesToKeep - 1]))
+    #     else:
+    #         genesToKeep = np.array(range(self.metadata.nGenes))
+    #     originalData.ltqs = originalData.ltqs[genesToKeep, :]
+    #     originalData.ltqsVars = originalData.ltqsVars[genesToKeep, :]
+    #     if originalData.geneVariances is not None:
+    #         originalData.geneVariances = originalData.geneVariances[genesToKeep]
+    #         # originalData.trueVariances = originalData.trueVariances[genesToKeep]
+    #     if originalData.priorVariances is not None:
+    #         originalData.priorVariances = originalData.priorVariances[genesToKeep]
+    #     self.metadata.nGenes = len(genesToKeep)
+    #     self.metadata.geneIds = list(np.array(self.metadata.geneIds)[genesToKeep])
+
+    # def calc_euclidean_distances(self, distsFile=None):
+    #     avgDists = pdist(self.ltqs.T, metric='sqeuclidean') / self.nGenes
+    #     mpiRank = mpi_wrapper.get_process_rank()
+    #     if (mpiRank == 0) and distsFile:
+    #         np.savetxt(self.data_path(distsFile), avgDists)
+    #     return avgDists
+
+
+# Used
+def nnnReorderRandom(args, outputFolder, verbose=False, randomMoves=0,
+                     veryVerbose=False, randomTries=None, resultsFolder=None):
+    """
+    In this function we take single edges in the tree and consider all nodes connected to it. We start by
+    calculating the tree likelihood for the current configuration. Then we delete the edge such that all nodes
+    are connected to one root. Then we just do our usual (mergeChildrenUB) to find the best configuration. We
+    compare the resulting tree likelihood with the previous one. Then we either loop over all edges and take the
+    best few reconfigurations, or we just do a reconfiguration whenever we find a good one.
+    :param verbose:
+    :return:
+    """
+    mpiInfo = mpi_wrapper.get_mpi_info()
+    tmp_folder = os.path.join(resultsFolder, 'intermediate_trees')
+    stored_tree_ind = None
+    if mpiInfo.rank == 0:
+        found_intermediate = False
+        if args.pickup_intermediate and os.path.exists(tmp_folder):
+            intermediateFolders = os.listdir(tmp_folder)
+            if len(intermediateFolders):
+                intermediateFolder, stored_tree_ind = get_latest_intermediate(intermediateFolders, base='nnn')
+                if intermediateFolder is not None:
+                    # scData.tree = unpickleTree(tmp_folder, intermediateFile)
+                    scData = loadReconstructedTreeAndData(args, os.path.join(tmp_folder, intermediateFolder),
+                                                          reprocess_data=False, all_genes=False, get_cell_info=False,
+                                                          all_ranks=False, rel_to_results=False)
+                    randomMoves = 0
+                    found_intermediate = True
+            elif os.path.exists(os.path.join(resultsFolder, 'random_trees', 'orig_tree')):
+                scData = loadReconstructedTreeAndData(args, os.path.join(resultsFolder, 'random_trees', 'orig_tree'),
+                                                      reprocess_data=False, all_genes=False, get_cell_info=False,
+                                                      all_ranks=False, rel_to_results=False)
+                found_intermediate = True
+
+        if not found_intermediate:
+            scData = loadReconstructedTreeAndData(args, outputFolder, reprocess_data=False, all_genes=False,
+                                                  get_cell_info=False, all_ranks=False, rel_to_results=True)
+        Path(tmp_folder).mkdir(parents=True, exist_ok=True)
+        scData.tree.root.mergeZeroTimeChilds()
+        scData.tree.root.renumberNodes(change_node_inds=False)
+        scData.tree.nNodes = bs_glob.nNodes
+
+        # First make sure every node knows where its parent node is
+        # mp_print("Before storing parent, memory usage is ",
+        #          psutil.Process(os.getpid()).memory_info().rss / 1024 ** 2, " MB.", ALL_RANKS=True)
+        scData.tree.root.storeParent()
+        # mp_print("Before getting ltqs, memory usage is ",
+        #          psutil.Process(os.getpid()).memory_info().rss / 1024 ** 2, " MB.", ALL_RANKS=True)
+        scData.tree.root.getLtqsComplete(mem_friendly=True)
+        origLoglik = scData.tree.calcLogLComplete(mem_friendly=True, loglikVarCorr=scData.metadata.loglikVarCorr,
+                                                  recalc=False)
+        scData.metadata.loglik = origLoglik
+
+    randomMoves = mpi_wrapper.bcast(randomMoves, root=0)
+    if randomMoves == 0:
+        randomTries = 0
+    else:
+        if (randomTries is None) or ((randomTries > 0) and (randomTries < mpiInfo.size)):
+            randomTries = mpiInfo.size
+    np.random.seed(42)
+    seeds = np.random.choice(int(randomTries * 1e4), size=randomTries, replace=False)
+    # Start by doing random moves. Different move series are done in parallel.
+    # First create a copy of the original tree from which each move series will start
+    random_folder = os.path.join(resultsFolder, 'random_trees')
+    # mp_print("Before storing tree, memory usage is ",
+    #          psutil.Process(os.getpid()).memory_info().rss / 1024 ** 2, " MB.", ALL_RANKS=True)
+    if mpiInfo.rank == 0:
+        # pickleTree(pickleFolder, 'orig_tree.dat', self.tree)
+        scData.storeTreeInFolder(os.path.join(random_folder, 'orig_tree'), with_coords=True, verbose=False, nwk=False)
+        scData = None
+        gc.collect()
+    mpi_wrapper.barrier()
+
+    myTasks = np.arange(mpiInfo.rank, randomTries, mpiInfo.size)
+    treeLogliks = {}
+
+    for task in myTasks:
+        moveCounter = 0
+        np.random.seed(seeds[task])
+        # First load the original tree again
+        # mp_print("Before loading tree, memory usage is ",
+        #          psutil.Process(os.getpid()).memory_info().rss / 1024 ** 2, " MB.", ALL_RANKS=True)
+        # self.tree = unpickleTree(pickleFolder, 'orig_tree.dat')
+        # noinspection PyMethodFirstArgAssignment
+        scData = loadReconstructedTreeAndData(args, os.path.join(random_folder, 'orig_tree'),
+                                              reprocess_data=False, all_genes=False, get_cell_info=False,
+                                              all_ranks=True, rel_to_results=False)
+        # scData.tree.root.storeParent()
+        # mp_print(scData.metadata.loglik, scData.tree.root.ltqs[:5], ALL_RANKS=True)
+        currLoglik = scData.metadata.loglik
+        # Then do random moves on this copy of the tree
+        while moveCounter < randomMoves:
+            # if moveCounter % 100 == 0:
+            #     mp_print("After %d random moves, memory usage is " % moveCounter,
+            #              psutil.Process(os.getpid()).memory_info().rss / 1024 ** 2, " MB.", ALL_RANKS=True)
+            # TODO: Optimize the following couple of lines
+            # Create a list of nodes that are not the root and not leafs
+            nodesList = recursionWrap(scData.tree.root.getNodeList, [], returnLeafs=True,
+                                      returnRoot=True)  # TODO: Fast to maintain?
+            nodeIndToNode = {node.nodeInd: node for node in nodesList}
+            candidatesList = [node for node in nodesList if (not node.isLeaf) and (not node.isRoot)]  # TODO: Same
+            nCandidates = len(candidatesList)
+
+            randInd = np.random.randint(nCandidates)
+            # Make sure this node knows what its ltqs and ltqsVars would be if it would be the root
+            # candidatesList[randInd].getAIRootUpstream()
+            nnnLoglik, optEdgeList, mostUSInfo = scData.tree.getOptEdgeList(candidatesList[randInd], args,
+                                                                            finalOptTimes=True,
+                                                                            returnEdgelist=True, random=True,
+                                                                            trackCloseness=False, singleProcess=True,
+                                                                            mem_friendly=True)
+
+            if optEdgeList is None:
+                if verbose:
+                    cand = candidatesList[randInd]
+                    message = "node %d" % cand.nodeInd if cand.parentNode is None \
+                        else "nodes %d and %d" % (cand.nodeInd, cand.parentNode.nodeInd)
+                    mp_print("Random reconfiguration around %s is skipped because of many connected nodes." % message,
+                             ALL_RANKS=True)
+                continue
+            # Process optimal reordering in the original tree
+            scData.tree.processOptReconfig(optEdgeList, nodeIndToNode, nodesList, candidatesList, mostUSInfo,
+                                           trackCloseness=False)
+            currLoglik += nnnLoglik
+            if veryVerbose:
+                mp_print("Move %d: Random reconfiguration of the nodes around node %d "
+                         "changed the loglikelihood by %f" % (moveCounter, randInd, nnnLoglik))
+            if verbose and (moveCounter % 1000 == 0):
+                mp_print(
+                    "Tree %d, Move %d: Random reconfiguration of next-nearest neighbours. Loglik now: %f" % (
+                        task, moveCounter, currLoglik), ALL_RANKS=True)
+            moveCounter += 1
+
+        # Store tree loglikelihood after this random series of moves
+        scData.metadata.loglik = scData.tree.calcLogLComplete(mem_friendly=True,
+                                                              loglikVarCorr=scData.metadata.loglikVarCorr)
+        treeLogliks[task] = scData.metadata.loglik
+        # Store this tree in a tmp-file
+        # pickleTree(nnn_folder, 'randomTree_%d' % task, self.tree)
+        scData.storeTreeInFolder(os.path.join(random_folder, 'random_tree_%d' % task), with_coords=False,
+                                 verbose=verbose, all_ranks=True)
+        scData = None
+        gc.collect()
+        # mp_print("After storing random tree, memory usage is ",
+        #          psutil.Process(os.getpid()).memory_info().rss / 1024 ** 2, " MB.", ALL_RANKS=True)
+        if verbose:
+            mp_print("Process %d made tree number %d by doing %d random moves with a loglikelihood of %f." % (
+                mpiInfo.rank, task, moveCounter, treeLogliks[task]), ALL_RANKS=True)
+
+    if randomTries > 0:
+        # Random bunch of trees has been created. Now select the best one
+        allTreeLogliks = mpi_wrapper.gather(treeLogliks, root=0)
+        if mpiInfo.rank == 0:
+            for oneTreeLogliks in allTreeLogliks:
+                treeLogliks.update(oneTreeLogliks)
+            tasks, logliks = zip(*treeLogliks.items())
+            bestTreeInd = np.argmax(logliks)
+            max_rand_loglik = logliks[bestTreeInd]
+            take_original_tree = False
+            if max_rand_loglik < origLoglik:
+                mp_print("Best random tree still has lower likelihood than the original tree. This is probably normal "
+                         "and desired behavior, but maybe check if something didn't go terribly wrong.", WARNING=True)
+                take_original_tree = True
+            if verbose and (not take_original_tree):
+                mp_print("Taking tree number %d. The random moves increased the loglikelihood from %f to %f." % (
+                    tasks[bestTreeInd], origLoglik, logliks[bestTreeInd]), ALL_RANKS=True)
+            bestTree = tasks[bestTreeInd]
+            # currLoglik = logliks[bestTreeInd]
+            # Then load this tree to move on
+            # self.tree = unpickleTree(pickleFolder, 'randomTree_%d.dat' % bestTree)
+            # mp_print("Before loading optimal random tree, memory usage is ",
+            #          psutil.Process(os.getpid()).memory_info().rss / 1024 ** 2, " MB.", ALL_RANKS=True)
+            if take_original_tree:
+                scData = loadReconstructedTreeAndData(args, os.path.join(random_folder, 'orig_tree'),
+                                                      reprocess_data=False, all_genes=False, get_cell_info=False,
+                                                      all_ranks=False, rel_to_results=False)
+            else:
+                scData = loadReconstructedTreeAndData(args, os.path.join(random_folder, 'random_tree_%d' % bestTree),
+                                                      reprocess_data=False, all_genes=False, get_cell_info=False,
+                                                      all_ranks=False, rel_to_results=False)
+            mp_print("Loaded optimal tree has loglikelihood: %r" % scData.metadata.loglik)
+            # mp_print("Loaded optimal tree has true loglikelihood: %r" % scData.tree.calcLogLComplete(mem_friendly=True,
+            #                                                                                  loglikVarCorr=scData.metadata.loglikVarCorr))
+            # mp_print("After loading optimal random tree, memory usage is ",
+            #          psutil.Process(os.getpid()).memory_info().rss / 1024 ** 2, " MB.", ALL_RANKS=True)
+        mpi_wrapper.barrier()
+    elif mpiInfo.rank == 0:
+        scData = loadReconstructedTreeAndData(args, os.path.join(random_folder, 'orig_tree'),
+                                              reprocess_data=False, all_genes=False, get_cell_info=False,
+                                              all_ranks=True, rel_to_results=False)
+
+    # Process 0 now has the tree on which we should proceed. Communicate this.
+    # Then do on this tree all remaining beneficial reconfigurations in a greedy manner
+    if mpiInfo.rank == 0:
+        stored_tree_ind = 0 if stored_tree_ind is None else stored_tree_ind
+        scData.storeTreeInFolder(os.path.join(tmp_folder, 'nnn_tree_%d' % stored_tree_ind), with_coords=True,
+                                 verbose=verbose, cleanup_tree=False)
+        scData = None
+        gc.collect()
+        # mp_print("After storing optimal random tree, memory usage is ",
+        #          psutil.Process(os.getpid()).memory_info().rss / 1024 ** 2, " MB.", ALL_RANKS=True)
+        # pickleTree(nnn_folder, 'nnn_start', self.tree)
+    if mpiInfo.rank == 0:
+        remove_tree_folders(random_folder, removeDir=True)
+    stored_tree_ind = mpi_wrapper.bcast(stored_tree_ind, root=0)
+    return stored_tree_ind, tmp_folder
+
+
+def nnnReorder(args, tmp_folder, stored_tree_ind, maxMoves=100, closenessBound=0.5, verbose=False, mem_friendly=True):
+    mpiInfo = mpi_wrapper.get_mpi_info()
+    moveCounter = 0
+    # mp_print("Before loading initial tree, memory usage is ",
+    #          psutil.Process(os.getpid()).memory_info().rss / 1024 ** 2, " MB.", ALL_RANKS=True)
+    scData = loadReconstructedTreeAndData(args, os.path.join(tmp_folder, 'nnn_tree_%d' % stored_tree_ind),
+                                          reprocess_data=False, all_genes=False, get_cell_info=False,
+                                          all_ranks=True, rel_to_results=False)
+    mp_print("Loaded tree has loglikelihood: %r" % scData.metadata.loglik)
+    currLoglik = scData.metadata.loglik
+    # mp_print("After loading initial tree, memory usage is ",
+    #          psutil.Process(os.getpid()).memory_info().rss / 1024 ** 2, " MB.", ALL_RANKS=True)
+    # scData.tree.root.storeParent()
+    stored_tree_ind += 1
+    goodMovesLeft = True
+    while goodMovesLeft and (moveCounter < maxMoves):
+        # TODO: Optimize this as above
+        # Create a list of nodes that are not the root and not leafs
+        nodesList = recursionWrap(scData.tree.root.getNodeList, [], returnLeafs=True,
+                                  returnRoot=True)  # TODO: Fast to maintain?
+        nodeIndToNode = {node.nodeInd: node for node in nodesList}  # TODO: Maybe add to node-object
+        candidatesList = [node for node in nodesList if (not node.isLeaf) and (not node.isRoot)]  # TODO: Same
+        nCandidates = len(candidatesList)
+
+        if not mem_friendly:
+            # Since we will calculate reorderings from every node, it is beneficial to get AIRootInfo all at once
+            scData.tree.root.getAIRootInfo(None, None)
+
+        myTasks = getMyTaskNumbers(nCandidates, mpiInfo.size, mpiInfo.rank, skippingSteps=False)
+        nTasks = len(myTasks)
+        calcCounter = 0
+        maxReorder = (-1, -1e9)
+        maxReorderNoTopChange = (-1, -1e9)
+        # as reorderDlogL we will store tuples (dLogL, topChangeYN) where second boolean indicates topology-change
+        reorderDLogLs = {}
+        for myInd, ind in enumerate(myTasks):
+            dsNode = candidatesList[ind]
+            if verbose and ((myInd + 1) % 1000 == 0):
+                mp_print("Move %d. Considering edge %d out of %d." % (moveCounter, myInd + 1, nTasks),
+                         ALL_RANKS=True)
+
+            if (dsNode.cumClosenessNNN is not None) and (dsNode.cumClosenessNNN <= closenessBound):
+                reorderDLogL = dsNode.nnnLoglik
+                topChange = dsNode.nnnLoglikTopChange
+            else:
+                calcCounter += 1
+                reorderDLogL, topChange = scData.tree.getOptEdgeList(dsNode, args, finalOptTimes=False,
+                                                                     returnEdgelist=False, singleProcess=True,
+                                                                     mem_friendly=mem_friendly)
+                if reorderDLogL is None:
+                    if verbose:
+                        message = "node %d" % dsNode.nodeInd if dsNode.parentNode is None \
+                            else "nodes %d and %d" % (dsNode.nodeInd, dsNode.parentNode.nodeInd)
+                        mp_print(
+                            "Reconfiguration around %s is skipped because of many connected nodes." % message,
+                            ALL_RANKS=True)
+                    reorderDLogL = -1
+                    topChange = False
+                reorderDLogLs[dsNode.nodeInd] = (reorderDLogL, topChange)
+            if topChange and (reorderDLogL > maxReorder[1]):
+                maxReorder = (dsNode.nodeInd, reorderDLogL)
+            elif (not topChange) and (reorderDLogL > maxReorderNoTopChange[1]):
+                maxReorderNoTopChange = (dsNode.nodeInd, reorderDLogL)
+
+        # Communicate maxima and take only the maximum
+        maxReorderTuples = mpi_wrapper.world_allgather(maxReorder)
+        _, maxReorders = zip(*maxReorderTuples)
+        maxReorder = maxReorderTuples[np.argmax(maxReorders)]
+        maxReorderNoTopChangeTuples = mpi_wrapper.world_allgather(maxReorderNoTopChange)
+        _, maxReordersNoTopChange = zip(*maxReorderNoTopChangeTuples)
+        maxReorderNoTopChange = maxReorderNoTopChangeTuples[np.argmax(maxReordersNoTopChange)]
+
+        # mp_print("Reconfig without topology change: %f. With topology change: %f" % (
+        #       maxReorderNoTopChange[1], maxReorder[1]))
+        # if maxReorderNoTopChange[1] > maxReorder[1]:
+        #     mp_print("Reconfig without topology change is larger than with topology change.")
+
+        # Communicate calculated reorderDLogLs and add to dsNodes
+        reorderDLogLsAll = mpi_wrapper.world_allgather(reorderDLogLs)
+        for reorderDLogLsSingle in reorderDLogLsAll:
+            for nodeInd in reorderDLogLsSingle:
+                nodeOI = nodeIndToNode[nodeInd]
+                nodeOI.nnnLoglik = reorderDLogLsSingle[nodeInd][0]
+                nodeOI.nnnLoglikTopChange = reorderDLogLsSingle[nodeInd][1]
+                nodeOI.cumClosenessNNN = 0.
+        calcCounters = mpi_wrapper.gather(calcCounter, root=0)
+        if mpiInfo.rank == 0:
+            calcCounter = sum(calcCounters)
+
+        # If loglikelihood increased enough, do these optimal merges in the original tree as well
+        # Find optimal reorder
+        optNodeInd = maxReorder[0]
+        if (maxReorder[1] / (scData.metadata.nCells * scData.metadata.nGenes)) < 1e-6:
+            mp_print(
+                "Couldn't find any more reconfigurations of next-nearest neighbours that increased the "
+                "likelihood by more than 1e-6 per gene per cell.")
+            goodMovesLeft = False
+            continue
+
+        nnnLoglik, optEdgeList, mostUSInfo = scData.tree.getOptEdgeList(nodeIndToNode[optNodeInd], args,
+                                                                        finalOptTimes=True, returnEdgelist=True,
+                                                                        mem_friendly=mem_friendly)
+
+        if (nnnLoglik / (scData.metadata.nCells * scData.metadata.nGenes)) < 1e-6:
+            mp_print(
+                "Couldn't find any more reconfigurations of next-nearest neighbours that increased the "
+                "likelihood by more than 1e-6 per gene per cell.")
+            goodMovesLeft = False
+            continue
+
+        currLoglik += nnnLoglik
+        if verbose:
+            mp_print("Move %d: After %d calculations, it was found that re-ordering the nodes around node %d "
+                     "maximally increased the "
+                     "loglikelihood. Loglik now %f" % (moveCounter, calcCounter, optNodeInd, currLoglik))
+
+        # Process optimal reordering in the original tree
+        # Find most-upstream-node in original tree. In most cases, not all children will be reconfigured, only these
+        # should be deleted
+        scData.tree.processOptReconfig(optEdgeList, nodeIndToNode, nodesList, candidatesList, mostUSInfo)
+        moveCounter += 1
+
+        # TODO: Remove eventually, only uncomment this for making animations
+        # if (mpiInfo.rank == 0) and bs_glob.nwk_counter and (scData.tree is not None):
+        #     scData.tree.to_newick(use_ids=True,
+        #                    results_path=os.path.join(bs_glob.nwk_folder,
+        #                                              'tree_{}.nwk'.format(bs_glob.nwk_counter)))
+        #     bs_glob.nwk_counter += 1
+
+        if moveCounter % 100 == 0:
+            if mpiInfo.rank == 0:
+                scData.storeTreeInFolder(os.path.join(tmp_folder, 'nnn_tree_%d' % stored_tree_ind),
+                                         with_coords=False, verbose=verbose, cleanup_tree=False)
+                remove_tree_folders(tmp_folder, removeDir=False, notRemove=stored_tree_ind, base='nnn')
+                stored_tree_ind += 1
+                # pickleTree(tmp_folder, 'nnn_tree_%d.dat' % stored_tree_ind, self.tree)
+                # removePickledTrees(tmpFolder, removeDir=False, notRemove=stored_tree_ind, base='random')
+                # stored_tree_ind += 1
+    if mpiInfo.rank == 0:
+        remove_tree_folders(tmp_folder, removeDir=True, base='nnn')
+        # removePickledTrees(tmpFolder, removeDir=False, base='random')
+        return scData
+    else:
+        return None
+
+
+def logLGradDepOnV(v, C, ltqsSq, ltqsVars):
+    denominator = 1 / (v - ltqsVars)
+    ltqsSqDenom = ltqsSq * denominator
+    logL = - 2 * C * np.log(v)
+    logL -= np.sum(np.log(denominator) + ltqsSqDenom)
+    dLogL = - 2 * C / v
+    dLogL += np.sum(denominator * (1 + ltqsSqDenom))
+    return -logL, -dLogL
+
+
+def neg_loglik_grad_using_measurements_and_errors(logv, measurements, variances, return_mean_ML=False):
+    v = np.exp(logv)
+    total_var_i = v + variances
+    precision_i = 1 / total_var_i
+    total_precision = np.sum(precision_i)
+    mean_ML = np.sum(precision_i * measurements) / total_precision
+    # Full loglik:
+    # loglik = 0.5 * np.sum(-np.log(2* np.pi) + np.log(precision_i) - precision_i * (measurements - mean_ML) ** 2)
+    weighted_dev = precision_i * (measurements - mean_ML) ** 2
+    loglik = 0.5 * np.sum(np.log(precision_i) - weighted_dev)
+
+    grad = 0.5 * np.sum(precision_i * (-1 + weighted_dev))
+    grad_log = v * grad
+    if not return_mean_ML:
+        return -loglik, -grad_log
+    else:
+        return -loglik, -grad_log, mean_ML
+
+
+# Used
+def correct_means_stds(originalData, priorVariances, all_genes=False):
+    # TODO: Check this derivation and computation
+    cutoff = 1e-4
+    uncorrected = copy.deepcopy(originalData)
+    denominatorFactor = np.maximum(priorVariances[:, np.newaxis] - originalData.ltqsVars, cutoff)
+    if not all_genes:
+        genes_to_keep = np.where(np.min(denominatorFactor, axis=1) > cutoff)[0]
+    else:
+        genes_to_keep = np.arange(originalData.ltqsVars.shape[0])
+    if len(genes_to_keep) == 0:
+        problematic_cells = np.argsort(-np.sum(denominatorFactor == cutoff, axis=0))[
+                            :min(10, originalData.ltqsVars.shape[1])]
+    else:
+        problematic_cells = None
+    factor = priorVariances[genes_to_keep, np.newaxis] / denominatorFactor[genes_to_keep, :]
+    originalData.ltqs = factor * originalData.ltqs[genes_to_keep, :]
+    originalData.ltqsVars = originalData.ltqsVars[genes_to_keep, :] * factor
+    if originalData.geneVariances is not None:
+        originalData.geneVariances = originalData.geneVariances[genes_to_keep]
+    if originalData.priorVariances is not None:
+        originalData.priorVariances = originalData.priorVariances[genes_to_keep]
+
+    uncorrected.ltqs = uncorrected.ltqs[genes_to_keep, :]
+    uncorrected.ltqsVars = uncorrected.ltqsVars[genes_to_keep, :]
+    if uncorrected.geneVariances is not None:
+        uncorrected.geneVariances = uncorrected.geneVariances[genes_to_keep]
+    if uncorrected.priorVariances is not None:
+        uncorrected.priorVariances = uncorrected.priorVariances[genes_to_keep]
+
+    return uncorrected, genes_to_keep, problematic_cells
+
+
+# Not used
+# def recoverTmpTree(args, tmpFolder, optimizeTimes=True):
+#     scData = recoverTreeFromFile(args, tmpFolder, allRanks=False)
+#
+#     # If tmp-tree comes from unfinished run, optimal branch lengths to root have not been stored.
+#     mpiRank = mpi_wrapper.get_process_rank()
+#     if (mpiRank == 0) and (scData.tree.starryYN or optimizeTimes):
+#         startTimeOpt = time.time()
+#         # Get ltqs and ltqsVars of children
+#         scData.tree.root.getLtqsComplete(mem_friendly=True)
+#         scData.tree.optTimes(verbose=args.verbose, mem_friendly=True)
+#         scData.metadata.loglik = scData.tree.calcLogLComplete(mem_friendly=True,
+#                                                               loglikVarCorr=scData.metadata.loglikVarCorr)
+#         # scData.tree.root.setLtqsVarsOrW(W_g=W_g)
+#         dTimeOpt = time.time() - startTimeOpt
+#         if args.verbose:
+#             mp_print("Initial optimisation of times of recovered tree took " + str(dTimeOpt) + " seconds.")
+#             mp_print("Optimal loglikelihood is: " + str(scData.metadata.loglik))
+#
+#     scData = broadcastRecursiveStruct(scData, root=0)
+#     communicateGlobalVars()
+#     return scData
+
+
+# Not used
+# def recoverTreeFromFile(args, mergerFilename, allRanks=True):
+#     mpiRank = mpi_wrapper.get_process_rank()
+#     if mpiRank == 0:
+#         scData = SCData(dataset=args.dataset, filenamesData=args.filenames_data, verbose=args.verbose,
+#                         pathToOrigData=args.data_folder, zscoreCutoff=args.zscore_cutoff,
+#                         createStarTree=False)
+#
+#         scData.mergers = np.loadtxt(scData.result_path(mergerFilename))
+#         scData.tree = scData.buildTreeFromMergers(scData.mergers)
+#         scData.metadata.loglik = scData.tree.calcLogLComplete(mem_friendly=True,
+#                                                               loglikVarCorr=scData.metadata.loglikVarCorr)
+#         if args.verbose:
+#             mp_print("\nLoglikelihood of tree recovered from file: " + str(scData.metadata.loglik) + '\n')
+#     else:
+#         scData = None
+#         gc.collect()
+#     if allRanks:
+#         # scData = mpi_wrapper.bcast(scData, root=0)
+#         scData = broadcastRecursiveStruct(scData, root=0)
+#         communicateGlobalVars()
+#     return scData
+
+
+# Used
+def initializeSCData(args, createStarTree=True, allGenes=False, allRanks=True, otherRanksMinimalInfo=False,
+                     optTimes=True, getOrigData=False, returnUncorrected=False, noDataNeeded=False, verbose=True):
+    zscoreCutoff = -1 if allGenes else args.zscore_cutoff
+    mpiInfo = mpi_wrapper.get_mpi_info(singleProcess=(not allRanks))
+    scData = SCData(dataset=args.dataset, filenamesData=args.filenames_data, verbose=args.verbose,
+                    pathToOrigData=args.data_folder, zscoreCutoff=zscoreCutoff, getOrigData=getOrigData,
+                    returnUncorrected=returnUncorrected, createStarTree=createStarTree, optTimes=optTimes,
+                    noDataNeeded=noDataNeeded, sanityOutput=args.input_is_sanity_output, mpiInfo=mpiInfo,
+                    results_folder=args.results_folder, rescale_by_var=args.rescale_by_var, all_genes=allGenes)
+
+    if allRanks:
+        if not otherRanksMinimalInfo:
+            # scData = mpi_wrapper.bcast(scData, root=0)
+            scData = broadcastRecursiveStruct(scData, root=0)
+        else:
+            if mpiInfo.rank != 0:
+                scData = SCData(onlyObject=True)
+                scData.tree = Tree()
+            scData.metadata = mpi_wrapper.bcast(scData.metadata, root=0)
+        communicateGlobalVars()
+    return scData
+
+
+# def loadCurrentState(outputFolder, filename='tmp_tree.dat', args=None, dataFolder=None, fullPath=None, allRanks=True,
+#                      dataOrResults='data', singleProcess=False):
+#     if (mpi_wrapper.get_process_rank() == 0) or singleProcess:
+#         if fullPath is None:
+#             if dataFolder is None:
+#                 if args.dataset is not None:
+#                     dataFolder = os.path.join(dataOrResults, args.dataset)
+#                 else:
+#                     dataFolder = args.data_folder
+#             tmpDataPath = os.path.join(dataFolder, outputFolder)
+#             fullPath = os.path.join(tmpDataPath, filename)
+#             mp_print("Loading tree from %s" % fullPath)
+#         try:
+#             with open(fullPath, 'rb') as file:
+#                 scData = pickle.load(file)
+#         except RecursionError:
+#             with RecursionLimit():
+#                 with open(fullPath, 'rb') as file:
+#                     scData = pickle.load(file)
+#
+#         bs_glob.nCells = scData.metadata.nCells
+#         bs_glob.nGenes = scData.metadata.nGenes
+#         bs_glob.nNodes = scData.tree.nNodes
+#
+#         scData.metadata.loglik = scData.tree.calcLogLComplete(mem_friendly=True,
+#                                                               loglikVarCorr=scData.metadata.loglikVarCorr)
+#         if args.verbose:
+#             mp_print("\nLoglikelihood of tree recovered from file: " + str(scData.metadata.loglik) + '\n')
+#     else:
+#         scData = SCData(onlyObject=True)
+#         scData.tree = Tree()
+#     if not singleProcess:
+#         if allRanks:  # So in this case we communicate all information with all processes
+#             with RecursionLimit():
+#                 scData = mpi_wrapper.bcast(scData)
+#         else:  # In this case, we only communicate the metadata
+#             scData.metadata = mpi_wrapper.bcast(scData.metadata, root=0)
+#         communicateGlobalVars()
+#     return scData
+
+
+# Used
+def getMetadata(args, scData, outputFolder_raw, computationTime):
+    outputFolder = scData.result_path(outputFolder_raw)
+    mpiRank = mpi_wrapper.get_process_rank()
+    if mpiRank == 0:
+        scData.metadata.loglik = scData.tree.calcLogLComplete(mem_friendly=True,
+                                                              loglikVarCorr=None)
+        # Read in data with all genes
+        # scDataFull = loadReconstructedTreeAndData(args, outputFolder, all_genes=True, get_cell_info=False,
+        #                                           reprocess_data=True, all_ranks=False)
+        # scDataFull = initializeSCData(args, createStarTree=False, allGenes=True, allRanks=False)
+        # scDataFull.tree = scDataFull.buildTreeFromMergers(scData.mergers)
+        # scDataFull.metadata.loglik = scDataFull.tree.calcLogLComplete(mem_friendly=True,
+        #                                                               loglikVarCorr=scDataFull.metadata.loglikVarCorr)
+        # mp_print("Final loglikelihood of inferred tree on filtered genes: " + str(scDataFull.metadata.loglik))
+
+        if os.path.exists(scData.data_path('true_tree')):
+            scDataFull = loadReconstructedTreeAndData(args, outputFolder_raw, all_genes=True, get_cell_info=False,
+                                                      reprocess_data=True, all_ranks=False, rel_to_results=True,
+                                                      no_data_needed=False)
+            scDataFull.metadata.loglik = scDataFull.tree.calcLogLComplete(mem_friendly=True,
+                                                                          loglikVarCorr=None)
+            mp_print(
+                "Loglikelihood of reconstructed tree (all genes, before optTimes): " + str(scDataFull.metadata.loglik))
+            scDataFull.tree.optTimes(mem_friendly=True, tol=1e-8)
+            scDataFull.metadata.loglik = scDataFull.tree.calcLogLComplete(mem_friendly=True,
+                                                                          loglikVarCorr=None)
+            full_loglik = scDataFull.metadata.loglik
+
+            scData_true = loadReconstructedTreeAndData(args, scData.data_path('true_tree'), all_genes=True,
+                                                       get_cell_info=False,
+                                                       reprocess_data=True, all_ranks=False)
+            true_loglik = scData_true.tree.calcLogLComplete(mem_friendly=True,
+                                                            loglikVarCorr=None)
+            mp_print("Loglikelihood of ground truth tree (before optTimes): " + str(true_loglik))
+            scData_true.tree.optTimes_single_scalar(mem_friendly=True, tol=1e-8)
+            true_loglik = scData_true.tree.calcLogLComplete(mem_friendly=True,
+                                                            loglikVarCorr=None)
+            # true_mergers = np.loadtxt(scData.data_path('true_mergers.txt'))
+            # true_tree = scDataFull.buildTreeFromMergers(true_mergers)
+            # true_loglik = true_tree.calcLogLComplete(mem_friendly=True, loglikVarCorr=scDataFull.metadata.loglikVarCorr)
+            mp_print("Loglikelihood of reconstructed tree on all genes: " + str(scDataFull.metadata.loglik))
+            mp_print("Loglikelihood of ground truth tree: " + str(true_loglik))
+        else:
+            true_loglik = np.nan
+            full_loglik = np.nan
+
+        metadata = pd.DataFrame(
+            {'nGenes': scData.metadata.nGenes, 'nCells': scData.metadata.nCells, 'reconsTime': computationTime,
+             'zscoreCutoff': args.zscore_cutoff, 'coresUsed': mpi_wrapper.get_process_size(),
+             'finalLoglik': scData.metadata.loglik, 'trueLoglik': true_loglik, 'fullLoglik': full_loglik,
+             'remainingRootChildren': len(scData.tree.root.childNodes)},
+            index=['metadata'])
+        return metadata
+
+
+def loadReconstructedTreeAndData(args, tree_folder, reprocess_data=False, all_genes=False, all_ranks=True,
+                                 get_cell_info=False, corrected_data=True, rel_to_results=False, no_data_needed=False,
+                                 single_process=False, keep_original_data=False, calc_loglik=False, get_data=True,
+                                 get_posterior_ltqs=False, otherRanksMinimalInfo=False, verbose=True,
+                                 calc_posteriors=True):
+    """
+
+    :param args:
+    :param tree_folder:
+    :param reprocess_data:
+    :param all_genes:
+    :param all_ranks:
+    :param get_cell_info:
+    :param corrected_data:
+    :param rel_to_results:
+    :param no_data_needed:
+    :param single_process:
+    :param keep_original_data:
+    :param calc_loglik:
+    :param get_data:
+    :param get_posterior_ltqs:
+    :param otherRanksMinimalInfo:
+    :param verbose:
+    :param calc_posteriors: This boolean may be false, even when get_posterior_ltqs is True. This means that, even
+    though we want to read in the posteriors if they are stored in the folder, we do not calculate them if they are not
+    available. This is to save the memory of storing these posteriors on the tree. Instead, we only have to calculate
+    them when we immediately write them to the file.
+    :return:
+    """
+    if type(args) is dict:
+        args = convert_dict_to_named_tuple(args)
+    mpi_info = mpi_wrapper.get_mpi_info(singleProcess=single_process)
+    if reprocess_data:
+        scData = initializeSCData(args, createStarTree=False, allGenes=all_genes, allRanks=all_ranks, optTimes=False,
+                                  getOrigData=True, returnUncorrected=(not corrected_data), noDataNeeded=no_data_needed,
+                                  otherRanksMinimalInfo=otherRanksMinimalInfo, verbose=verbose)
+    else:
+        scData = SCData(onlyObject=True, dataset=args.dataset, results_folder=args.results_folder)
+    if rel_to_results:
+        tree_folder = scData.result_path(tree_folder)
+
+    get_all_data = get_data and ((mpi_info.rank == 0) or (all_ranks and (not otherRanksMinimalInfo)))
+    tree_tuple = reconstructTreeFromEdgeVertInfo(scData, tree_folder, verbose=verbose)
+    vertIndToNode, vertIndToNodeInd, vertIndToNodeId, edgeList, distList = tree_tuple
+    data_found = load_data_for_tree(scData, tree_folder, vertIndToNode, get_all_data=get_all_data,
+                                    load_data=(not reprocess_data),
+                                    verbose=False, keep_original_data=keep_original_data,
+                                    get_posterior_ltqs=get_posterior_ltqs,
+                                    no_data_needed=no_data_needed)
+    if data_found and get_all_data and calc_loglik and (mpi_info.rank == 0):
+        scData.metadata.loglik = scData.tree.calcLogLComplete(mem_friendly=True,
+                                                              loglikVarCorr=scData.metadata.loglikVarCorr)
+        if verbose:
+            mp_print("Loaded tree has loglikelihood %.4f" % scData.metadata.loglik)
+
+    if (bs_glob.nCells is not None) and (bs_glob.nCells > 25000):
+        bs_glob.mem_friendly = True
+        scData.tree.root.keep_one_ltqsvars_or_W(keep_ltqsvars=True)
+
+    # if (not corrected_data) and (scData.unscaled is not None) and (scData.unscaled.ltqs is not None) \
+    #         and get_all_data and data_found:
+    #     # scData.originalData = scData.unscaled
+    #     scData.unscaled = None
+    #     addDataToTree(scData, vertIndToNode)
+    #
+    #     mp_print("Calculating ltqs of internal nodes", ALL_RANKS=True)
+    #     scData.tree.root.getLtqsComplete(mem_friendly=True)
+
+    if data_found and get_posterior_ltqs and get_all_data and (scData.tree.root.ltqsAIRoot is None) and calc_posteriors:
+        if scData.tree.root.ltqs is None:
+            scData.tree.root.getLtqsComplete(mem_friendly=True)
+        scData.tree.root.getAIRootInfo(None, None)
+
+    # Also store for every node who its parent is
+    scData.tree.root.storeParent()
+
+    if not get_cell_info:
+        return scData
+
+    get_cell_info_tree(scData, vertIndToNode)
+    return scData, vertIndToNodeId
+
+
+def reconstructTreeFromEdgeVertInfo(scData, tree_folder, verbose=False):
+    # Read reconstructed tree information
+    edgeList = []
+    distList = []
+    edgeFile = os.path.join(tree_folder, 'edgeInfo.txt')
+    with open(edgeFile, "r") as file:
+        reader = csv.reader(file, delimiter="\t")
+        for row in reader:
+            edgeList.append((int(row[0]), int(row[1])))
+            distList.append(float(row[2]))
+
+    vertIndToNodeInd = {}
+    vertIndToNodeId = {}
+    vertFile = os.path.join(tree_folder, 'vertInfo.txt')
+    with open(vertFile, "r") as file:
+        reader = csv.reader(file, delimiter="\t")
+        skipRow = True
+        for row in reader:
+            if skipRow:
+                skipRow = False
+                continue
+            vertIndToNodeInd[int(row[0])] = int(row[1])
+            vertIndToNodeId[int(row[0])] = row[2]
+
+    # Update recursion limits so that very deep trees don't create errors
+    set_recursion_limits(len(edgeList))
+
+    scData.tree = Tree()
+    vertIndToNode = {}
+    for ind, edge in enumerate(edgeList):
+        if ind == 0:
+            scData.tree.root = TreeNode(nodeInd=vertIndToNodeInd[edge[0]], childNodes=[], isLeaf=False, isRoot=True,
+                                        ltqs=None, ltqsVars=None, tParent=None, nodeId=vertIndToNodeId[edge[0]])
+            vertIndToNode[edge[0]] = scData.tree.root
+            childNode = TreeNode(nodeInd=vertIndToNodeInd[edge[1]], childNodes=[], isLeaf=True, isRoot=False,
+                                 ltqs=None, ltqsVars=None, tParent=distList[ind], nodeId=vertIndToNodeId[edge[1]])
+            scData.tree.root.childNodes.append(childNode)
+            vertIndToNode[edge[1]] = childNode
+            scData.tree.nNodes = 2
+            continue
+        if edge[0] in vertIndToNode:
+            parentVert = edge[0]
+            childVert = edge[1]
+        else:
+            parentVert = edge[1]
+            childVert = edge[0]
+        childNode = TreeNode(nodeInd=vertIndToNodeInd[childVert], childNodes=[], isLeaf=True, isRoot=False,
+                             ltqs=None, ltqsVars=None, tParent=distList[ind], nodeId=vertIndToNodeId[childVert])
+        parentNode = vertIndToNode[parentVert]
+        parentNode.childNodes.append(childNode)
+        parentNode.isLeaf = False
+        vertIndToNode[childVert] = childNode
+        scData.tree.nNodes += 1
+    bs_glob.nNodes = scData.tree.nNodes
+    # Store vert_inds on nodes
+    for vert_ind, node in vertIndToNode.items():
+        node.vert_ind = vert_ind
+    scData.tree.vert_ind_to_node = vertIndToNode
+    # Commented out the below on January 6, 2026. This was supposed to make vert-indices consistent with depth-first
+    # search, but this does not seem necessary, and it may mess up reading in the coordinates.
+
+    # vertIndToNode_test, scData.tree.nNodes = scData.tree.root.renumber_verts(vertIndToNode={}, vert_count=0)
+    # vertIndToNodeId_test = {}
+    # vertIndToNodeInd_test = {}
+    # for vert_ind, node in vertIndToNode_test.items():
+    #     vertIndToNodeId_test[vert_ind] = node.nodeId
+    #     vertIndToNodeInd_test[vert_ind] = node.nodeInd
+
+    tree_tuple = vertIndToNode, vertIndToNodeInd, vertIndToNodeId, edgeList, distList
+    scData.tree.max_node_ind = scData.tree.root.get_max_node_ind(-np.inf)
+    bs_glob.max_node_ind = scData.tree.max_node_ind
+    if verbose:
+        mp_print("\n\nReconstructed tree loaded from: \n%s \n%s" % (edgeFile, vertFile))
+    return tree_tuple
+
+
+def load_data_for_tree(scData, tree_folder, vertind_to_node, get_all_data=True, load_data=True, verbose=False,
+                       keep_original_data=False, get_posterior_ltqs=False, no_data_needed=False):
+    if not load_data:  # In this case, data was already loaded, we only add it to the tree and do some checks
+        if scData.metadata.nCells is None:
+            scData.metadata.nCells = scData.tree.root.countDSLeafs(0)
+            bs_glob.nCells = scData.metadata.nCells
+            scData.metadata.cellIds = ["Cell_%d" % ind for ind in range(scData.metadata.nCells)]
+        if get_all_data and (scData.originalData.ltqs is not None):
+            addDataToTree(scData, vertind_to_node)
+            # scData.metadata.loglik = scData.tree.calcLogLComplete(mem_friendly=True)
+        if not keep_original_data:
+            scData.originalData = None
+        if verbose and (scData.metadata.loglik is not None):
+            mp_print("\nLoglikelihood of tree recovered from file: " + str(scData.metadata.loglik))
+        return True
+
+    # Read all metadata
+    scData.metadata = Metadata(json_filepath=os.path.join(tree_folder, 'metadata.json'), curr_metadata=scData.metadata)
+    bs_glob.nGenes = scData.metadata.nGenes
+    bs_glob.nCells = scData.metadata.nCells
+    bs_glob.nNodes = scData.tree.nNodes
+
+    # Try to read data in following order:
+    # - see if there is data for all vertices stored where the tree is stored
+    # - if not, read the data of all leafs from the folder that is indicated in the metadata-file, then calculate all
+    # data for all vertices
+    data_found = True
+    posteriors_found = False
+    ltqs_found = False
+    if get_posterior_ltqs:
+        meanspath = os.path.join(tree_folder, 'posterior_ltqs_vertByGene.npy')
+        if os.path.exists(meanspath):
+            posteriors_found = True
+            varspath = os.path.join(tree_folder, 'posterior_ltqsVars_vertByGene.npy')
+            readFolder = tree_folder
+
+    if (not get_posterior_ltqs) or (not posteriors_found):
+        meanspath = os.path.join(tree_folder, 'ltqs_vertByGene.npy')
+        if os.path.exists(meanspath):
+            ltqs_found = True
+            varspath = os.path.join(tree_folder, 'ltqsVars_vertByGene.npy')
+            readFolder = tree_folder
+
+    if (not ltqs_found) and (not posteriors_found):
+        readFolder = scData.metadata.processedDatafolder
+
+    if scData.metadata.processedDatafolder is None:
+        scData.metadata.processedDatafolder = readFolder
+
+    if get_all_data:
+        cell_id_set = set(scData.metadata.cellIds)
+        try:
+            start = time.time()
+            if ltqs_found or posteriors_found:
+                print_ind = 1000
+                ltqs_cg = np.load(meanspath, allow_pickle=False, mmap_mode='r')
+                ltqsVars_cg = np.load(varspath, allow_pickle=False, mmap_mode='r')
+                if ltqs_cg.shape[0] != bs_glob.nNodes:
+                    raise Exception("Trying to load data for {} nodes, "
+                                    "while tree has {} nodes.".format(ltqs_cg.shape[0], bs_glob.nNodes))
+                for vert_ind in range(bs_glob.nNodes):
+                    if (vert_ind == print_ind) and verbose:
+                        print_ind *= 2
+                        mp_print("Loaded coordinates for %d vertices out of %d in %.2f seconds." % (
+                            vert_ind, bs_glob.nNodes, time.time() - start))
+                    node = vertind_to_node[vert_ind]
+                    if posteriors_found:
+                        node.ltqsAIRoot = ltqs_cg[vert_ind, :]
+                        node.setLtqsVarsOrW(ltqsVars=ltqsVars_cg[vert_ind, :], AIRoot=True)
+                    else:
+                        node.ltqs = ltqs_cg[vert_ind, :]
+                        node.setLtqsVarsOrW(ltqsVars=ltqsVars_cg[vert_ind, :])
+                    node.isCell = node.nodeId in cell_id_set
+                del ltqs_cg
+                del ltqsVars_cg
+                gc.collect()
+                if verbose:
+                    mp_print("Loaded coordinates for %d vertices out of %d in %.2f seconds." % (
+                        vert_ind, bs_glob.nNodes, time.time() - start))
+            else:
+                origFolder = scData.metadata.processedDatafolder
+                scData.originalData = OriginalData()
+                if os.path.exists(os.path.join(origFolder, 'delta.npy')):
+                    meanspath = os.path.join(origFolder, 'delta.npy')
+                    varspath = os.path.join(origFolder, 'delta_vars.npy')
+                    scData.originalData.ltqs = np.load(meanspath, allow_pickle=False, mmap_mode='r')
+                    scData.originalData.ltqsVars = np.load(varspath, allow_pickle=False, mmap_mode='r')
+                    if scData.originalData.ltqs.shape[1] != len(scData.metadata.cellIds):
+                        raise Exception("Trying to load data for {} cells from folder {}, "
+                                        "while tree seems to have {} cells.".format(scData.originalData.ltqs.shape[1],
+                                                                                    origFolder,
+                                                                                    len(scData.metadata.cellIds)))
+                    # scData.originalData.ltqs = ltqs_cg.T
+                    # scData.originalData.ltqsVars = ltqsVars_cg.T
+                elif os.path.exists(os.path.join(origFolder, 'delta_vmax.txt')):
+                    raise Exception("Trying to load data from folder {}, "
+                                    "but no pre-processed data can be found.".format(origFolder))
+                    scData.originalData.ltqs = np.loadtxt(os.path.join(origFolder, 'delta_vmax.txt'))
+                    scData.originalData.ltqsVars = np.loadtxt(os.path.join(origFolder, 'd_delta_vmax.txt')) ** 2
+                elif no_data_needed:
+                    print("Original data was not found, but is not strictly needed now. Will continue without it.")
+                    data_found = False
+                else:
+                    exit("No data was found, please provide correct paths to where the original data is stored.")
+                addDataToTree(scData, vertind_to_node)
+                if not keep_original_data:
+                    scData.originalData = None
+                if data_found:
+                    scData.metadata.loglik = scData.tree.calcLogLComplete(mem_friendly=True,
+                                                                          loglikVarCorr=scData.metadata.loglikVarCorr)
+        except Exception as e:
+            mp_print("Encountered exception '{}'".format(e), WARNING=True)
+            if no_data_needed:
+                mp_print("Original data was not found, but is not strictly needed now. Will continue without it.",
+                         WARNING=True)
+                data_found = False
+        if verbose:
+            if scData.metadata.loglik is not None:
+                mp_print("\nLoglikelihood of tree recovered from file: " + str(scData.metadata.loglik))
+
+    return data_found
+
+
+def addDataToTree(scData, vertIndToNode):
+    cell_id_to_ind = {cell_id: ind for ind, cell_id in enumerate(scData.metadata.cellIds)}
+    for vert, node in vertIndToNode.items():
+        if node.nodeId in cell_id_to_ind:
+            cellInd = cell_id_to_ind[node.nodeId]
+            if (scData.originalData is not None) and (scData.originalData.ltqs is not None):
+                node.ltqs = scData.originalData.ltqs[:, cellInd]
+                node.setLtqsVarsOrW(ltqsVars=scData.originalData.ltqsVars[:, cellInd])
+            node.isCell = True
+
+
+# Old
+# def addIgraph(scData, vertIndToNode, vertIndToNodeInd, edgeList, distList):
+#     # We store how many vertices there are in our final tree
+#     scData.nVert = len(vertIndToNode)
+#     # And we make up some names
+#     scData.vertNames = ['vert_' + str(ind) for ind in range(scData.nVert)]
+#
+#     # If the tree reconstruction is run on cellstates-output, we should first account for mapping the cells to
+#     # cellstates
+#     cellsToCellstates = {}
+#     cellstatesToVerts = {}
+#     scData.cellsToVerts = {}
+#     scData.cellIndToVertInd = {}
+#     cellIdToVertInd = {node.nodeId: vertInd for vertInd, node in vertIndToNode.items()}
+#     for ind in range(scData.metadata.nCells):
+#         cellId = scData.metadata.cellIds[ind]
+#         cellstateId = cellId
+#         cellsToCellstates[cellId] = cellstateId
+#         if cellId in cellIdToVertInd:
+#             vert_ind = cellIdToVertInd[cellId]
+#         else:
+#             vert_ind = -1
+#         # Find out to which new vertex this was again send to
+#         cellstatesToVerts[cellstateId] = scData.vertNames[vert_ind]
+#         # Store in cell_assignment to which eventual vertex the original cell was sent
+#         scData.cellsToVerts[cellId] = cellstatesToVerts[cellsToCellstates[cellId]]
+#         # Also store a map of which cellInd went to which vertInd
+#         scData.cellIndToVertInd[ind] = vert_ind
+#
+#     # Build up the tree
+#     scData.mst = igraph.Graph(directed=True)
+#     scData.mst.add_vertices(scData.nVert)
+#
+#     scData.mst.add_edges(edgeList)
+#     scData.mst.es["weight"] = distList
+#     scData.mst.vs["name"] = scData.vertNames
+#     scData.mst.es["name"] = ['e_' + str(ind) for ind in range(scData.nVert - 1)]
+#     igraph.summary(scData.mst)
+#     scData.nCellsPerVert = np.zeros(scData.nVert)
+#     scData.vertIndToCellInds = {ind: [] for ind in range(scData.nVert)}
+#     for ind in range(scData.metadata.nCells):
+#         if scData.cellIndToVertInd[ind] == -1:
+#             # TODO: Clean this up
+#             continue
+#         scData.vertIndToCellInds[scData.cellIndToVertInd[ind]].append(ind)
+#         scData.nCellsPerVert[scData.cellIndToVertInd[ind]] += 1
+
+
+# Used
+def get_cell_info_tree(scData, vertIndToNode):
+    # We store how many vertices there are in our final tree
+    scData.nVerts = len(vertIndToNode)
+    # And we make up some names
+    scData.vertNames = ['vert_' + str(ind) for ind in range(scData.nVerts)]
+
+    scData.cellsToVerts = {}
+    scData.cellIndToVertInd = {}
+    if hasattr(scData.metadata, 'nCss'):
+        scData.csToVerts = {}
+        scData.csIndToVertInd = {}
+        get_cs_info = True
+        logger.error("I didn't think getting cs-info here would ever be necessary. Check why this happens.")
+        exit()
+    else:
+        get_cs_info = False
+    nodeIdToVertInd = {node.nodeId: vertInd for vertInd, node in vertIndToNode.items()}
+    cells_not_found = []
+    for ind in range(scData.metadata.nCells):
+        cellId = scData.metadata.cellIds[ind]
+        if cellId in nodeIdToVertInd:
+            vert_ind = nodeIdToVertInd[cellId]
+        else:
+            cells_not_found.append(cellId)
+            vert_ind = None
+        if vert_ind is not None:
+            # Store in cell_assignment to which vertex the original cell was sent
+            scData.cellsToVerts[cellId] = scData.vertNames[vert_ind]
+            # Also store a map of which cellInd went to which vertInd
+            # TODO: Maybe eventually only store this.
+            scData.cellIndToVertInd[ind] = vert_ind
+
+    if len(cells_not_found):
+        mp_print("{}\n\n Could not find the above cells in the tree. "
+                 "Check this! Now exiting!".format(cells_not_found), ERROR=True)
+        exit()
+
+    scData.nCellsPerVert = np.zeros(scData.nVerts)
+    scData.vertIndToCellInds = {ind: [] for ind in range(scData.nVerts)}
+    # for ind in range(scData.metadata.nCells):
+    for cell_ind, vert_ind in scData.cellIndToVertInd.items():
+        # if scData.cellIndToVertInd[ind] == -1:
+        #     continue
+        scData.vertIndToCellInds[vert_ind].append(cell_ind)
+        scData.nCellsPerVert[vert_ind] += 1
+
+
+def infer_true_var_log(inferred_vals, inferred_vars):
+    """ finds tau """
+    n_genes = inferred_vals.shape[0]
+    true_vars = np.zeros(n_genes)
+    for ind in range(n_genes):
+        if (ind % 1000) == 0:
+            print("Done %d genes." % ind)
+        true_var_log, fval, ierr, numfunc = fminbound(loglik_given_true_var_log, -13, 13,
+                                                      args=(inferred_vals[ind, :], inferred_vars[ind, :]),
+                                                      full_output=1, xtol=1.e-06)
+        if ierr:
+            sys.exit("log_activities has not converged after %d iterations.\n"
+                     % numfunc)
+        true_vars[ind] = np.exp(true_var_log)
+
+    return true_vars
+
+
+def loglik_given_true_var_log(true_var_log, inferred_vals, inferred_vars):
+    """ Calculate likelihood """
+    true_var = np.exp(true_var_log)
+    alpha = 1. / (inferred_vars + true_var)
+
+    m0 = np.sum(alpha)
+    m1 = np.sum(alpha * inferred_vals)
+    m2 = np.sum(alpha * np.power(inferred_vals, 2))
+    mu = m1 / m0
+
+    return (0.5 * (-m1 * mu + m2) - 0.5 * np.sum(np.log(alpha))) + 0.5 * np.log(
+        np.sum(alpha))  # the middle term was missing in the other implementation
+
+
+def read_and_filter(data_folder, meansfile, stdsfile, sanityOutput, zscoreCutoff, mpiInfo, tmp_folder=None,
+                    verbose=False, all_genes=False):
+    """
+    Reads in means and standard deviations line by line (i.e per gene/feature), possibly parallelized over multiple
+    processes. For each gene, we determine if it makes the zscore-cutoff before adding it to the data to save memory.
+    :param meanspath: Full path to means-file. The centers of the Gaussian likelihood of the data (the measurements).
+    :param stdspath: Full path to standard deviations corresponding to the Gaussian likelihoods (the error-bars)
+    :param sanityOutput: Boolean determining if the input is Sanity output, in which case we know how to correct the
+    means and stds
+    :param zscoreCutoff: Cutoff for the signal-to-noise ratio of genes
+    :param mpiInfo: Information on how many processes are working in parallel, and the rank of the current process
+    :param verbose:
+    :return:
+    """
+    # Read in means and stds per feature, immediately determine zscore and discard if under cutoff
+    genes_to_keep = []
+    tmp_means = []
+    tmp_vars = []
+    tmp_gene_vars = []
+    print_ind = 1000
+    if tmp_folder is None:
+        tmp_folder = data_folder
+        Path(tmp_folder).mkdir(parents=True, exist_ok=True)
+
+    # Define cutoff for how close the variances on LTQs can be to the true variances before throwing out a gene.
+    # In error-less data, variances on the LTQ-posterior should always be smaller than the true variance
+    if not all_genes:
+        divide_out_prior_cutoff = 1e-4
+    else:
+        divide_out_prior_cutoff = -1
+
+    if sanityOutput:
+        mp_print("Since the argument '--input_is_sanity_output' is 'True', "
+                 "we are assuming the input-files are Sanity output.\n"
+                 "If this is not the desired behavior, change this argument in the Bonsai config-yaml file.")
+        meanspath = os.path.join(data_folder, 'delta_vmax.txt')
+        input_incomplete = False
+        if not os.path.exists(meanspath):
+            mp_print("File {} not found.".format(meanspath), WARNING=True)
+            exit()
+            input_incomplete = True
+        stdspath = os.path.join(data_folder, 'd_delta_vmax.txt')
+        if not os.path.exists(stdspath):
+            mp_print("File {} not found.".format(stdspath), WARNING=True)
+            input_incomplete = True
+        gene_variancepath = os.path.join(data_folder, 'variance_vmax.txt')
+        if not os.path.exists(gene_variancepath):
+            mp_print("File {} not found.".format(gene_variancepath), WARNING=True)
+            input_incomplete = True
+        gene_meanspath = os.path.join(data_folder, 'mu_vmax.txt')
+        if not os.path.exists(gene_meanspath):
+            mp_print("File {} not found.".format(gene_meanspath), WARNING=True)
+            input_incomplete = True
+        # Check if correct version of Sanity was run
+        if input_incomplete:
+            if os.path.exists(os.path.join(data_folder, 'delta.txt')):
+                mp_print("Only found delta.txt, not delta_vmax.txt. "
+                         "Make sure to run Sanity with the argument '-max_v only_max_output'", ERROR=True)
+            else:
+                mp_print("Could not find (the right) Sanity-output.\n"
+                         "Are you sure the argument --input_is_sanity_output should be set to True?"
+                         "\nAre you sure you are running Sanity with the extended-output flag -e 1, "
+                         "and the vmax-argument: -vmax true?", ERROR=True)
+            exit()
+    else:
+        meanspath = os.path.join(data_folder, meansfile)
+        stdspath = os.path.join(data_folder, stdsfile) if (stdsfile is not None) else None
+        if not os.path.exists(meanspath):
+            mp_print("Did not find necessary input-file: {}".format(meanspath), ERROR=True)
+            exit()
+
+    # First determine the number of genes on process 0
+    if mpiInfo.rank == 0:
+        nGenesOrig = None
+        with open(meanspath, 'r') as fp:
+            for (nGenesOrig, _) in enumerate(fp, 1):
+                pass
+    else:
+        nGenesOrig = None
+    nGenesOrig = mpi_wrapper.bcast(nGenesOrig, root=0)  # Communicate number of genes with other processes
+    # Get number of cells
+    with open(meanspath, 'r') as fmeans:
+        reader_means = csv.reader(fmeans, delimiter='\t')
+        nCells = len(next(reader_means))
+
+    # Distribute genes that should be read in over the different processes
+    myTasks = getMyTaskNumbers(nGenesOrig, mpiInfo.size, mpiInfo.rank, skippingSteps=False)
+    if len(myTasks) > 0:
+        myTasks = [myTasks[0], myTasks[-1] + 1]
+        nTasks = myTasks[1] - myTasks[0]
+    else:
+        myTasks = [-1, -1]
+        nTasks = 0
+    start = time.time()
+
+    if (stdspath is not None) and os.path.exists(stdspath):
+        # In this case, we read in standard deviations, and use them to estimate a signal-to-noise ratio for each gene.
+        ltqStdsFound = True
+        zscoreCutoffSq = zscoreCutoff ** 2 if zscoreCutoff > 0 else 0.0
+        if sanityOutput:
+            # If input is sanity output, we know that we get the posterior means and variances, instead of the
+            # likelihood means and variances. So the posteriors can immediately be used for calculating the
+            # signal-to-noise ratio.
+            # The likelihood means and variances can be reconstructed by reading in the estimated variances so
+            # that we can divide out the prior. In addition, we can read in the gene-means, so that we get LTQs instead
+            # of the reported log-fold changes.
+            # Start by reading the gene-means and gene-variances
+            gene_variances = np.loadtxt(gene_variancepath)
+            if len(gene_variances) != nGenesOrig:
+                print("Number of gene variances in file {} does not match number of features in the ltq-matrix.\n"
+                      "Check this.".format(gene_variancepath))
+                exit()
+            gene_means = np.loadtxt(gene_meanspath)
+            if len(gene_means) != nGenesOrig:
+                print("Number of gene means in file {} does not match number of features in the ltq-matrix.\n"
+                      "Check this.".format(gene_meanspath))
+                exit()
+
+            with open(meanspath, 'r') as fmeans:
+                with open(stdspath, 'r') as fstd:
+                    for row_ind in range(myTasks[0]):
+                        # Skip over every row that other processes read, until first task for this process is reached
+                        next(fmeans)
+                        next(fstd)
+                    # When reaching first task, read in first row.
+                    reader_means = csv.reader(fmeans, delimiter='\t')
+                    reader_stds = csv.reader(fstd, delimiter='\t')
+                    for row_ind in range(myTasks[0], myTasks[1]):
+                        read = next(reader_stds)
+                        vars = np.maximum(np.asarray(read, dtype='float') ** 2, 1e-12)
+                        means = np.asarray(next(reader_means), dtype='float')
+
+                        # Do not subtract mean of means anymore
+                        # zscoreSq = np.sum((means - np.mean(means)) ** 2 / vars) / nCells
+                        zscoreSq = np.sum(means ** 2 / vars) / nCells
+
+                        if zscoreSq > zscoreCutoffSq:
+                            # Because Sanity reports means and variances of the posteriors, rather than of the
+                            # likelihood, we here correct for that by dividing out the prior
+                            gene_var = gene_variances[row_ind]
+                            # denominatorFactor = np.maximum(priorVariances[:, np.newaxis] - originalData.ltqsVars,
+                            #                                cutoff)
+                            denominator_factor = gene_var - vars
+                            if np.any(denominator_factor < divide_out_prior_cutoff):
+                                continue
+                            denominator_factor = np.maximum(denominator_factor, 1e-6)
+
+                            # factor = priorVariances[genes_to_keep, np.newaxis] / denominatorFactor[genes_to_keep, :]
+                            factor = gene_var / denominator_factor
+                            # originalData.ltqs = factor * originalData.ltqs[genes_to_keep, :]
+                            means *= factor
+                            # originalData.ltqsVars = originalData.ltqsVars[genes_to_keep, :] * factor
+                            vars *= factor
+
+                            means += gene_means[row_ind]
+
+                            tmp_means.append(means)
+                            tmp_vars.append(vars)
+                            tmp_gene_vars.append(gene_var)
+                            genes_to_keep.append(row_ind)
+                        if (row_ind - myTasks[0]) > print_ind:
+                            print_ind *= 2
+                            mp_print(
+                                "Processing data for the the %d-th feature out of %d, this took %.2f seconds." % (
+                                    row_ind - myTasks[0], nTasks, time.time() - start), ONLY_RANK=0)
+        else:
+            with open(meanspath, 'r') as fmeans:
+                with open(stdspath, 'r') as fstd:
+                    for row_ind in range(myTasks[0]):
+                        # Skip over every row that other processes read, until first task for this process is reached
+                        next(fmeans)
+                        next(fstd)
+                    # When reaching first task, read in first row.
+                    reader_means = csv.reader(fmeans, delimiter='\t')
+                    reader_stds = csv.reader(fstd, delimiter='\t')
+                    for row_ind in range(myTasks[0], myTasks[1]):
+                        read = next(reader_stds)
+                        vars = np.maximum(np.asarray(read, dtype='float') ** 2, 1e-12)
+                        means = np.asarray(next(reader_means), dtype='float')
+
+                        # TODO: Check whether it helps to give a derivative to that function as well
+                        try:
+                            log_v0 = np.log(np.var(means))
+                        except RuntimeWarning:
+                            log_v0 = 0
+                        opt_res = minimize(neg_loglik_grad_using_measurements_and_errors, x0=log_v0,
+                                           jac=True, args=(means, vars, False))
+                        inferred_gene_var = np.exp(opt_res.x[0])
+                        if not opt_res.success:
+                            mp_print("Could not optimize variance for feature {}.\n"
+                                     "Discarding this feature as variance is likely very small".format(row_ind))
+                            continue
+                        _, _, inferred_gene_mean = neg_loglik_grad_using_measurements_and_errors(opt_res.x, means, vars,
+                                                                                                 return_mean_ML=True)
+                        # zscoreSq = np.sum((means - np.mean(means)) ** 2 / vars) / nCells
+                        zscoreSq = np.sum((inferred_gene_var / (inferred_gene_var + vars)) * (
+                                means - inferred_gene_mean) ** 2 / vars) / nCells
+
+                        if zscoreSq > zscoreCutoffSq:
+                            tmp_means.append(means)
+                            tmp_vars.append(vars)
+                            genes_to_keep.append(row_ind)
+                            tmp_gene_vars.append(inferred_gene_var)
+                        if (row_ind - myTasks[0]) == print_ind:
+                            print_ind *= 2
+                            mp_print(
+                                "Processing data for the the %d-th feature out of %d, this took %.2f seconds." % (
+                                    row_ind - myTasks[0], nTasks, time.time() - start), ONLY_RANK=0)
+
+        if len(tmp_vars) == 0:
+            ltqsVars = np.zeros((0, nCells))
+            ltqs = np.zeros((0, nCells))
+            genes_to_keep = np.zeros(0, dtype=int)
+            gene_vars = np.zeros(0)
+        else:
+            ltqsVars = np.vstack(tmp_vars)
+            ltqs = np.vstack(tmp_means)
+            genes_to_keep = np.array(genes_to_keep)
+            gene_vars = np.array(tmp_gene_vars)
+    else:
+        # In this case, we do not read in standard deviations, all genes are kept.
+        ltqStdsFound = False
+        if stdspath is not None:
+            mp_print("****\nNo standard-deviations found for features at {}. Assuming very small error-bar instead. "
+                     "\nCheck if this is the desired behaviour!!!\n****".format(stdspath), ERROR=True)
+        else:
+            mp_print("****\nNo filename is given for standard-deviations. Check if this is the desired behavior.\n****",
+                     WARNING=True)
+        with open(meanspath, 'r') as fmeans:
+            for row_ind in range(myTasks[0]):
+                next(fmeans)
+            reader_means = csv.reader(fmeans, delimiter='\t')
+            for row_ind in range(myTasks[0], myTasks[1]):
+                means = np.asarray(next(reader_means), dtype='float')
+                inferred_gene_var = np.var(means)
+                if inferred_gene_var > 0.0:
+                    tmp_means.append(means)
+                    genes_to_keep.append(row_ind)
+                    tmp_gene_vars.append(inferred_gene_var)
+                if (row_ind - myTasks[0]) == print_ind:
+                    print_ind *= 2
+                    mp_print("Processing data for the the %d-th feature out of %d, this took %.2f seconds." % (
+                        row_ind - myTasks[0], nTasks, time.time() - start), ONLY_RANK=0)
+        if len(tmp_means) == 0:
+            ltqsVars = np.zeros((0, nCells))
+            ltqs = np.zeros((0, nCells))
+            genes_to_keep = np.zeros(0, dtype=int)
+            gene_vars = np.zeros(0)
+        else:
+            ltqs = np.vstack(tmp_means)
+            ltqsVars = np.ones(ltqs.shape) * 1e-6
+            nGenes = ltqs.shape[0]
+            genes_to_keep = np.array(genes_to_keep)
+            gene_vars = np.array(tmp_gene_vars)
+
+    if mpiInfo.size > 1:
+        # Write the data gathered on each process to a numpy file
+        if not os.path.exists(tmp_folder):
+            Path(tmp_folder).mkdir(parents=True, exist_ok=True)
+        fname = os.path.join(tmp_folder, 'tmp_data_proc_{}.npz'.format(mpiInfo.rank))
+        np.savez(fname, genes_to_keep=genes_to_keep, gene_vars=gene_vars, ltqs=ltqs, ltqsVars=ltqsVars)
+
+        # Wait until all processes are done
+        mpi_wrapper.barrier()
+
+        # Gather data only on process 0
+        if mpiInfo.rank == 0:
+            genes_to_keep_list = []
+            gene_vars_list = []
+            ltqs_list = []
+            ltqs_vars_list = []
+            for proc in range(mpiInfo.size):
+                fname = os.path.join(tmp_folder, 'tmp_data_proc_{}.npz'.format(proc))
+                data = np.load(fname)
+
+                genes_to_keep_list.append(data["genes_to_keep"])
+                gene_vars_list.append(data["gene_vars"])
+                ltqs_list.append(data["ltqs"])
+                ltqs_vars_list.append(data["ltqsVars"])
+
+            # Concatenate vertically
+            genes_to_keep = np.concatenate(genes_to_keep_list, axis=0)
+            gene_vars = np.concatenate(gene_vars_list, axis=0)
+            ltqs = np.vstack(ltqs_list)
+            ltqsVars = np.vstack(ltqs_vars_list)
+            del ltqs_list
+            del ltqs_vars_list
+            gc.collect()
+
+            # Check if there are genes to continue, otherwise communicate with other processes to exit
+            if len(genes_to_keep) <= 1:
+                continueYN = False
+                mpi_wrapper.bcast(continueYN, root=0)
+                if len(genes_to_keep) == 0:
+                    exit("No gene made the zscore-cutoff. Considering lowering the cutoff.")
+                else:
+                    exit("Only one gene made the zscore-cutoff. Considering lowering the zscore-cutoff.")
+            continueYN = True
+            mpi_wrapper.bcast(continueYN, root=0)
+
+            # Remove the communicated data
+            if (mpiInfo.rank == 0) and (tmp_folder is not None):
+                remove_folder(tmp_folder)
+        else:
+            continueOrBreak = None
+            continueYN = mpi_wrapper.bcast(continueOrBreak, root=0)
+            if not continueYN:
+                exit()
+
+    else:
+        if ltqs.shape[0] == 0:
+            exit("Exiting: No gene made the zscore-cutoff. Consider lowering the cutoff.")
+        elif ltqs.shape[0] == 1:
+            exit("Exiting: Only one gene made the zscore-cutoff. Consider lowering the cutoff.")
+
+    """REPLACE FROM HERE!"""
+    # if mpiInfo.size > 1:
+    #     # Make all processes communicate the read-in data with process 0.
+    #     ltqsInfo = np.concatenate((genes_to_keep[:, None], gene_vars[:, None], ltqs, ltqsVars), axis=1)
+    #     mp_print("Size of ltqsInfo that is communicated with other processes: ", ltqsInfo.shape, ONLY_RANK=0)
+    #     ltqsInfo = mpi_wrapper.GatherNpUnknownSize(ltqsInfo, root=0)
+    #     if mpiInfo.rank == 0:
+    #         if ltqsInfo.shape[0] <= 1:
+    #             # Check if there are genes to continue, otherwise communicate with other processes to exit
+    #             continueYN = False
+    #             mpi_wrapper.bcast(continueYN, root=0)
+    #             if ltqsInfo.shape[0] == 0:
+    #                 exit("No gene made the zscore-cutoff. Considering lowering the cutoff.")
+    #             else:
+    #                 exit("Only one gene made the zscore-cutoff. Considering lowering the zscore-cutoff.")
+    #         # Gather all information from all processes, this is now a matrix with a gene on each row, and then blocks
+    #         # with, respectively, gene_inds, means, variances
+    #         ltqsInfo = np.vstack(ltqsInfo)
+    #         genes_to_keep, gene_vars, ltqs, ltqsVars = np.array_split(ltqsInfo, indices_or_sections=[1, 2, nCells + 2],
+    #                                                                   axis=1)
+    #         continueYN = True
+    #         mpi_wrapper.bcast(continueYN, root=0)
+    #     else:
+    #         continueOrBreak = None
+    #         continueYN = mpi_wrapper.bcast(continueOrBreak, root=0)
+    #         if not continueYN:
+    #             exit()
+    # else:
+    #     if ltqs.shape[0] == 0:
+    #         exit("Exiting: No gene made the zscore-cutoff. Consider lowering the cutoff.")
+    #     elif ltqs.shape[0] == 1:
+    #         exit("Exiting: Only one gene made the zscore-cutoff. Consider lowering the cutoff.")
+    """REPLACE UNTIL HERE!"""
+
+    if mpiInfo.rank != 0:
+        # Save memory by removing all data-variables from processes other than 0
+        del ltqs
+        del ltqsVars
+        gc.collect()
+        return None, None, None, None, None, None, None, None
+    # genes_to_keep = genes_to_keep.flatten().astype(dtype=int)
+    # gene_vars = gene_vars.flatten()
+    nGenes = ltqs.shape[0]
+    if verbose:
+        mp_print("Processed %d genes in %.2f seconds, found %d cells. At zscore-cutoff of %f, %d genes were kept." % (
+            nGenesOrig, time.time() - start, nCells, zscoreCutoff, nGenes))
+
+    return ltqs, ltqsVars, gene_vars, nCells, nGenes, genes_to_keep, ltqStdsFound, nGenesOrig
+
+
+def storeData(metadata, ltqs, ltqsVars, verbose=False):
+    datafolder = metadata.processedDatafolder
+    Path(datafolder).mkdir(parents=True, exist_ok=True)
+    np.save(os.path.join(datafolder, "delta.npy"), ltqs, allow_pickle=False)
+    np.save(os.path.join(datafolder, "delta_vars.npy"), ltqsVars, allow_pickle=False)
+    metadata.to_json(os.path.join(datafolder, 'metadata.json'))
+
+
+def get_bonsai_posteriors(final_bonsai_folder, vert_ids):
+    bonsai_ltqs_vg = np.load(os.path.join(final_bonsai_folder, 'posterior_ltqs_vertByGene.npy'))
+    bonsai_ltqsVars_vg = np.load(os.path.join(final_bonsai_folder, 'posterior_ltqsVars_vertByGene.npy'))
+    num_dims = bonsai_ltqs_vg.shape[1]
+    bonsai_ltqs_gc = np.zeros((num_dims, len(vert_ids)))
+    bonsai_ltqsVars_gc = np.zeros((num_dims, len(vert_ids)))
+    # Read in vertInfo and cellIds
+    node_id_to_vert_ind = {}
+    vertFile = os.path.join(final_bonsai_folder, 'vertInfo.txt')
+    with open(vertFile, "r") as file:
+        reader = csv.reader(file, delimiter="\t")
+        skipRow = True
+        for row in reader:
+            if skipRow:
+                skipRow = False
+                continue
+            node_id_to_vert_ind[row[2]] = int(row[0])
+    # metadata = Metadata(json_filepath=os.path.join(args.bonsai_results, 'metadata.json'))
+    for ind_cell, vert_id in enumerate(vert_ids):
+        if vert_id in node_id_to_vert_ind:
+            bonsai_ltqs_gc[:, ind_cell] = bonsai_ltqs_vg[node_id_to_vert_ind[vert_id], :]
+            bonsai_ltqsVars_gc[:, ind_cell] = bonsai_ltqsVars_vg[node_id_to_vert_ind[vert_id], :]
+        else:
+            mp_print("Couldn't find vert_id {} in Bonsai-output.", ERROR=True)
+    return bonsai_ltqs_gc, bonsai_ltqsVars_gc
+
+
+def get_bonsai_euclidean_distances(final_bonsai_folder, cell_ids):
+    bonsai_ltqs_gc, _ = get_bonsai_posteriors(final_bonsai_folder, vert_ids=cell_ids)
+    num_dims = bonsai_ltqs_gc.shape[0]
+    bonsai_dists = distance.pdist(bonsai_ltqs_gc.T, metric='sqeuclidean') / num_dims
+    return bonsai_dists

--- a/omicverse/external/bonsai/bonsai/bonsai_globals.py
+++ b/omicverse/external/bonsai/bonsai/bonsai_globals.py
@@ -1,0 +1,6 @@
+globalVars = {'nCells', 'nGenes', 'nNodes', 'max_node_ind', 'mem_friendly'}
+nCells = None
+nGenes = None
+nNodes = None
+max_node_ind = 0
+mem_friendly = False

--- a/omicverse/external/bonsai/bonsai/bonsai_helpers.py
+++ b/omicverse/external/bonsai/bonsai/bonsai_helpers.py
@@ -1,0 +1,1247 @@
+from argparse import ArgumentTypeError
+from . import mpi_wrapper as mpi_wrapper
+import sys
+from matplotlib import cm
+from matplotlib.colors import ListedColormap
+import numpy as np
+import matplotlib.pyplot as plt
+import time
+from scipy import optimize
+from scipy.optimize import minimize
+from . import bonsai_globals as bs_glob
+import os, shutil
+import csv
+import pickle
+from pathlib import Path
+import resource
+from datetime import datetime
+from collections import namedtuple
+from ruamel.yaml import YAML
+
+custom_colors = ['#d7191c', '#fdae61', '#abd9e9']
+custom_colors_rgb = [tuple(float(int(h.lstrip('#')[i:i + 2], 16)) / 255 for i in (0, 2, 4)) for h in custom_colors]
+custom_colors_rgba = [tuple(list(rgb) + [1.0]) for rgb in custom_colors_rgb]
+blackish = '#%02x%02x%02x' % (35, 31, 32)
+blackish = (0.08578431372549018, 0.08578428015768168, 0.11935208866155156, 1.0)
+
+# omicverse: matplotlib removed cm.get_cmap in 3.9; matplotlib.colormaps is
+# the supported lookup from 3.5 onwards.
+def _get_cmap(name):
+    import matplotlib
+    try:
+        return matplotlib.colormaps[name]
+    except (AttributeError, KeyError):
+        return cm.get_cmap(name)
+
+grey_cmap = _get_cmap('gray')
+grey = grey_cmap(0.7)
+# celltype_colors = _get_cmap('tab10')
+other_colors = _get_cmap('tab20')
+# gradient_colors = _get_cmap('terrain')
+gradient_colors = _get_cmap('viridis')
+
+import logging
+FORMAT = '%(asctime)s %(funcName)s %(levelname)s %(message)s'
+log_level = logging.WARNING
+log_level = logging.DEBUG
+logging.basicConfig(format=FORMAT,
+                    datefmt='%m-%d %H:%M:%S',
+                    level=logging.WARNING)   # silence all libraries
+
+# Create your app logger
+logger = logging.getLogger("myapp")
+logger.setLevel(log_level)
+
+plt.set_loglevel(level='warning')
+
+
+class Run_Configs:
+    config_yaml = None
+
+    def __init__(self, yaml_filepath=None, args=None, args_to_copy=None, step=None, create_empty_configs=False):
+
+        pars_defaults = {'step': 'all',
+                         'dataset': 'new_dataset',
+                         'data_folder': None,
+                         'filenames_data': 'delta.txt,d_delta.txt',
+                         'results_folder': None,
+                         'verbose': True,
+                         'input_is_sanity_output': True,
+                         'zscore_cutoff': 1.0,
+                         'rescale_by_var': True,
+                         'nnn_n_randommoves': 1000,
+                         'nnn_n_randomtrees': 10,
+                         'use_knn': 10,
+                         'UB_ellipsoid_size': 1.0,
+                         'skip_greedy_merging': False,
+                         'skip_redo_starry': False,
+                         'skip_opt_times': False,
+                         'skip_spr_moves': False,
+                         'skip_nnn_reordering': False,
+                         'skip_reorder_edges': False,
+                         'pickup_intermediate': False,
+                         'tmp_folder': None,
+                         'spr_strategy': 'large_tree'}
+
+        if create_empty_configs:
+            for label in pars_defaults:
+                setattr(self, label, pars_defaults[label])
+            return
+
+        if yaml_filepath is not None and os.path.exists(yaml_filepath):
+            yaml = YAML()
+            with open(yaml_filepath, 'r') as file_obj:
+                self.config_yaml = yaml.load(file_obj)
+        else:
+            print("No YAML-file with run configurations found{}".format(
+                "." if yaml_filepath is None else " at {}".format(yaml_filepath)))
+            print("Create a YAML-file using the script bonsai/create_config_file.py, or copy the template at "
+                  "'bonsai/config_template_do_not_change/config_template.yaml' "
+                  "and insert the correct configuration there.\n"
+                  "Then add the path to this YAML-file in the '--config_filepath' parameters")
+            exit()
+
+        for label in pars_defaults:
+            if (label in self.config_yaml) and (self.config_yaml[label] is not None):
+                setattr(self, label, self.config_yaml[label])
+            else:
+                setattr(self, label, pars_defaults[label])
+
+        if (args_to_copy is not None) and (args is not None):
+            for label in args_to_copy:
+                if hasattr(args, label):
+                    setattr(self, label, getattr(args, label))
+
+        # The following run-configurations are still used in Bonsai, but can no longer be set by users. Instead,
+        # picking up intermediate results is only done through --pickup_intermediate and providing the correct
+        # intermediate-results folders in the results-folder
+        deprecated_args = ['skip_greedy_merging', 'skip_opt_times', 'skip_redo_starry', 'skip_spr_moves',
+                           'skip_nnn_reordering', 'skip_reorder_edges']
+        for dep_arg in deprecated_args:
+            if hasattr(self, dep_arg) and getattr(self, dep_arg):
+                setattr(self, dep_arg, False)
+                mp_print(
+                    "The argument '{}' is deprecated and no longer have any effect. "
+                    "Use --pickup_intermediate True to pick up intermediate results from "
+                    "previous Bonsai runs.".format(dep_arg),
+                    WARNING=True)
+
+        if step is not None:
+            self.step = step
+        # Add timestamp
+        self.config_yaml['start_time'] = datetime.now().strftime('%d.%m.%y_%H:%M:%S')
+
+    def store_yaml(self, yaml_filepath=None):
+        if yaml_filepath is not None:
+            yaml = YAML()
+            with open(yaml_filepath, 'w') as file_obj:
+                yaml.dump(self.config_yaml, file_obj)
+
+
+def get_pdist_inds(shape, i, j):
+    if i < j:
+        return shape * i + j - ((i + 2) * (i + 1)) // 2
+    else:
+        return shape * j + i - ((j + 2) * (j + 1)) // 2
+
+
+# def dist_ind_to_pair_ind(d, i):
+#     b = 1 - 2 * d
+#     x = np.floor((-b - np.sqrt(b**2 - 8*i))/2).astype(int)
+#     y = (i + x * (b + x + 2) / 2 + 1).astype(int)
+#     return x, y
+
+
+def str2bool(v):
+    if v.lower() in ('yes', 'true', 't', 'y', '1'):
+        return True
+    elif v.lower() in ('no', 'false', 'f', 'n', '0'):
+        return False
+    else:
+        raise ArgumentTypeError('Boolean value expected.')
+
+
+def mp_print(*args, **kwargs):
+    """
+    Multiprocessing wrapper for print().
+    Prints the given arguments, but only on process 0 unless
+    named argument ALL_RANKS is set to true.
+    :return:
+    """
+    print_message = None
+    error = False
+    debug = False
+    warning = False
+    if ('ERROR' in kwargs) and kwargs['ERROR']:
+        error = True
+    if ('DEBUG' in kwargs) and kwargs['DEBUG']:
+        debug = True
+    if ('WARNING' in kwargs) and kwargs['WARNING']:
+        warning = True
+    mpi_rank = mpi_wrapper.get_process_rank()
+    if 'ALL_RANKS' in kwargs and kwargs['ALL_RANKS']:
+        print_message = "Process %d: " % (mpi_rank) + ' '.join(map(str, args))
+    elif 'ONLY_RANK' in kwargs:
+        if kwargs['ONLY_RANK'] == mpi_rank:
+            print_message = "Process %d: " % (mpi_rank) + ' '.join(map(str, args))
+    elif mpi_rank == 0:
+        print_message = ' '.join(map(str, args))
+
+    if print_message is None:
+        return
+
+    if error:
+        logger.error(print_message)
+    elif debug:
+        logger.debug(print_message)
+    elif warning:
+        logger.warning(print_message)
+    else:
+        logger.info(print_message)
+
+    sys.stdout.flush()
+    sys.stderr.flush()
+
+
+# Should go to tree vis file
+def get_celltype_colors(n_celltypes, colortype=None, gradientType='hsv'):
+    if (colortype is None) and (n_celltypes <= 8):
+        col_HSC = "#0B5345"  # darkgreen
+        col_MPP = "#229954"  # green
+        col_LMPP = "#48C9B0"  # turchqoise
+        col_CMP = "#AF601A"
+        # col_UNK = "#E5E7E9"
+        col_MEP = "#FE776D"
+        col_pDC = "#A690A4"
+        col_GMP = "#FCD0A1"
+        col_CLP = "#AFD2E9"
+        col_5h1 = "#FF7F11"  # orange
+        col_5h2 = "#FF1B1C"  # red
+        col_10h1 = "#10AFF8"  # light blue
+        col_10h2 = "#0E2DF5"  # darker blue
+
+        celltype_colors = [col_CLP, col_CMP, col_GMP, col_HSC, col_LMPP, col_MEP, col_MPP, col_pDC]
+        celltype_colors = ListedColormap(celltype_colors)
+        if n_celltypes == 4:
+            celltype_colors = ListedColormap([col_10h1, col_10h2, col_5h1, col_5h2])
+        # col_dict = {"MEP": col_MEP,
+        #             "pDC": col_pDC,
+        #             "GMP": col_GMP,
+        #             "CLP": col_CLP,
+        #             "HSC": col_HSC,
+        #             "MPP": col_MPP,
+        #             "LMPP": col_LMPP,
+        #             "CMP": col_CMP,
+        #             "UNK": col_UNK,
+        #             "GMP-A": col_GMPA,
+        #             "GMP-B": col_GMPB,
+        #             "GMP-C": col_GMPC
+        #             }
+    elif (colortype is None) and (n_celltypes < 10):
+        celltype_colors = _get_cmap('tab10')
+    elif (colortype is None) and (n_celltypes < 20):
+        celltype_colors = _get_cmap('tab20')
+    elif colortype == 'offOn':
+        tab10 = _get_cmap('tab10')
+        two_colors = tab10([1, 2])
+        two_colors[1, :] = grey_cmap(0.5)
+        celltype_colors = ListedColormap(two_colors)
+    else:
+        gradient = _get_cmap(gradientType)
+        celltype_colors = ListedColormap(gradient(np.linspace(0, 1, n_celltypes)))
+    return celltype_colors
+
+
+# Should go to tree vis file
+def transform_coords_poincare(coords, origin=np.zeros(2), zoom=1, no_transform=False):
+    # if no_transform:
+    #     return (coords - origin) * zoom
+    if no_transform:
+        new_coords = coords - origin
+        radii_euclidean = np.sqrt(np.sum(new_coords ** 2, axis=1))
+        radii_euclidean *= zoom
+        large_radii = radii_euclidean > 1
+        radii_euclidean[large_radii] = 1.1
+        nonzeros = radii_euclidean != 0
+    else:
+        new_coords = coords - origin
+        radii_euclidean = np.sqrt(np.sum(new_coords ** 2, axis=1))
+        radii_euclidean *= zoom
+        nonzeros = radii_euclidean != 0
+        radii_euclidean[nonzeros] = -1 / (2 * radii_euclidean[nonzeros]) + np.sqrt(
+            1 + 1 / (4 * (radii_euclidean[nonzeros] ** 2)))
+    coords_transformed = np.zeros(new_coords.shape)
+    coords_transformed[nonzeros, :] = radii_euclidean[nonzeros, np.newaxis] * (
+            new_coords[nonzeros, :] / np.linalg.norm(new_coords[nonzeros, :], axis=1, ord=2)[:, np.newaxis])
+    return coords_transformed
+
+
+# Should go to tree vis file
+def invert_coords_poincare(coords, origin=np.zeros(2), zoom=1, no_transform=False):
+    if no_transform:
+        radii = np.sqrt(np.sum(coords ** 2, axis=1))
+        small_radii = radii <= 1
+        new_coords = coords.copy()
+        new_coords[small_radii] = coords[small_radii] / zoom + origin
+        return coords / zoom + origin
+    coords_polar = np.zeros(coords.shape)
+    coords_polar[:, 0] = np.sqrt(np.sum(coords ** 2, axis=1))
+    coords_polar[:, 1] = np.arctan2(coords[:, 1], coords[:, 0])
+    coords_polar[:, 0] = (1 / zoom) * coords_polar[:, 0] / (1 - (coords_polar[:, 0] ** 2))
+    coords_transformed = np.zeros(coords_polar.shape)
+    coords_transformed[:, 0] = coords_polar[:, 0] * np.cos(coords_polar[:, 1])
+    coords_transformed[:, 1] = coords_polar[:, 0] * np.sin(coords_polar[:, 1])
+    coords_transformed += origin
+    return coords_transformed
+
+
+# Should go to tree vis file
+def pause_anim(t):  # This is taken from plt.pause(...), but without unnecessary
+    # stuff. Note that the time module should be previously imported.
+    # Again, this use the controversial event_loop of Matplotlib.
+    backend = plt.rcParams['backend']
+    if backend in plt._interactive_bk:
+        figManager = plt._pylab_helpers.Gcf.get_active()
+        if figManager is not None:
+            figManager.canvas.start_event_loop(t)
+            return
+    else:
+        time.sleep(t)
+
+
+# Should go to tree vis file
+def get_opt_zoom_origin_poincare(coords, frac_within=0.8, within_radius=0.8, tol=1e-6, max_iter=20, verbose=False):
+    converged = False
+    old_zoom = 1
+    origin0 = np.mean(coords, axis=0)
+    counter = 0
+    while not converged:
+        counter += 1
+        new_zoom = get_zoom_given_origin(origin0, coords, frac_within=frac_within, within_radius=within_radius)
+        origin0 = get_centroid_poincare(coords, zoom=new_zoom, verbose=verbose)
+        if verbose:
+            print('Zoom is ' + str(new_zoom))
+            print('Origin is ' + str(origin0) + '\n')
+        if np.abs(old_zoom - new_zoom) < tol:
+            converged = True
+        else:
+            old_zoom = new_zoom
+        if counter == max_iter:
+            print("Maximum number of iterations reached: just returning last found value.")
+            print("Zoom value converged to " + str(np.abs(old_zoom - new_zoom)))
+            converged = True
+    return new_zoom, origin0
+
+
+# Should go to tree vis file
+def get_zoom_given_origin(origin, coords, frac_within=0.8, within_radius=.8):
+    n_points = coords.shape[0]
+    n_points_within = int(np.ceil(frac_within * n_points))
+
+    def radius_needed(logzoom):
+        zoom = np.exp(logzoom)
+        needed_radius = np.sort(get_radial_poincare(coords, origin=origin, zoom=zoom))[
+                            n_points_within - 1] - within_radius
+        return needed_radius
+
+    bracket = (-6, 1)
+    bracket_ok = False
+    while not bracket_ok:
+        if radius_needed(bracket[0]) >= 0:
+            bracket = (bracket[0] - 1, bracket[1])
+        elif radius_needed(bracket[1]) <= 0:
+            bracket = (bracket[0], bracket[1] + 1)
+        else:
+            bracket_ok = True
+
+    opt_result = optimize.root_scalar(radius_needed, bracket=bracket)
+    if opt_result.converged:
+        result = np.exp(opt_result.root)
+    else:
+        print(opt_result.flag)
+        print("Finding optimal zoom failed. Using 0.001 instead.")
+        result = 0.001
+
+    return result
+
+
+# Should go to tree vis file
+def get_radial_poincare(coords, origin=np.zeros(2), zoom=1):
+    new_coords = coords - origin
+    radii_euclidean = np.sqrt(np.sum(new_coords ** 2, axis=1))
+    # nonzeros = coords[:, 0] != 0
+    # coords_polar[~nonzeros, 1] = np.sign(coords[~nonzeros, 1])
+    radii_euclidean *= zoom
+    # coords_transformed_polar = coords_polar.copy()
+    # coords_transformed_polar[:, 0] = -1 / (2 * coords_polar[:, 0]) + np.sqrt(1 + 1 / (4 * (coords_polar[:, 0] ** 2)))
+    nonzeros = radii_euclidean != 0
+    radii_euclidean[nonzeros] = -1 / (2 * radii_euclidean[nonzeros]) + np.sqrt(
+        1 + 1 / (4 * (radii_euclidean[nonzeros] ** 2)))
+    return radii_euclidean
+
+
+# Should go to tree vis file
+def get_centroid_poincare(coords, zoom=1, verbose=False):
+    origin0 = np.mean(coords, axis=0)
+
+    def dist_fun(ori):
+        return np.mean(get_radial_poincare(coords, origin=ori, zoom=zoom))
+
+    opt_result = minimize(dist_fun, origin0)
+    if opt_result.success:
+        if verbose:
+            print(opt_result.message)
+        origin = opt_result.x
+    else:
+        print(opt_result.message)
+        print("We take the centroid of the graph in Euclidean space instead.")
+        origin = origin0
+    return origin
+
+
+# Should go to tree vis file
+class InteractionEvent:
+    function = None
+    kwargs = None
+
+    def __init__(self, func=None, kwargs=None):
+        if func is None:
+            print("You should pass a funcion.")
+            return
+        self.function = func
+        self.kwargs = kwargs
+
+    def execute(self):
+        if self.kwargs is not None:
+            self.function(**self.kwargs)
+        else:
+            self.function()
+
+
+def checkGrad(funGrad, coords, args, dx=1e-6, dims=None):
+    """
+    This function checks for a (multivariate) function that returns a function and a gradient as its two outputs
+    whether the gradient matches a numerical gradient.
+    :param funGrad: function that takes a numpy-vector of size coords.shape and returns a function value and its
+    gradient
+    :param coords: Point at which we want to check the  gradient
+    :return: numpy vector of deviation of gradient from numerical derivative
+    """
+    if dims is None:
+        nDims = len(coords)
+        dims = np.array(range(nDims))
+    else:
+        nDims = len(dims)
+    deviations = np.zeros(nDims)
+    relDeviations = np.zeros(nDims)
+    funOrig, gradOrig = funGrad(coords, *args)
+    for dimInd, dim in enumerate(dims):
+        if dimInd % 10 == 0:
+            mp_print("Checking derivative for dimension " + str(dimInd) + " out of " + str(nDims))
+        coordsdx = coords.copy()
+        coordsMinusDx = coords.copy()
+        coordsdx[dim] += dx
+        coordsMinusDx[dim] -= dx
+        numGrad = (funGrad(coordsdx, *args)[0] - funGrad(coordsMinusDx, *args)[0]) / (2 * dx)
+        deviations[dimInd] = gradOrig[dim] - numGrad
+        relDeviations[dimInd] = abs(deviations[dimInd] / gradOrig[dim])
+
+    return deviations, relDeviations
+
+
+# Used
+def hierarchy_to_newick(pathToMerger, clustIds, pathToOutput):
+    """
+    Function for getting a newick string from a hierarchy DataFrame.
+    Parameters
+    ----------
+    Returns
+    -------
+    newick_string : str
+        string of cluster hierarchy in Newick format
+    """
+    import pandas as pd
+    mergers_df = pd.read_csv(pathToMerger, names=['cluster_new', 'cluster_old', 'dist1', 'dist2'], delimiter=' ')
+
+    cluster_string_dict = {}
+    # cluster_distance = {c: min_distance for c in cluster_names}
+    for cInd, cId in enumerate(clustIds):
+        cluster_string = f'C{cId}'
+        cluster_string_dict[cInd] = cluster_string
+
+    c_low = min(cluster_string_dict.keys())
+
+    # if distance:
+    #     distances = np.cumsum(np.where((hierarchy_df.delta_LL >= 0), 1, -hierarchy_df.delta_LL + 1))
+
+    # use index i instead of step in case hierarchy_df.index is non-standard
+    i = mergers_df.shape[0] - 1
+    for step, row in mergers_df.iterrows():
+        c_old = row.cluster_old
+        c_new = row.cluster_new
+        s_old = cluster_string_dict[c_old]
+        s_new = cluster_string_dict[c_new]
+
+        # d = distances[-i - 1]
+        d_old = row[2]
+        d_new = row[3]
+        cluster_string_new = f'({s_new}:{d_new},{s_old}:{d_old})I{i}'
+
+        cluster_string_dict[c_new] = cluster_string_new
+        del cluster_string_dict[c_old]
+        # del cluster_distance[c_old]
+
+        i -= 1
+
+    newick_string = cluster_string_dict[c_new] + ';'
+    with open(pathToOutput, 'w') as f:
+        f.write("%s" % newick_string)
+
+
+# Should go to tree vis file
+def compile_tree_from_newick(newickFilename):
+    from skbio import TreeNode
+    njTreenode = TreeNode.read(newickFilename, convert_underscores=False)
+    return compile_tree_from_nj_treenode(njTreenode)
+
+
+# Should go to tree vis file
+def compile_tree_from_nj_treenode(njTreenode):
+    # Convert to igraph tree
+    tree = njTreenode
+    internal_counter = 0
+    id_ind_dict = {}
+    curr_ind = 0
+    edge_list = []
+    dist_list = []
+    orig_vert_names = []
+    for node in tree.preorder():
+        # If node is internal it does not have an ID, so we give it one.
+        if node.name is None:
+            node.name = 'internal_' + str(internal_counter)
+            internal_counter += 1
+
+        # We keep track of which node is at which index by updating a dict
+        id_ind_dict[node.name] = curr_ind
+        orig_vert_names.append(node.name)
+
+        # For each node that we traverse, we add an edge to its parent with the right length
+        if not node.is_root():
+            edge_list.append((id_ind_dict[node.parent.name], curr_ind))
+            dist_list.append(node.length)
+        curr_ind += 1
+    return edge_list, dist_list, orig_vert_names
+
+
+# Used
+def startMPI(verbose=True):
+    mpi_wrapper.mpi_init()
+    mpiSize = mpi_wrapper.get_process_size()
+    mpiRank = mpi_wrapper.get_process_rank()
+    if verbose and (mpiRank in [mpiSize - 1, 0]):
+        mp_print("Process " + str(mpiRank) + " out of " + str(mpiSize) + " has started.", ALL_RANKS=True)
+    return mpiRank, mpiSize
+
+
+# TODO: Do this without networkx. Only used to get sparse distance matrix
+def get_shortest_distances_on_tree(ig_graph, indices=None):
+    from scipy.sparse.csgraph import floyd_warshall, shortest_path
+    from scipy.sparse import csr_matrix
+    from scipy.spatial.distance import squareform
+    edgelist = ig_graph.get_edge_dataframe()[['source', 'target', 'weight']]
+
+    # weighted_edges = list(edgelist.to_records(index=False))
+    # import networkx as nx
+    # G = nx.Graph()
+    # G.add_weighted_edges_from(weighted_edges)
+    # distance_csr = ig_graph.get_adjacency_sparse(attribute="weight")
+    # distances = squareform(floyd_warshall(csgraph=distance_csr, directed=False))
+
+    cols = edgelist['source'].values
+    rows = edgelist['target'].values
+    weights = edgelist['weight'].values
+    colsComplete = np.concatenate((cols, rows))
+    rowsComplete = np.concatenate((rows, cols))
+    weightsComplete = np.concatenate((weights, weights))
+    nVerts = np.max(colsComplete) + 1
+    distance_csr = csr_matrix((weightsComplete, (rowsComplete, colsComplete)), shape=(nVerts, nVerts))
+
+    distances = squareform(shortest_path(distance_csr, method='auto', directed=False, return_predecessors=False,
+                                         unweighted=False, overwrite=False, indices=indices)[:, indices], checks=False)
+    return distances
+
+
+# Used
+def getOutputFolder(zscore_cutoff=-1, greedy=True, redo_starry=True, opt_times=True, final=False,
+                    reorderedEdges=False, spr_moves=False, nnn_reorder=False, tmp_file='', get_all_possibilities=False):
+    if get_all_possibilities:
+        all_possibilities = []
+
+    # Distinguish preprocessed-results from tree-reconstruction results
+    if final:
+        mergerFolder = 'final_bonsai'
+    elif not greedy:
+        mergerFolder = 'preprocessed'
+    else:
+        mergerFolder = 'intermediate_bonsai'
+
+    # Store zscore_cutoff in the filename
+    if zscore_cutoff > 0:
+        mergerFolder += "_zscore" + str(zscore_cutoff)
+    if get_all_possibilities:
+        all_possibilities.append(mergerFolder)
+
+    # Add the several steps that we already did
+    if (redo_starry or get_all_possibilities) and (not final):
+        mergerFolder += "_redoStarry"
+    if get_all_possibilities:
+        all_possibilities.append(mergerFolder)
+    if (opt_times or get_all_possibilities) and (not final):
+        mergerFolder += "_optTimes"
+    if get_all_possibilities:
+        all_possibilities.append(mergerFolder)
+    if (spr_moves or get_all_possibilities) and (not final):
+        mergerFolder += "_sprMoves"
+    if get_all_possibilities:
+        all_possibilities.append(mergerFolder)
+    if (nnn_reorder or get_all_possibilities) and (not final):
+        mergerFolder += "_nnnReorder"
+    if get_all_possibilities:
+        all_possibilities.append(mergerFolder)
+    if (reorderedEdges or get_all_possibilities) and (not final):
+        mergerFolder += "_reorderedEdges"
+    if get_all_possibilities:
+        all_possibilities.append(mergerFolder)
+    if len(tmp_file) > 0:
+        mergerFolder += "_tmpStart" + tmp_file
+        if get_all_possibilities:
+            for ind in range(len(all_possibilities)):
+                all_possibilities[ind] += "_tmpStart" + tmp_file
+    if get_all_possibilities:
+        return all_possibilities
+    return mergerFolder
+
+
+def find_latest_tree_folder(results_folder, not_final=False):
+    tree_folder = None
+    for file in os.listdir(results_folder):
+        if (file[:12] == 'final_bonsai') and (not not_final):
+            tree_folder = file
+            break
+        elif file[:19] == 'intermediate_bonsai':
+            if tree_folder is None:
+                tree_folder = file
+            elif len(file) > len(tree_folder):
+                tree_folder = file
+    if tree_folder is None:
+        tree_folder = results_folder
+    return tree_folder
+
+
+def find_latest_tree_folder_new(args, results_folder, not_final=False, set_skip_args=False):
+    # tree_folder = None
+
+    if set_skip_args:
+        # Start with assuming we can skip everything
+        args.skip_greedy_merging = True
+        args.skip_redo_starry = True
+        args.skip_opt_times = True
+        args.skip_spr_moves = True
+        args.skip_nnn_reordering = True
+        args.skip_reorder_edges = True
+
+    # We go over the possible tree folders in reverse order, i.e., most advanced first, and check whether it's present
+    # 1. Finished tree folder
+    if not not_final:
+        dir_path = getOutputFolder(zscore_cutoff=args.zscore_cutoff, tmp_file=os.path.basename(args.tmp_folder),
+                                   final=True)
+        if os.path.exists(os.path.join(results_folder, dir_path, 'vertInfo.txt')):
+            return dir_path
+
+    # 2. Check if done all computation steps, except for the final metadata
+    dir_path = getOutputFolder(zscore_cutoff=args.zscore_cutoff, redo_starry=True, opt_times=True, final=False,
+                               reorderedEdges=True, nnn_reorder=True, spr_moves=True,
+                               tmp_file=os.path.basename(args.tmp_folder))
+    if os.path.exists(os.path.join(results_folder, dir_path, 'vertInfo.txt')):
+        return dir_path
+
+    # 3. Check if done everything but swapping the order of branches and setting root
+    if set_skip_args:
+        args.skip_reorder_edges = False
+    dir_path = getOutputFolder(zscore_cutoff=args.zscore_cutoff, redo_starry=True, opt_times=True, final=False,
+                               nnn_reorder=True, reorderedEdges=False, spr_moves=True,
+                               tmp_file=os.path.basename(args.tmp_folder))
+    if os.path.exists(os.path.join(results_folder, dir_path, 'vertInfo.txt')):
+        return dir_path
+
+    # 4. Check if done everything up to nn-interchanges
+    if set_skip_args:
+        args.skip_nnn_reordering = False
+    dir_path = getOutputFolder(zscore_cutoff=args.zscore_cutoff, redo_starry=True, opt_times=True, final=False,
+                               nnn_reorder=False, reorderedEdges=False, spr_moves=True,
+                               tmp_file=os.path.basename(args.tmp_folder))
+    if os.path.exists(os.path.join(results_folder, dir_path, 'vertInfo.txt')):
+        return dir_path
+
+    # 4. Check if done everything up to SPR-moves
+    if set_skip_args:
+        args.skip_spr_moves = False
+    dir_path = getOutputFolder(zscore_cutoff=args.zscore_cutoff, redo_starry=True, opt_times=True, final=False,
+                               nnn_reorder=False, reorderedEdges=False, spr_moves=False,
+                               tmp_file=os.path.basename(args.tmp_folder))
+    if os.path.exists(os.path.join(results_folder, dir_path, 'vertInfo.txt')):
+        return dir_path
+
+    # 4. Check if done everything up to time optimization
+    if set_skip_args:
+        args.skip_opt_times = False
+    dir_path = getOutputFolder(zscore_cutoff=args.zscore_cutoff, redo_starry=True, opt_times=False, final=False,
+                               nnn_reorder=False, reorderedEdges=False, spr_moves=False,
+                               tmp_file=os.path.basename(args.tmp_folder))
+    if os.path.exists(os.path.join(results_folder, dir_path, 'vertInfo.txt')):
+        return dir_path
+
+    # 4. Check if done everything up to redoing-starry, i.e., only the greedy merging
+    if set_skip_args:
+        args.skip_redo_starry = False
+    dir_path = getOutputFolder(zscore_cutoff=args.zscore_cutoff, redo_starry=False, opt_times=False, final=False,
+                               nnn_reorder=False, reorderedEdges=False, spr_moves=False,
+                               tmp_file=os.path.basename(args.tmp_folder))
+    if os.path.exists(os.path.join(results_folder, dir_path, 'vertInfo.txt')):
+        return dir_path
+
+    # 5. Check if only preprocessing has been done
+    if set_skip_args:
+        args.skip_greedy_merging = False
+    dir_path = getOutputFolder(zscore_cutoff=args.zscore_cutoff, greedy=False, redo_starry=False, opt_times=False,
+                               final=False, tmp_file=os.path.basename(args.tmp_folder))
+    if os.path.exists(os.path.join(results_folder, dir_path, 'vertInfo.txt')):
+        return dir_path
+
+    # If nothing has been done, just return the results_folder
+    return results_folder
+
+def clean_up_redundant_data_files(scData, args, verbose=True):
+    if verbose:
+        mp_print("Cleaning up intermediate datafiles.")
+    all_possible_folders = getOutputFolder(zscore_cutoff=args.zscore_cutoff,
+                                           tmp_file=os.path.basename(args.tmp_folder), get_all_possibilities=True)
+    try:
+        for tree_folder in all_possible_folders:
+            tree_folder = scData.result_path(tree_folder)
+            if os.path.exists(tree_folder) and os.path.isdir(tree_folder):
+                for filename in os.listdir(tree_folder):
+                    if filename[-15:] == '_vertByGene.npy':
+                        os.remove(os.path.join(tree_folder, filename))
+    except:
+        mp_print("Somehow couldn't fully remove directory with intermediate tree-files. Not a problem, these "
+                 "directories don't take much memory.")
+
+
+# Used
+def getNodePairInfo(pairInfoDict, sortedNodeInds):
+    info = None
+    if sortedNodeInds in pairInfoDict:
+        info = pairInfoDict[sortedNodeInds]
+    return info
+
+
+# Used
+def communicateNodePairInfo(oldPairInfoDict, newPairInfoDict, mpi_rank, allRanksGetInfo=True):
+    newPairInfoDicts = mpi_wrapper.world_allgather(newPairInfoDict)
+    if (mpi_rank == 0) or allRanksGetInfo:
+        for infoDict in newPairInfoDicts:
+            oldPairInfoDict.update(infoDict)
+    else:
+        oldPairInfoDict = None
+    return oldPairInfoDict
+
+
+# Used
+def cleanUpPairDict(deletedNodes, pairDict):
+    keys, vals = zip(*pairDict.items())
+    keyArray = np.array(keys)
+    valArray = np.array(vals)
+    for node in deletedNodes:
+        toBeDeleted = np.where(keyArray == node)[0]
+        keyArray = np.delete(keyArray, toBeDeleted, axis=0)
+        valArray = np.delete(valArray, toBeDeleted, axis=0)
+    return dict(zip(list(map(tuple, keyArray)), list(valArray)))
+
+
+# Used
+def communicateGlobalVars():
+    allGlobalVars = sorted(list(bs_glob.globalVars))
+    for globalVar in allGlobalVars:
+        thisVar = mpi_wrapper.bcast(getattr(bs_glob, globalVar), root=0)
+        setattr(bs_glob, globalVar, thisVar)
+
+
+# Used
+def calcTInit(tOld1, tOld2, sequential):
+    tAnc0 = min(tOld1, tOld2) / 2
+    if sequential:
+        t0_i = [tOld1 + tOld2 - 2 * tAnc0, tAnc0]
+    else:
+        t0_i = [tOld1 - tAnc0, tOld2 - tAnc0, tAnc0]
+    return t0_i
+
+
+# Used
+def getAllDLogLs(dLogLDict, mpi_rank, nChildren):
+    # Gather all dLogLs on the first process
+    dLogLsDicts = mpi_wrapper.world_allgather(dLogLDict)
+    if mpi_rank != 0:
+        dLogLs = None
+    else:
+        allDLogLsDict = {}
+        for dLogLDict in dLogLsDicts:
+            allDLogLsDict.update(dLogLDict)
+        dLogLs = np.zeros(int(nChildren * (nChildren - 1) / 2))
+
+        curr_pairs = nChildren - 1
+        done = 0
+        for i in range(nChildren - 1):
+            dLogLs[done:done + curr_pairs] = allDLogLsDict[i]
+            done += curr_pairs
+            curr_pairs -= 1
+    return dLogLs
+
+
+# Used
+def getMyTaskNumbers(nTasks, mpiSize, mpiRank, skippingSteps=False):
+    if skippingSteps:
+        return np.arange(mpiRank, nTasks, mpiSize)
+    quotient, remainder = divmod(nTasks, mpiSize)
+    section_sizes = ([] +
+                     remainder * [quotient + 1] +
+                     (mpiSize - remainder) * [quotient])
+    prevTasks = np.append(0, np.cumsum(section_sizes))
+    return np.arange(prevTasks[mpiRank], prevTasks[mpiRank + 1])
+
+
+def printTiming(taskDescription, oldTime):
+    currTime = time.time()
+    mp_print("Timing: %s took %f seconds." % (taskDescription, currTime - oldTime))
+    return currTime
+
+
+def writeVectToEndCsv(filename, vect, init=False):
+    if mpi_wrapper.get_process_rank() == 0:
+        if init:
+            if os.path.exists(filename):
+                os.remove(filename)
+        if len(vect) > 0:
+            with open(filename, "a") as file:
+                file.write('\t'.join(np.char.mod('%.8e', vect)) + '\n')
+
+
+def readListFromTxt(filename):
+    inputList = []
+    if not os.path.exists(filename):
+        print("Can't read from %s, file not found." % filename)
+        return None
+    else:
+        with open(filename, 'r') as file:
+            reader = csv.reader(file, delimiter="\t")
+            for row in reader:
+                inputList.append(row[0])
+        return inputList
+
+
+def create_celltypefile_from_cellstates(cellstates_file, celltype_file, multiplicityCutoff=0):
+    with open(cellstates_file, 'r') as file:
+        reader = csv.reader(file, delimiter="\t")
+        cellstates = []
+        for row in reader:
+            cellstates.append("CS_" + row[0])
+    unq_cellstates, inverse, counts = np.unique(cellstates, return_inverse=True, return_counts=True)
+    if os.path.exists(celltype_file):
+        os.remove(celltype_file)
+    with open(celltype_file, "a") as file:
+        for ind, cellstate in enumerate(cellstates):
+            cellstate = cellstate if counts[inverse[
+                ind]] > multiplicityCutoff else "cs with <= %d cells" % multiplicityCutoff
+            file.write(cellstate + '\n')
+
+
+# def storeCurrentState(outputFolder, scData, filename='tmp_tree.dat', dataOrResults='data', args=None, dataFolder=None):
+#     if mpi_wrapper.get_process_rank() == 0:
+#         if dataFolder is None:
+#             if args.dataset is not None:
+#                 dataFolder = os.path.join(dataOrResults, args.dataset)
+#             else:
+#                 dataFolder = args.data_folder
+#         tmpDataPath = os.path.join(dataFolder, outputFolder)
+#         Path(tmpDataPath).mkdir(parents=True, exist_ok=True)
+#
+#         scData.tree.nNodes = bs_glob.nNodes
+#         mp_print("Printing tree at %s" % os.path.join(tmpDataPath, filename))
+#         try:
+#             with open(os.path.join(tmpDataPath, filename), 'wb') as file:
+#                 pickle.dump(scData, file)
+#         except RecursionError:
+#             with RecursionLimit():
+#                 with open(os.path.join(tmpDataPath, filename), 'wb') as file:
+#                     pickle.dump(scData, file)
+
+
+def get_latest_intermediate(intermediateFiles, base=None):
+    tmpTreeInd = None
+    try:
+        indexed_files = []
+        for ind, intFile in enumerate(intermediateFiles):
+            if base is not None:
+                if intFile.split('_')[0] != base:
+                    indexed_files.append(np.nan)
+                    continue
+            index_string = intFile.split('.')[0].split('_')[-1]
+            indexed_files.append(int(index_string)) if index_string.isdigit() else indexed_files.append(np.nan)
+        if len(indexed_files):
+            latestIntFile = np.nanargmax(indexed_files)
+            tmpTreeInd = indexed_files[latestIntFile]
+        else:
+            mp_print("Could not find intermediate file, starting from scratch", ALL_RANKS=True)
+            return None, None
+    except:
+        mp_print("Could not find intermediate file, starting from scratch.", ALL_RANKS=True)
+        return None, None
+    return intermediateFiles[latestIntFile], tmpTreeInd
+
+
+# def pickleTree(pickleFolder, filename, tree):
+#     Path(pickleFolder).mkdir(parents=True, exist_ok=True)
+#     tree.nNodes = bs_glob.nNodes
+#     try:
+#         with open(os.path.join(pickleFolder, filename), 'wb') as file:
+#             pickle.dump(tree, file)
+#     except RecursionError:
+#         with RecursionLimit():
+#             with open(os.path.join(pickleFolder, filename), 'wb') as file:
+#                 pickle.dump(tree, file)
+
+
+# def unpickleTree(pickleFolder, filename):
+#     mp_print("Trying to unpickle tree from ", os.path.join(pickleFolder, filename), ALL_RANKS=True)
+#     try:
+#         with open(os.path.join(pickleFolder, filename), 'rb') as file:
+#             tree = pickle.load(file)
+#     except RecursionError:
+#         with RecursionLimit():
+#             with open(os.path.join(pickleFolder, filename), 'rb') as file:
+#                 tree = pickle.load(file)
+#     bs_glob.nNodes = tree.nNodes
+#     bs_glob.nGenes = len(tree.root.ltqs)
+#     return tree
+
+
+def remove_tree_folders(tree_folder, removeDir=False, notRemove=None, base=None):
+    empty = True
+    if not os.path.exists(tree_folder):
+        return
+    for intFile in os.listdir(tree_folder):
+        try:
+            if (base is not None) and (intFile.split('_')[0] != base):
+                empty = False
+                continue
+            if notRemove is not None:
+                index_string = intFile.split('.')[0].split('_')[-1]
+                if index_string.isdigit() and (int(index_string) in [notRemove, notRemove - 1]):
+                    empty = False
+                    continue
+            if os.path.isdir(os.path.join(tree_folder, intFile)):
+                shutil.rmtree(os.path.join(tree_folder, intFile))
+            else:
+                os.remove(os.path.join(tree_folder, intFile))
+        except:
+            mp_print("Somehow couldn't remove intermediate trees.")
+            empty = False
+    if removeDir and empty:
+        try:
+            shutil.rmtree(tree_folder)
+        except FileNotFoundError or OSError:
+            mp_print("Process %d: Apparently, folder %s was already removed." % (
+                mpi_wrapper.get_process_rank(), tree_folder), ALL_RANKS=True)
+
+
+def remove_folder(folder_path):
+    try:
+        shutil.rmtree(folder_path)
+    except FileNotFoundError or OSError:
+        mp_print("Apparently, folder %s was already removed." % folder_path)
+
+
+def empty_folder(folder_path):
+    try:
+        for file_path in os.listdir(folder_path):
+            os.remove(os.path.join(folder_path, file_path))
+    except:
+        mp_print("Somehow couldn't empty folder %s." % folder_path)
+
+
+def removePickledTrees(pickleFolder, removeDir=False, notRemove=None, base=None):
+    try:
+        for intFile in os.listdir(pickleFolder):
+            if (base is not None) and (intFile.split('_')[0] != base):
+                continue
+            if notRemove is not None:
+                index_string = intFile.split('.')[0].split('_')[-1]
+                if index_string.isdigit() and (int(index_string) in [notRemove, notRemove - 1]):
+                    continue
+            os.remove(os.path.join(pickleFolder, intFile))
+    except:
+        mp_print("Somehow couldn't remove pickled intermediate trees.")
+    if removeDir:
+        try:
+            for intFile in os.listdir(pickleFolder):
+                os.remove(os.path.join(pickleFolder, intFile))
+            os.rmdir(pickleFolder)
+        except FileNotFoundError or OSError:
+            mp_print("Process %d: Apparently, folder %s was already removed." % (
+                mpi_wrapper.get_process_rank(), pickleFolder))
+
+
+def recursionWrap(fun, *args, **kwargs):
+    with RecursionLimit():
+        result = fun(*args, **kwargs)
+    return result
+
+
+def set_recursion_limits(new_limit):
+    if sys.platform.startswith('linux'):
+        old_resourcelimit = resource.getrlimit(resource.RLIMIT_STACK)
+        # resource.setrlimit(resource.RLIMIT_STACK, (2**29, -1))
+        resource.setrlimit(resource.RLIMIT_STACK, (old_resourcelimit[0], resource.RLIM_INFINITY))
+    old_limit = sys.getrecursionlimit()
+    sys.setrecursionlimit(max(old_limit, new_limit))
+
+
+class RecursionLimit:
+    limit = 10 ** 6
+    old_limit = None
+    old_resourcelimit = None
+
+    def __init__(self, limit=None):
+        if limit is not None:
+            self.limit = limit
+
+    def __enter__(self):
+        if sys.platform.startswith('linux'):
+            self.old_resourcelimit = resource.getrlimit(resource.RLIMIT_STACK)
+            # resource.setrlimit(resource.RLIMIT_STACK, (2**29, -1))
+            resource.setrlimit(resource.RLIMIT_STACK, (resource.RLIM_INFINITY, resource.RLIM_INFINITY))
+        self.old_limit = sys.getrecursionlimit()
+        sys.setrecursionlimit(10 ** 6)
+
+    def __exit__(self, type, value, tb):
+        sys.setrecursionlimit(self.old_limit)
+        if sys.platform.startswith('linux'):
+            resource.setrlimit(resource.RLIMIT_STACK, self.old_resourcelimit)
+
+
+def broadcastRecursiveStruct(recursiveStruct, root=0):
+    try:
+        recursiveStruct = mpi_wrapper.bcast(recursiveStruct, root=root)
+    except RecursionError:
+        with RecursionLimit():
+            recursiveStruct = mpi_wrapper.bcast(recursiveStruct, root=root)
+    return recursiveStruct
+
+
+def time_format():
+    now = datetime.now()
+    timestr = now.strftime("%H:%M:%S")
+    return f'{timestr}|> '
+
+
+def convert_dict_to_named_tuple(d):
+    namedTupleConstructor = namedtuple('myNamedTuple', ' '.join(sorted(d.keys())))
+    nt = namedTupleConstructor(**d)
+    return nt
+
+
+def is_numeric(value):
+    try:
+        float(value)
+        return True
+    except ValueError:
+        return False
+
+
+# Kruskal's algorithm in Python
+class OwnGraph:
+    def __init__(self, vertices):
+        self.V = vertices
+        self.graph = []
+
+    def add_edge(self, u, v, w):
+        self.graph.append([u, v, w])
+
+    # Search function
+
+    def find(self, parent, i):
+        if parent[i] == i:
+            return i
+        return self.find(parent, parent[i])
+
+    def apply_union(self, parent, rank, x, y):
+        xroot = self.find(parent, x)
+        yroot = self.find(parent, y)
+        if rank[xroot] < rank[yroot]:
+            parent[xroot] = yroot
+        elif rank[xroot] > rank[yroot]:
+            parent[yroot] = xroot
+        else:
+            parent[yroot] = xroot
+            rank[xroot] += 1
+
+    #  Applying Kruskal algorithm
+    def kruskal_algo(self, verbose=True, very_verbose=False):
+        result = []
+        i, e = 0, 0
+        self.graph = sorted(self.graph, key=lambda item: item[2])
+        parent = []
+        rank = []
+        for node in range(self.V):
+            parent.append(node)
+            rank.append(0)
+        while e < self.V - 1:
+            u, v, w = self.graph[i]
+            i = i + 1
+            x = self.find(parent, u)
+            y = self.find(parent, v)
+            if x != y:
+                if verbose and ((e + 1) % 1000 == 0):
+                    print("Adding edge " + str(e + 1) + " out of " + str(self.V - 1))
+                e = e + 1
+                result.append([u, v, w])
+                self.apply_union(parent, rank, x, y)
+        if very_verbose:
+            for u, v, weight in result:
+                print("%d - %d: %d" % (u, v, weight))
+        return result
+
+    def kruskal_algo_maxdegree_two(self, verbose=True, very_verbose=False):
+        result = []
+        i, e = 0, 0
+        self.graph = sorted(self.graph, key=lambda item: item[2])
+        parent = []
+        rank = []
+        degree = []
+        for node in range(self.V):
+            parent.append(node)
+            rank.append(0)
+            degree.append(0)
+        while e < self.V - 1:
+            u, v, w = self.graph[i]
+            i = i + 1
+            x = self.find(parent, u)
+            y = self.find(parent, v)
+            if x != y:
+                if (degree[u] < 2) and (degree[v] < 2):
+                    if verbose and ((e + 1) % 1000 == 0):
+                        print("Adding edge " + str(e + 1) + " out of " + str(self.V - 1))
+                    e = e + 1
+                    result.append([u, v])
+                    self.apply_union(parent, rank, x, y)
+                    degree[u] += 1
+                    degree[v] += 1
+        if very_verbose:
+            for u, v in result:
+                print("%d - %d" % (u, v))
+        return result
+
+
+def add_celltype_info_to_tree(treenode, cell_id_to_ct):
+    if treenode.nodeId in cell_id_to_ct:
+        treenode.celltype = cell_id_to_ct[treenode.nodeId]
+    else:
+        treenode.celltype = 'unknown'
+    for child in treenode.childNodes:
+        add_celltype_info_to_tree(child, cell_id_to_ct)
+
+
+def read_ids(filepath):
+    if not os.path.exists(filepath):
+        logger.error("Can't find IDs stored at {}.".format(filepath))
+        return []
+    ids = []
+    with open(filepath, 'r') as file:
+        reader = csv.reader(file, delimiter="\t")
+        for row in reader:
+            ids.append(row[0])
+    return ids
+
+
+def write_ids(filepath, ids_list):
+    with open(filepath, 'w') as f:
+        for ID in ids_list:
+            f.write("%s\n" % ID)
+
+
+def print_memory(location=None):
+    import psutil
+    import tracemalloc
+    import resource
+    message = ''
+    if location is not None:
+        message += "{}: ".format(location)
+    # mp_print("Current RSS memory usage is ",
+    #       psutil.Process(os.getpid()).memory_info().rss / 1024 ** 2, " MB.", ALL_RANKS=True)
+    # print("Current shared memory usage is ",
+    #       psutil.Process(os.getpid()).memory_info().shared / 1024 ** 2, " MB.")
+    current, peak = tracemalloc.get_traced_memory()
+    tracemalloc.reset_peak()
+    message += "Current-mem: {} MB, Peak-mem since last: {} MB".format(current / 1000 ** 2, peak / 1000 ** 2)
+    # mp_print("Python data segment =",
+    #       resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024 ** 2, "MB", ALL_RANKS=True)
+    mp_print(message, ALL_RANKS=True)
+
+
+def store_scdata_and_communicate_path(scData, specific_results_folder, general_results_folder=None, prefix=None,
+                                      with_coords=True):
+    mpi_info = mpi_wrapper.get_mpi_info()
+    if mpi_info.rank == 0:
+        no_scdata_path = True
+        while no_scdata_path:
+            if prefix is None:
+                subfoldername = 'scdata_state_{}'.format(np.random.randint(1e6))
+            else:
+                subfoldername = prefix + '_' + 'scdata_state_{}'.format(np.random.randint(1e6))
+            if general_results_folder is None:
+                scdata_path = scData.result_path(os.path.join(specific_results_folder, subfoldername))
+            else:
+                scdata_path = os.path.join(general_results_folder, specific_results_folder, subfoldername)
+            if not os.path.exists(scdata_path):
+                no_scdata_path = False
+        # We store the tree to make sure we have the data of all vertices
+        scData.storeTreeInFolder(os.path.join(scdata_path), with_coords=with_coords, verbose=False, nwk=False)
+
+        # Communicate the path where scData is stored with the other processes. This also serves as a barrier between
+        # storing the tree and loading it on other processes
+        scdata_path = mpi_wrapper.bcast(scdata_path, root=0)
+    else:
+        scdata_path = None
+        # Other processes receive the path to scData
+        scdata_path = mpi_wrapper.bcast(scdata_path, root=0)
+    return scdata_path
+
+
+def look_for_output_folder(specific_results_folder, general_results_folder=None, prefix=None):
+    if general_results_folder is not None:
+        full_path = os.path.join(general_results_folder, specific_results_folder)
+    else:
+        full_path = specific_results_folder
+
+    full_path = Path(full_path)
+
+    if not full_path.exists() or not full_path.is_dir():
+        return False, None
+
+    subfolders = [p for p in full_path.iterdir() if p.is_dir() and (prefix is None or p.name.startswith(prefix))]
+    if len(subfolders) == 0:
+        return False, None
+
+    # Return the folder that was last modified
+    scdata_path = max(subfolders, key=lambda p: p.stat().st_mtime)
+    return True, scdata_path

--- a/omicverse/external/bonsai/bonsai/bonsai_main.py
+++ b/omicverse/external/bonsai/bonsai/bonsai_main.py
@@ -1,0 +1,699 @@
+from argparse import ArgumentParser
+import numpy as np
+import time
+from pathlib import Path
+import os, sys, psutil, gc
+
+# TODO: Remove this later maybe
+# import tracemalloc
+#
+# tracemalloc.start()
+
+
+if sys.platform == "win32":
+    import types
+    m = types.ModuleType("resource")
+    m.RLIMIT_AS = 0
+    m.RUSAGE_SELF = 0
+    m.getrusage = lambda x: types.SimpleNamespace(
+        ru_maxrss=0, ru_utime=0, ru_stime=0
+    )
+    m.setrlimit = lambda x, y: None
+    sys.modules["resource"] = m
+
+from .bonsai_helpers import Run_Configs, remove_tree_folders, find_latest_tree_folder_new, str2bool, \
+    store_scdata_and_communicate_path
+
+
+def main(args):
+    """Run Bonsai end to end.
+
+    Wrapped by omicverse: upstream ran this body at module level, which made
+    the module impossible to import without executing a whole run. ``args`` is
+    the namespace upstream's ArgumentParser produced, so the block under
+    ``__main__`` below still reproduces the original command-line behaviour.
+    """
+
+    pickup_intermediate = args.pickup_intermediate
+    # TODO: Remove
+    store_all_nwk_folder = args.store_all_nwk_folder
+    print_annotations = args.print_annotations
+
+    args = Run_Configs(args.config_filepath, step=args.step)
+
+    if pickup_intermediate:
+        args.pickup_intermediate = True
+
+    from . import mpi_wrapper as mpi_wrapper
+    from .bonsai_dataprocessing import initializeSCData, getMetadata, loadReconstructedTreeAndData, SCData, \
+        nnnReorder, nnnReorderRandom, do_spr_moveset
+    from .bonsai_helpers import mp_print, startMPI, getOutputFolder, get_latest_intermediate, \
+        clean_up_redundant_data_files, str2bool
+    from . import bonsai_globals as bs_glob
+
+    # TODO: Remove eventually, only uncomment this for making animations
+    if len(store_all_nwk_folder):
+        bs_glob.nwk_counter = 1
+        bs_glob.nwk_folder = os.path.join(store_all_nwk_folder, args.dataset)
+        Path(bs_glob.nwk_folder).mkdir(parents=True, exist_ok=True)
+    else:
+        bs_glob.nwk_counter = None
+        bs_glob.nwk_folder = None
+
+    # Some of the code can be run in parallel, parallelization is done via mpi4py
+    mpiRank, mpiSize = startMPI(args.verbose)
+    scData = None
+    startGML = None
+    ellipsoidSize = args.UB_ellipsoid_size if (args.UB_ellipsoid_size > 0) else None
+    origEllipsoidSize = ellipsoidSize
+
+    # The SEQUENTIAL-variables determines whether we first optimise diff. times between merged nodes, and then to ancestor
+    # from root, or all three at the same time. SEQUENTIAL=True is faster and leads to better tree likelihoods in tests
+    SEQUENTIAL = True
+    STORED_GREEDY_RESULT = False
+
+    start_all = time.time()
+    # print_memory("Start")
+
+    # Make sure that args.results_folder is set:
+    sc_data = SCData(onlyObject=True, dataset=args.dataset, results_folder=args.results_folder)
+    args.results_folder = sc_data.result_path()
+    del sc_data
+
+    """-----------------Greedily maximizing tree likelihood starting from star-tree------"""
+    if args.step in ['preprocess', 'all']:
+        outputFolder = getOutputFolder(zscore_cutoff=args.zscore_cutoff, greedy=False,
+                                       redo_starry=False, opt_times=False, tmp_file=os.path.basename(args.tmp_folder))
+        # If args.pickup_intermediate and preprocessing result is already present, we skip this step.
+        preprocessing_done = False
+        if args.pickup_intermediate:
+            try:
+                scData = loadReconstructedTreeAndData(args, outputFolder, reprocess_data=False, all_genes=False,
+                                                      get_cell_info=False,
+                                                      all_ranks=False, rel_to_results=True)
+                mp_print("Since --pickup_intermediate = True, Bonsai successfully loaded the preprocessing result from {}."
+                         "\nPlease set --pickup_intermediate False "
+                         "for redoing the preprocessing.".format(scData.result_path(outputFolder)))
+                preprocessing_done = True
+            except Exception as error:
+                mp_print("Encountered an error when trying to pick up the preprocessing "
+                         "results from a previous run: {}".format(error))
+                mp_print("Even though --pickup_intermediate = True, Bonsai could not load the preprocessing result from "
+                         "{}. Bonsai will now re-do the "
+                         "preprocessing.".format(os.path.join(args.results_folder, outputFolder)),
+                         WARNING=True)
+
+        if not preprocessing_done:
+            # Read in data and do initial time optimisation for star-tree
+            if len(args.tmp_folder):
+                if os.path.isdir(args.tmp_folder):
+                    # scData = recoverTmpTree(args, args.tmp_folder, optimizeTimes=True)
+                    scData = loadReconstructedTreeAndData(args, args.tmp_folder, all_genes=False, get_cell_info=False,
+                                                          corrected_data=True)
+                else:
+                    mp_print("Could not find tmp-folder at {}. Loading tree from start.".format(args.tmp_folder),
+                             ERROR=True)
+                    scData = initializeSCData(args, createStarTree=True, getOrigData=False, otherRanksMinimalInfo=True)
+            else:
+                scData = initializeSCData(args, createStarTree=True, getOrigData=False, otherRanksMinimalInfo=True)
+
+            # Store run configurations in YAML-file in output-folder
+            args.store_yaml(scData.result_path('used_run_configs.yaml'))
+
+            if mpiRank == 0:
+                # Store tree topology with optimised times, and the data only for selected genes, such that it can be read
+                # in by multiple cores such that the next part of the program can be run in parallel
+                mp_print("Storing result of preprocessing in " + scData.result_path(outputFolder) + "\n\n")
+                scData.storeTreeInFolder(scData.result_path(outputFolder), with_coords=True, verbose=args.verbose,
+                                         cleanup_tree=False)
+        if args.step in ['preprocess']:
+            exit()
+
+    # print_memory("After preprocessing.")
+
+    if args.step in ['core_calc', 'all']:
+        if scData is None:
+            scDataTmp = SCData(onlyObject=True, dataset=args.dataset, results_folder=args.results_folder)
+        results_folder = scData.result_path() if (scData is not None) else scDataTmp.result_path()
+
+        if args.pickup_intermediate:
+            # If args.pickup_intermediate, we first check which steps already successfully finished in the previous run, by
+            # checking the output-folder that is furthest along. We will then pick up the reconstruction there.
+            outputFolder = find_latest_tree_folder_new(args, results_folder, not_final=False, set_skip_args=True)
+            # outputFolder2 = find_latest_tree_folder(results_folder, not_final=True)
+
+        if args.skip_greedy_merging:
+            mp_print("Skipping greedy merging, since --pickup_intermediate is True, and "
+                     "the results of this step are already present in {}".format(results_folder))
+        else:
+            # Determine where to load the results
+            outputFolder = getOutputFolder(zscore_cutoff=args.zscore_cutoff, greedy=False,
+                                           redo_starry=False, opt_times=False, tmp_file=os.path.basename(args.tmp_folder))
+            if scData is None:
+                scData = loadReconstructedTreeAndData(args, outputFolder, reprocess_data=False, all_genes=False,
+                                                      get_cell_info=False,
+                                                      all_ranks=False, rel_to_results=True)
+
+            # TODO: Remove this later. Only uncomment this for printing cell-annotations
+            # if len(print_annotations) > 0:
+            #     cell_info_df, data_matrices = scData.get_annotations(print_annotations)
+            #     cell_id_to_ct = dict(zip(list(cell_info_df.index), list(cell_info_df.iloc[:, 0].values)))
+            #     add_celltype_info_to_tree(scData.tree.root, cell_id_to_ct)
+            #     bs_glob.geneIds = scData.metadata.geneIds
+
+            if args.verbose:
+                mp_print("Starting to greedily merge nodes to maximise tree likelihood.")
+
+            # TODO: Remove eventually, only uncomment this for making animations
+            # if (args.step == 'core_calc') and (bs_glob.nwk_folder is not None):
+            #     all_nwk_files = [os.path.basename(filepath) for filepath in Path(bs_glob.nwk_folder).glob('*.nwk')]
+            #     tree_nums = [int(nwk_file.split('.nwk')[0].split('_')[-1]) for nwk_file in all_nwk_files]
+            #     bs_glob.nwk_counter = np.max(tree_nums) + 1
+
+            if mpiRank == 0 and args.verbose:
+                mp_print("Loaded tree loglikelihood is:",
+                         scData.tree.calcLogLComplete(mem_friendly=True, loglikVarCorr=scData.metadata.loglikVarCorr))
+            startGML = time.time()
+            outputFolder = getOutputFolder(zscore_cutoff=args.zscore_cutoff, greedy=True,
+                                           redo_starry=False, opt_times=False, tmp_file=os.path.basename(args.tmp_folder))
+            outputFolder = scData.result_path(outputFolder)
+            tmpTreeInd = None
+            tmp_folder = os.path.join(outputFolder, 'tmp_trees')
+            if (mpiRank == 0) and args.pickup_intermediate and os.path.exists(tmp_folder):
+                intermediateFolders = os.listdir(tmp_folder)
+                if len(intermediateFolders):
+                    intermediateFolder, tmpTreeInd = get_latest_intermediate(intermediateFolders, base='greedy')
+                    if intermediateFolder is not None:
+                        # scData.tree = unpickleTree(tmp_folder, intermediateFile)
+                        scData = loadReconstructedTreeAndData(args, os.path.join(tmp_folder, intermediateFolder),
+                                                              reprocess_data=False, all_genes=False, get_cell_info=False,
+                                                              all_ranks=False, rel_to_results=False, calc_loglik=True)
+            Path(tmp_folder).mkdir(parents=True, exist_ok=True)
+            nChildNN = -1 if args.use_knn < 0 else 50
+            scData.tree.root.mergeChildrenUB(scData.tree.root.ltqs, scData.tree.root.getW(), scData=scData,
+                                             sequential=SEQUENTIAL, verbose=args.verbose,
+                                             ellipsoidSize=origEllipsoidSize, outputFolder=outputFolder, nChildNN=nChildNN,
+                                             kNN=args.use_knn, mergeDownstream=True, tree=scData.tree,
+                                             tmpTreeInd=tmpTreeInd)
+            if (scData is not None) and (scData.tree is not None):
+                scData.tree.root.clear_memory()
+            if mpiRank == 0:
+                mp_print("First greedy maximisation of tree likelihood took " + str(time.time() - startGML) + " seconds.")
+                scData.metadata.loglik = scData.tree.calcLogLComplete(mem_friendly=True,
+                                                                      loglikVarCorr=scData.metadata.loglikVarCorr)
+                mp_print("Loglikelihood of tree after first greedy optimisation: " + str(scData.metadata.loglik))
+                # Store intermediate results in merge-file.
+
+                # TODO: Remove eventually, only uncomment this for making animations
+                # if (mpi_wrapper.get_process_rank() == 0) and bs_glob.nwk_counter:
+                #     bs_glob.nwk_counter += 100
+
+                outputFolder = getOutputFolder(zscore_cutoff=args.zscore_cutoff,
+                                               greedy=True, redo_starry=False, opt_times=False,
+                                               tmp_file=os.path.basename(args.tmp_folder))
+
+                mp_print("Storing result of greedy optimisation in " + scData.result_path(outputFolder) + "\n\n")
+
+                # Store tree topology with optimised times, and the data only for selected genes, such that it can be read
+                # in by multiple cores such that the next part of the program can be run in parallel
+                # storeCurrentState(outputFolder, scData, dataOrResults='results', filename='tmp_tree.dat', args=args)
+                scData.storeTreeInFolder(scData.result_path(outputFolder), with_coords=True, verbose=args.verbose)
+                STORED_GREEDY_RESULT = True
+
+        # We can go over the tree once more to see whether some nodes have more than 2 children and are therefore candidates
+        # for adding an additional ancestor
+        """---------------------Redoing starry nodes."""
+        if args.skip_redo_starry:
+            mp_print("Skipping redoing starry-nodes (resolving polytomies), since --pickup_intermediate is True, and "
+                     "the results of this step are already present in {}".format(results_folder))
+        else:
+            mpi_wrapper.barrier()
+            # Determine where to load results from
+            outputFolder = getOutputFolder(zscore_cutoff=args.zscore_cutoff,
+                                           redo_starry=False, opt_times=False, tmp_file=os.path.basename(args.tmp_folder))
+            # Before doing the nnn_reordering, all processes must have the latest tree topology, but not the data. Before,
+            # the tree topology was only necessary on process 0. Therefore, we will load the results from the just stored
+            # file on process 0, and send only the tree topology to other processes.
+            if (mpiRank != 0) or (not STORED_GREEDY_RESULT):
+                scData = loadReconstructedTreeAndData(args, outputFolder, reprocess_data=False, all_genes=False,
+                                                      get_cell_info=False, all_ranks=False, rel_to_results=True)
+
+            startRedoingStarry = time.time()
+            scData.tree.root.mergeZeroTimeChilds()
+            scData.tree.root.renumberNodes(change_node_inds=False)  # Some nodes may have merged, need to renumber them
+            scData.tree.nNodes = bs_glob.nNodes
+
+            # Then start merging
+            if mpiRank == 0:
+                scData.tree.root.getAIRootInfo(None, None)
+            nChildNN = -1 if args.use_knn < 0 else 50
+            scData.tree.root.mergeChildrenRecursive(scData.tree.root.ltqs, scData.tree.root.getW(),
+                                                    sequential=SEQUENTIAL, verbose=args.verbose,
+                                                    ellipsoidSize=origEllipsoidSize, nChildNN=nChildNN, kNN=args.use_knn,
+                                                    mergeDownstream=True, tree=scData.tree)
+            if (scData is not None) and (scData.tree is not None):
+                scData.tree.root.clear_memory()
+            if mpiRank == 0:
+                mp_print("Redoing starry nodes took " + str(time.time() - startRedoingStarry) + " seconds.")
+                scData.metadata.loglik = scData.tree.calcLogLComplete(mem_friendly=True,
+                                                                      loglikVarCorr=scData.metadata.loglikVarCorr)
+                mp_print("Loglikelihood of inferred tree after redoing starry nodes: " + str(scData.metadata.loglik))
+
+            # Store intermediate results.
+            outputFolder = getOutputFolder(zscore_cutoff=args.zscore_cutoff,
+                                           redo_starry=True, opt_times=False, tmp_file=os.path.basename(args.tmp_folder))
+            mp_print("Storing result after redoing starry nodes in " + scData.result_path(outputFolder) + "\n\n")
+            scData.storeTreeInFolder(scData.result_path(outputFolder), with_coords=True, verbose=args.verbose)
+            # storeCurrentState(outputFolder, scData, dataOrResults='results', args=args)
+
+            # TODO: Remove eventually, only uncomment this for making animations
+            # if (mpi_wrapper.get_process_rank() == 0) and bs_glob.nwk_counter:
+            #     bs_glob.nwk_counter += 100
+
+        """--------------------Optimise all times on the tree to finalise the tree reconstruction """
+        if args.skip_opt_times:
+            mp_print("Skipping optimizing times, since --pickup_intermediate is True, and "
+                     "the results of this step are already present in {}".format(results_folder))
+        else:
+            # Time optimization is not parallelized. Only do this on process 0
+            if mpiRank == 0:
+                mp_print("Starting final optimization of all diffusion times.")
+                if scData is None or args.skip_greedy_merging:
+                    # Determine where to load results from
+                    outputFolder = getOutputFolder(zscore_cutoff=args.zscore_cutoff,
+                                                   redo_starry=True, opt_times=False,
+                                                   tmp_file=os.path.basename(args.tmp_folder))
+                    scData = loadReconstructedTreeAndData(args, outputFolder, reprocess_data=False, all_genes=False,
+                                                          get_cell_info=False, all_ranks=False, rel_to_results=True)
+
+                startOptTimes = time.time()
+                optTimes = scData.tree.optTimes(verbose=True, singleProcess=True, mem_friendly=True, maxiter=100)
+
+                if (scData is not None) and (scData.tree is not None):
+                    scData.tree.root.clear_memory()
+                mp_print("Optimization of diffusion times took " + str(time.time() - startOptTimes) + " seconds.")
+                scData.metadata.loglik = scData.tree.calcLogLComplete(mem_friendly=True,
+                                                                      loglikVarCorr=scData.metadata.loglikVarCorr)
+                mp_print("Loglikelihood of inferred tree after optimising diffusion times: " + str(scData.metadata.loglik))
+
+                # self.metadata.geneVariances = self.tree.optGeneVars(scData.metadata.geneVariances, verbose=True, singleProcess=True, genesSimultaneously=True)
+                # self.metadata.loglikVarCorr = - self.metadata.nCells * np.sum(np.log(self.metadata.geneVariances))
+
+                # Store intermediate results in merge-file.
+                outputFolder = getOutputFolder(zscore_cutoff=args.zscore_cutoff,
+                                               redo_starry=True, opt_times=True, tmp_file=os.path.basename(args.tmp_folder))
+                mp_print("Storing result after optimising diffusion times in " + scData.result_path(outputFolder) + "\n")
+                scData.storeTreeInFolder(scData.result_path(outputFolder), with_coords=True, verbose=args.verbose)
+                # Store tree topology with optimised times, and the data only for selected genes, such that it can be read in
+                # by multiple cores such that the next part of the program can be run in parallel
+                # storeCurrentState(outputFolder, scData, dataOrResults='results', args=args)
+
+                # TODO: Remove eventually, only uncomment this for making animations
+                # if (mpiRank == 0) and bs_glob.nwk_counter and (scData.tree is not None):
+                #     scData.tree.to_newick(use_ids=True,
+                #                           results_path=os.path.join(bs_glob.nwk_folder,
+                #                                                     'tree_{}.nwk'.format(bs_glob.nwk_counter)))
+                #     bs_glob.nwk_counter += 1
+                # if (mpi_wrapper.get_process_rank() == 0) and bs_glob.nwk_counter:
+                #     bs_glob.nwk_counter += 100
+
+        """--------------------Optimise all times on the tree to finalise the tree reconstruction """
+        if args.skip_spr_moves:
+            mp_print("Skipping the SPR moves, since --pickup_intermediate is True, and "
+                     "the results of this step are already present in {}".format(results_folder))
+        else:
+            mp_print("Starting SPR moves.")
+            start_spr = time.time()
+            if mpiRank == 0:
+                if scData is None or args.skip_greedy_merging:
+                    # Determine where to load results from
+                    outputFolder = getOutputFolder(zscore_cutoff=args.zscore_cutoff,
+                                                   redo_starry=True, opt_times=True,
+                                                   tmp_file=os.path.basename(args.tmp_folder))
+                    scData = loadReconstructedTreeAndData(args, outputFolder, reprocess_data=False, all_genes=False,
+                                                          get_cell_info=False, all_ranks=False, rel_to_results=True,
+                                                          verbose=True)
+
+                rootsetting_success = scData.tree.set_mindist_root(cell_ids=scData.metadata.cellIds)
+                scData.metadata.loglik = scData.tree.calcLogLComplete(mem_friendly=True,
+                                                                      loglikVarCorr=scData.metadata.loglikVarCorr)
+                mp_print("Loglikelihood of inferred tree before starting SPR moves: " + str(scData.metadata.loglik))
+
+            # For memory usage reasons, it's best to here delete scData, then read it in using memmap in the SPR-moves
+            # function
+            scdata_path = store_scdata_and_communicate_path(scData, specific_results_folder='spr_intermediates',
+                                                            general_results_folder=args.results_folder)
+            scData = None
+            gc.collect()
+            # print_memory("Ready to start SPR moves")
+
+            # Do the actual moves here:
+            scData = do_spr_moveset(scdata_path, args, strategy=args.spr_strategy,
+                                    pickup_intermediate=args.pickup_intermediate)
+            # print_memory("Done with SPR moves")
+            if (scData is not None) and (scData.tree is not None):
+                scData.tree.root.clear_memory()
+
+            if mpiRank == 0:
+                scData.tree.remove_two_child_root()
+
+                mp_print("SPR moves took " + str(time.time() - start_spr) + " seconds.")
+                scData.metadata.loglik = scData.tree.calcLogLComplete(mem_friendly=True,
+                                                                      loglikVarCorr=scData.metadata.loglikVarCorr)
+                mp_print("Loglikelihood of inferred tree after SPR moves: " + str(scData.metadata.loglik))
+
+                # Store intermediate results in merge-file.
+                outputFolder = getOutputFolder(zscore_cutoff=args.zscore_cutoff, spr_moves=True,
+                                               redo_starry=True, opt_times=True, tmp_file=os.path.basename(args.tmp_folder))
+                mp_print("Storing result after SPR moves in " + scData.result_path(outputFolder) + "\n")
+                scData.storeTreeInFolder(scData.result_path(outputFolder), with_coords=True, verbose=args.verbose)
+
+                redundant_folder = scData.result_path('spr_intermediates')
+                if os.path.exists(redundant_folder):
+                    remove_tree_folders(redundant_folder, removeDir=True)
+
+                # Store tree topology with optimised times, and the data only for selected genes, such that it can be read
+                # by multiple cores such that the next part of the program can be run in parallel
+                # storeCurrentState(outputFolder, scData, dataOrResults='results', args=args)
+
+            # TODO: Remove eventually, only uncomment this for making animations
+            # if (mpiRank == 0) and bs_glob.nwk_counter and (scData.tree is not None):
+            #     scData.tree.to_newick(use_ids=True,
+            #                           results_path=os.path.join(bs_glob.nwk_folder,
+            #                                                     'tree_{}.nwk'.format(bs_glob.nwk_counter)))
+            #     bs_glob.nwk_counter += 1
+            # if (mpi_wrapper.get_process_rank() == 0) and bs_glob.nwk_counter:
+            #     bs_glob.nwk_counter += 100
+
+        """--------------------Do random re-ordering of next-nearest-neighbour-nodes """
+        if args.skip_nnn_reordering:
+            mp_print("Skipping Nearest-Neighbor interchanges, since --pickup_intermediate is True, and "
+                     "the results of this step are already present in {}".format(results_folder))
+        else:
+            # Before doing the nnn_reordering, all processes must have the latest tree, which was before only necessary on
+            # process 0. Therefore, we will just load the results from the just stored file here.
+
+            # Barrier to make sure that also process 0 is done with storing the results from optTimes
+            mpi_wrapper.barrier()
+            # Determine where to load results from
+            outputFolder = getOutputFolder(zscore_cutoff=args.zscore_cutoff, spr_moves=True,
+                                           redo_starry=True, opt_times=True, tmp_file=os.path.basename(args.tmp_folder))
+
+            mp_print("Starting re-ordering of next-nearest-neighbour-nodes.")
+            startNnnReorder = time.time()
+            np.random.seed(42)
+
+            scData = SCData(onlyObject=True, dataset=args.dataset, results_folder=args.results_folder)
+            # mp_print("Before starting nnnReorderRandom, memory usage is ",
+            #          psutil.Process(os.getpid()).memory_info().rss / 1024 ** 2, " MB.", ALL_RANKS=True)
+            stored_tree_ind, tmp_folder = nnnReorderRandom(args, outputFolder, verbose=args.verbose,
+                                                           randomMoves=args.nnn_n_randommoves,
+                                                           randomTries=args.nnn_n_randomtrees,
+                                                           resultsFolder=scData.result_path())
+
+            # TODO: Remove eventually, only uncomment this for making animations
+            # if (mpiRank == 0) and bs_glob.nwk_counter and (scData.tree is not None):
+            #     scData.tree.to_newick(use_ids=True,
+            #                           results_path=os.path.join(bs_glob.nwk_folder,
+            #                                                     'tree_{}.nwk'.format(bs_glob.nwk_counter)))
+            #     bs_glob.nwk_counter += 1
+            # if (mpi_wrapper.get_process_rank() == 0) and bs_glob.nwk_counter:
+            #     bs_glob.nwk_counter += 100
+
+            # mp_print("Before starting nnnReorder, memory usage is ",
+            #          psutil.Process(os.getpid()).memory_info().rss / 1024 ** 2, " MB.", ALL_RANKS=True)
+            scData = nnnReorder(args, tmp_folder, stored_tree_ind, maxMoves=1000, closenessBound=0.5, verbose=args.verbose)
+            if (scData is not None) and (scData.tree is not None):
+                scData.tree.root.clear_memory()
+
+            if mpiRank != 0:
+                mp_print("This process's job is done. Closing down.")
+                exit()
+            else:
+                bs_glob.nNodes = scData.tree.nNodes
+
+            mpiSize = 1
+            mp_print("Reordering next-to-nearest neighbours took " + str(time.time() - startNnnReorder) + " seconds.")
+            scData.metadata.loglik = scData.tree.calcLogLComplete(mem_friendly=True,
+                                                                  loglikVarCorr=scData.metadata.loglikVarCorr)
+            mp_print(
+                "Loglikelihood of inferred tree after next-to-nearest-neighbour reordering: " + str(scData.metadata.loglik))
+
+            startOptTimes = time.time()
+            mp_print("Starting a final optimization of diffusion times.")
+            optTimes = scData.tree.optTimes(verbose=True, mem_friendly=True, maxiter=100, singleProcess=True)
+            new_opt_times = scData.tree.test_for_zero_times(verbose=True, mem_friendly=True, singleProcess=True)
+            mp_print("Optimization of diffusion times took " + str(time.time() - startOptTimes) + " seconds.")
+            scData.metadata.loglik = scData.tree.calcLogLComplete(mem_friendly=True,
+                                                                  loglikVarCorr=scData.metadata.loglikVarCorr)
+            if (scData is not None) and (scData.tree is not None):
+                scData.tree.root.clear_memory()
+
+            mp_print("Loglikelihood of inferred tree after optimising diffusion times: " + str(scData.metadata.loglik))
+
+            # Store intermediate results
+            outputFolder = getOutputFolder(zscore_cutoff=args.zscore_cutoff, spr_moves=True,
+                                           redo_starry=True, opt_times=True, nnn_reorder=True,
+                                           tmp_file=os.path.basename(args.tmp_folder))
+            mp_print(
+                "Storing result after next-to-nearest neighbour reorder in " + scData.result_path(outputFolder) + "\n\n")
+            scData.storeTreeInFolder(scData.result_path(outputFolder), with_coords=True, verbose=args.verbose)
+            # storeCurrentState(outputFolder, scData, dataOrResults='results', args=args)
+
+            # TODO: Remove eventually, only uncomment this for making animations
+            # if (mpiRank == 0) and bs_glob.nwk_counter and (scData.tree is not None):
+            #     scData.tree.to_newick(use_ids=True,
+            #                           results_path=os.path.join(bs_glob.nwk_folder,
+            #                                                     'tree_{}.nwk'.format(bs_glob.nwk_counter)))
+            #     bs_glob.nwk_counter += 1
+
+        if (hasattr(args, 'skip_reorder_edges')) and args.skip_reorder_edges:
+            mp_print("Skipping reordering branches and resetting the root, since --pickup_intermediate is True, and "
+                     "the results of this step are already present in {}".format(results_folder))
+        else:
+            """----------------Swap children order to minimize cousin distance to improve visual apperance.--------------"""
+            # The tree likelihood is independent of swapping the left-right order of children of the same node, so everyone is
+            # free to choose their own order. We here try to minimize distances between 'cousins', but ladderizing the tree is
+            # another option.
+            if mpiRank == 0:
+                mp_print("Starting setting midpoint root and reordering (left-right order) of children of all nodes.")
+                if scData is None:
+                    # Determine where to load results from
+                    outputFolder = getOutputFolder(zscore_cutoff=args.zscore_cutoff, spr_moves=True,
+                                                   redo_starry=True, opt_times=True, nnn_reorder=True, reorderedEdges=False,
+                                                   tmp_file=os.path.basename(args.tmp_folder))
+                    scData = loadReconstructedTreeAndData(args, outputFolder, reprocess_data=False, all_genes=False,
+                                                          get_cell_info=False, all_ranks=False, rel_to_results=True)
+
+                start_setting_root = time.time()
+                rootsetting_success = scData.tree.set_mindist_root(cell_ids=scData.metadata.cellIds)
+                if not rootsetting_success:
+                    mp_print("Setting minimal-distance root didn't succeed, setting midpoint root instead.")
+                    scData.tree.set_midpoint_root()
+
+                mp_print("Setting root took " + str(time.time() - start_setting_root) + " seconds.")
+                # scData.metadata.loglik = scData.tree.calcLogLComplete(mem_friendly=True,
+                #                                                       loglikVarCorr=scData.metadata.loglikVarCorr)
+                # mp_print("Loglikelihood of inferred tree after reordering children: " + str(scData.metadata.loglik))
+
+                startReorderEdges = time.time()
+                nChildren = scData.tree.root.gatherInfoDepthFirst([])
+                scData.tree.root.deleteParentsWithOneChild()
+                scData.tree.root.mergeZeroTimeChilds()
+                scData.tree.root.renumberNodes(change_node_inds=False)
+                scData.tree.nNodes = bs_glob.nNodes
+                # scData.tree.root.reorderChildrenRoot(verbose=args.verbose, maxChild=8)
+                scData.tree.root.ladderize_in_main()
+                if (scData is not None) and (scData.tree is not None):
+                    scData.tree.root.clear_memory()
+
+                mp_print("Reordering children took " + str(time.time() - startReorderEdges) + " seconds.")
+                scData.metadata.loglik = scData.tree.calcLogLComplete(mem_friendly=True,
+                                                                      loglikVarCorr=scData.metadata.loglikVarCorr)
+                mp_print("Loglikelihood of inferred tree after reordering children: " + str(scData.metadata.loglik))
+
+                # Store intermediate results
+                outputFolder = getOutputFolder(zscore_cutoff=args.zscore_cutoff, spr_moves=True,
+                                               redo_starry=True, opt_times=True, nnn_reorder=True, reorderedEdges=True,
+                                               tmp_file=os.path.basename(args.tmp_folder))
+                mp_print("Storing result after reordering children in " + scData.result_path(outputFolder) + "\n\n")
+                scData.storeTreeInFolder(scData.result_path(outputFolder), with_coords=True, verbose=args.verbose)
+                # storeCurrentState(outputFolder, scData, dataOrResults='results', args=args)
+
+        if startGML is not None:
+            computationTime = time.time() - startGML
+            mp_print("Calculation took %f seconds." % computationTime)
+        else:
+            computationTime = np.nan
+
+    """--------------Storing final tree and storing some metadata-----------"""
+    if args.step in ['metadata', 'all']:
+        if args.step == 'metadata':
+            computationTime = np.nan
+        # outputFolder = getOutputFolder(zscore_cutoff=args.zscore_cutoff,
+        #                                redo_starry=(not args.skip_redo_starry), opt_times=(not args.skip_opt_times),
+        #                                reorderedEdges=True, tmp_file=os.path.basename(args.tmp_folder),
+        #                                nnn_reorder=(not args.skip_nnn_reordering))
+        if scData is None:
+            scDataTmp = SCData(onlyObject=True, dataset=args.dataset, results_folder=args.results_folder)
+        results_folder = scData.result_path() if (scData is not None) else scDataTmp.result_path()
+        if args.pickup_intermediate:
+            dir_path = getOutputFolder(zscore_cutoff=args.zscore_cutoff, tmp_file=os.path.basename(args.tmp_folder),
+                                       final=True)
+            if os.path.exists(os.path.join(results_folder, dir_path, 'vertInfo.txt')):
+                mp_print("\nYou set --pickup_intermediate True, but the final results folder is already present."
+                         "\nTree reconstruction thus seems to be finished.\n"
+                         "\nIf this is not the desired behaviour, please either"
+                         "\n - set --pickup_intermediate False, which will start "
+                         "the tree reconstruction from scratch, or "
+                         "\n - delete the results-folders of the steps that you want to and keep "
+                         "--pickup_intermediate True.", WARNING=True)
+                exit()
+
+        if scData is None:
+            # if type(args) is dict:
+            #     args = convert_dict_to_named_tuple(args)
+            scDataTmp = SCData(onlyObject=True, dataset=args.dataset, results_folder=args.results_folder)
+            results_folder = scDataTmp.result_path()
+        else:
+            results_folder = scData.result_path()
+        outputFolder = find_latest_tree_folder_new(args, results_folder, not_final=True)
+
+        if scData is None:
+            all_genes = False
+            scData = loadReconstructedTreeAndData(args, outputFolder, all_genes=all_genes, get_cell_info=False,
+                                                  reprocess_data=True, all_ranks=True, rel_to_results=True,
+                                                  no_data_needed=False, get_posterior_ltqs=True, otherRanksMinimalInfo=True,
+                                                  calc_posteriors=False)
+
+        # scDataUncorrected = loadReconstructedTreeAndData(args, outputFolder, reprocess_data=True, all_genes=False,
+        #                                                  all_ranks=False, get_cell_info=False, corrected_data=False,
+        #                                                  rel_to_results=True, no_data_needed=False, single_process=False,
+        #                                                  keep_original_data=False, calc_loglik=False, get_data=True)
+
+        if mpiRank == 0:
+            finalFolder = getOutputFolder(zscore_cutoff=args.zscore_cutoff, tmp_file=os.path.basename(args.tmp_folder),
+                                          final=True)
+            scData.storeTreeInFolder(scData.result_path(finalFolder), with_coords=True, verbose=args.verbose,
+                                     store_posterior_ltqs=True)
+            mp_print("\n\nStored final tree in " + scData.result_path(finalFolder) + ".\n\n")
+
+            metadata = getMetadata(args, scData, outputFolder, computationTime)
+            metadata.to_csv(os.path.join(scData.result_path(finalFolder), 'metadata_bonsai.txt'))
+            mp_print("Stored metadata in {}".format(os.path.join(scData.result_path(finalFolder), 'metadata_bonsai.txt')))
+
+            # Finally clean up some redundant data-files:
+            clean_up_redundant_data_files(scData, args, verbose=args.verbose)
+            redundant_folders = ['random_trees', 'intermediate_trees']
+            for redundant_folder in redundant_folders:
+                redundant_folder = scData.result_path(redundant_folder)
+                if os.path.exists(redundant_folder):
+                    remove_tree_folders(redundant_folder, removeDir=True)
+
+    mp_print("Time necessary for the whole calculation was {} seconds.".format(time.time() - start_all))
+    # print_memory("Memory usage after the whole calculation")
+
+
+
+def _build_parser():
+    """Upstream's ArgumentParser, lifted out of ``__main__`` so omicverse can
+    reuse it to build an args namespace without spawning a process."""
+    parser = ArgumentParser(
+        description='Infers a cell-tree to approximate the distances in gene expression space between cells in single'
+                    ' cell data.')
+    parser.add_argument('--config_filepath', type=str, default=None,
+                        help='Absolute (or relative to "bonsai-development") path to YAML-file that contains all arguments'
+                             'needed to run Bonsai.')
+    parser.add_argument('--step', type=str, default='all',
+                        help='Optional: Use this argument to run all or only a single step of the script, continuing from '
+                             'the state of the previous step. Can be used when parallelizing on HPC-clusters, because '
+                             'mostly core_calc benefits from parallelization, and preprocess has the highest memory '
+                             'requirements.'
+                             'Allowed values (in order of execution): all, preprocess, core_calc, metadata.')
+    parser.add_argument('--pickup_intermediate', type=str2bool, default=False,
+                        help='Optional: Set this argument to true if Bonsai needs to search in the indicated results-folder'
+                             'for the furthest developed tree reconstruction, and pick it up from there. If this argument'
+                             'is True, it over-rules the same argument in bonsai_config.yaml, and the other way around.')
+    # TODO: To be removed
+    parser.add_argument('--store_all_nwk_folder', type=str, default='',
+                        help='REMOVE LATER! This will slow down the program by storing a newick file after every change to'
+                             'the tree. This is only necessary for making a tree reconstruction animation.')
+    parser.add_argument('--print_annotations', type=str, default='',
+                        help='REMOVE LATER! Only for debugging, string given here should give path to annotation-folder.')
+    #
+    # # Arguments that define where to find the data and where to store results. Also, whether data comes from Sanity or not
+    # parser.add_argument('--dataset', type=str, default='Zeisel',
+    #                     help='Name of dataset. This will determine name of results-folder that is created.')
+    # parser.add_argument('--data_folder', type=str, default='data',
+    #                     help='path to folder where input data can be found. This folder should contain a file with means'
+    #                          'and standard-deviations in files "delta.txt" and "d_delta.txt" unless argument '
+    #                          'filenames_data changes this behaviour.')
+    # parser.add_argument('--results_folder', type=str, default=None,
+    #                     help='path to folder where results will be stored.')
+    # parser.add_argument('--filenames_data', type=str, default='delta.txt,d_delta.txt',
+    #                     help='Filenames of input-files for means and standard deviations separated by a comma. '
+    #                          'These files should have different cells in the columns, and '
+    #                          'features (like gene expression quotients) as rows.')
+    # parser.add_argument('--input_is_sanity_output', type=str2bool, default=True,
+    #                     help='Whether we divide out Sanitys prior, to get likelihood of data given LTQs, instead of vice '
+    #                          'versa. This should be turned off when tree reconstruction is used on data that is not the'
+    #                          'output of Sanity.')
+    # parser.add_argument('--tmp_folder', type=str, default='',
+    #                     help='Foldername pointing towards tmp-file (absolute path). '
+    #                          'Relevant if one wants to start from an intermediate tree,'
+    #                          ' either for debugging reasons, or because the previous run did not finalize. This tmp-tree is'
+    #                          ' automatically stored as a file in the results-folder during a normal run.')
+    # parser.add_argument('--pickup_intermediate', type=str2bool, default=False,
+    #                     help='Decides whether we look for intermediate results from previous runs or not.')
+    # # parser.add_argument('--manual_merge', type=str, default='',
+    # #                     help='Filename pointing towards merge-file (relative to results-folder). '
+    # #                          'Relevant if one wants to quickly repeat the merge steps of an earlier run of the algorithm.')
+    #
+    # # Arguments that determine running configurations of bonsai. How much is printed, which steps are run?
+    # parser.add_argument('--verbose', type=str2bool, default=True,
+    #                     help='--verbose False only shows essential print messages (default: True)')
+    # parser.add_argument('--skip_greedy_merging', type=str2bool, default=False,
+    #                     help='Used to skip tree reconstruction when this is already done and stored')
+    #
+    # # Arguments that decide on how many genes are kept for the inference
+    # parser.add_argument('--zscore_cutoff', type=float, default=-1.,
+    #                     help='Genes with a variability under this cutoff will be dropped. Negative means: keep all.'
+    #                          'zscore_cutoff.')
+    #
+    # # Arguments that decide how much post-optimisation is done
+    # parser.add_argument("--skip_opt_times", type=str2bool, default=False,
+    #                     help="Decides whether all times are optimised after tree reconstruction.")
+    # parser.add_argument("--skip_redo_starry", type=str2bool, default=False,
+    #                     help="Decides whether, after the first greedy merging, for nodes with more than 2 children, "
+    #                          "pairs of children are considered for merge.")
+    # parser.add_argument("--use_knn", type=int, default=20,
+    #                     help="Decides whether nearest-neighbours are used to get candidate pairs to merge. Set to -1 for"
+    #                          "considering all pairs of leafs.")
+    # parser.add_argument("--skip_nnn_reordering", type=str2bool, default=False,
+    #                     help="Decides whether we go over edges and try to reconfigure all connected nodes (which are thus"
+    #                          "next-nearest-neighbours).")
+    # parser.add_argument("--nnn_n_randommoves", type=int, default=1000,
+    #                     help="Decides how many random nnn-moves we do before finally doing them greedily.")
+    # parser.add_argument("--nnn_n_randomtrees", type=int, default=1,
+    #                     help="Decides how many random trees we create before taking the best loglikelihood and doing nnn "
+    #                          "greedily.")
+    #
+    # # Arguments determining which computational speedups are done
+    # parser.add_argument("--UB_ellipsoid_size", type=float, default=-1,
+    #                     help="Decides whether we make an estimate of an upper bound (UB) for dLogL based on the current"
+    #                          "calculation, such that some calculations in the future may be skipped. If this arg < 0, this"
+    #                          "estimation will not be used. Otherwise, the argument decides how large the ellipsoid is in "
+    #                          "root-position/precision space for which we estimate the UB. Larger f will result in looser "
+    #                          "UB, so that more candidate pairs per merge have to be considered. However, it will also "
+    #                          "result in longer validity of the UB-estimation, so that more merges can be done without"
+    #                          "re-calculating the upper bounds. This is a computational optimization that should not affect "
+    #                          "the final result. Ellipsoid sizes below 5 are reasonable to try, I recommend to start at 2.")
+    #
+    # parser.add_argument("--rescale_by_var", type=str2bool, default=True,
+    #                     help="By default coordinates are rescaled by the inferred variance per gene (feature). This"
+    #                          "implicitly assumes that changes in highly-varying genes are more likely")
+    return parser
+
+
+if __name__ == "__main__":
+    main(_build_parser().parse_args())

--- a/omicverse/external/bonsai/bonsai/bonsai_treeHelpers.py
+++ b/omicverse/external/bonsai/bonsai/bonsai_treeHelpers.py
@@ -1,0 +1,5537 @@
+from .bonsai_helpers import *
+
+from . import bonsai_globals as bs_glob
+import numpy as np
+import time
+from scipy.optimize import brentq, minimize
+from scipy.spatial import distance
+from scipy.sparse import csr_array, lil_array
+import itertools
+import os
+import gc
+from itertools import permutations
+from .bonsai_approxNN import getApproxNNs
+import pandas as pd
+from ..downstream_analyses.get_clusters_max_diameter import get_min_pdists_clustering_from_nwk_str
+import json
+import heapq
+
+# TODO: Remove this
+
+
+class TreeNode:
+    nodeInd = None  # identifier index for the node
+    vert_ind = None  # will replace nodeInd for most purposes, however nodeInd is still useful in some cases
+    nodeId = None
+    tParent = None  # diffusion time to parent along tree
+    childNodes = None  # list with pointers to child TreeNode objects
+    parentNode = None
+    isLeaf = None
+    isRoot = None
+    isCell = None
+    dsLeafs = None
+    n_ds_nodes = None
+
+    # Position information
+    ltqs = None  # (Effective) coordinates of the (node) leaf
+
+    # W_g is 1/ltqsVars. We store both here, because it can be beneficial to precalculate this 1/ltqsVars
+    # We make sure that these two are consistent by making sure to put the other to None, whenever we update one. That's
+    # why they're only accessible through functions getW(), getLtqsVars() and set(LtqsVarsOrW()
+    _ltqsVars = None  # (Effective) variances of the (node) leaf
+    _W_g = None  # Precision of posterior of node position when all downstream nodes are integrated out
+
+    # Later it will be useful to let every node have its posterior position when all other nodes are integrated out.
+    # While ltqs, and ltqsVars are only its position when nodes downstream of it are integrated out
+    ltqsAIRoot = None
+    _ltqsVarsAIRoot = None
+    _W_gAIRoot = None
+    # This _AIRoot_version will be used when we only have to update part of the coordinates. By comparing to a higher
+    # version we can disqualify coordinates that are too old, and should be re-calculated
+    _AIRoot_version = -1
+    # This _spr_target_version will be used when we search for Subtree-Prune and Regraft targets. When starting from
+    # multiple startpoints, we update the version whenever we pass it, such that we don't do it again
+    _spr_target_version = -1
+    _spr_target_dlogl = None
+    _spr_target_opt_t = None
+
+    prefactor = None  # Prefactor that enters loglikelihood computation that can be started from root
+    dLoglikdtParent = None  # Derivative of total tree likelihood w.r.t. diff. time to parent
+
+    nnnLoglik = None  # Loglikelihood increase when next-nearest-neighbours of this node are reconfigured
+    cumClosenessNNN = None
+
+    def __init__(self, nodeInd=None, childNodes=None, parentNode=None, isLeaf=False, isRoot=False,
+                 ltqs=None, ltqsVars=None, tParent=None, nodeId=None, isCell=False, vert_ind=None):
+        self.childNodes = [] if (childNodes is None) else childNodes
+        self.nodeInd = nodeInd
+        self.nodeId = nodeId
+        self.tParent = tParent
+        self.parentNode = parentNode
+        self.isLeaf = isLeaf
+        self.isRoot = isRoot
+        self.ltqs = ltqs
+        self.setLtqsVarsOrW(ltqsVars=ltqsVars)
+        self.isCell = isCell
+        self.vert_ind = vert_ind
+
+    def __repr__(self):
+        return "TreeNode(\n" \
+               "nodeInd = %r \nnodeId = %r \n childNodes = %r \n parentNode = %r \ntParent = %r \nisLeaf = %r " \
+               "\nisRoot = %r \nisCell = %r \nltqs = %r \n_ltqsVars = %r \n_W_g = %r \nltqsAIRoot = %r " \
+               "\n_ltqsVarsAIRoot = %r \n_W_gAIRoot = %r \nprefactor = %r \ndLoglikdtParent = %r \nnnnLoglik = %r " \
+               "\ncumClosenessNNN = %r \n)" \
+               % (self.nodeInd, self.nodeId, [child.nodeInd for child in self.childNodes] if self.childNodes else None,
+                  self.parentNode.nodeInd if self.parentNode else None,
+                  self.tParent, self.isLeaf, self.isRoot,
+                  self.isCell, self.ltqs, self._ltqsVars, self._W_g, self.ltqsAIRoot, self._ltqsVarsAIRoot,
+                  self._W_gAIRoot, self.prefactor, self.dLoglikdtParent, self.nnnLoglik, self.cumClosenessNNN)
+
+    def to_newick_node(self, use_ids=True):
+        nwk_children = []
+        if use_ids and self.nodeId is None:
+            self.nodeId = 'new_node_id_{}'.format(self.nodeInd)
+        for child in self.childNodes:
+            nwk_children.append(child.to_newick_node())
+        if len(nwk_children) > 0:
+            nwk = ','.join(nwk_children)
+            nwk = '(' + nwk + ')'
+        else:
+            nwk = ''
+        if self.isRoot:
+            own_nwk = self.nodeId if use_ids else 'N' + str(self.nodeInd)
+        else:
+            own_nwk = self.nodeId + ':' + str(self.tParent) if use_ids else 'N' + str(self.nodeInd) + ':' + str(
+                self.tParent)
+        nwk = nwk + own_nwk
+        if self.isRoot:
+            return nwk + ';'
+        else:
+            return nwk
+
+    def get_max_node_ind(self, max_node_ind):
+        max_node_ind = max(max_node_ind, self.nodeInd)
+        for child in self.childNodes:
+            max_node_ind = child.get_max_node_ind(max_node_ind)
+
+        return max_node_ind
+
+    def get_edge_dict_node(self, edge_dict, nodeIdToVertInd=None):
+        for child in self.childNodes:
+            if nodeIdToVertInd is None:
+                edge_dict['source'].append(self.nodeId)
+                edge_dict['target'].append(child.nodeId)
+                edge_dict['dist'].append(child.tParent)
+                # new_row = {'source': self.nodeId, 'target': child.nodeId, 'dist': child.tParent}
+            else:
+                edge_dict['source'].append(self.nodeId)
+                edge_dict['target'].append(child.nodeId)
+                edge_dict['source_ind'].append(nodeIdToVertInd[self.nodeId])
+                edge_dict['target_ind'].append(nodeIdToVertInd[child.nodeId])
+                edge_dict['dist'].append(child.tParent)
+                # new_row = {'source': self.nodeId, 'source_ind': nodeIdToVertInd[self.nodeId], 'target': child.nodeId,
+                #            'target_ind': nodeIdToVertInd[child.nodeId], 'dist': child.tParent}
+            # edge_df = edge_df.append(new_row, ignore_index=True)
+            if not child.isLeaf:
+                edge_dict = child.get_edge_dict_node(edge_dict, nodeIdToVertInd=nodeIdToVertInd)
+        return edge_dict
+
+    def copy_node_topology(self):
+        node_copy = TreeNode(nodeInd=self.nodeInd, childNodes=[], parentNode=None, isLeaf=self.isLeaf,
+                             isRoot=self.isRoot, ltqs=None, ltqsVars=None, tParent=self.tParent, nodeId=self.nodeId,
+                             isCell=self.isCell)
+        for child in self.childNodes:
+            node_copy.childNodes.append(child.copy_node_topology())
+        return node_copy
+
+    def countDSLeafs(self, dsLeafs):
+        if self.isLeaf:
+            dsLeafs += 1
+        for child in self.childNodes:
+            dsLeafs = child.countDSLeafs(dsLeafs)
+        return dsLeafs
+
+    def getTotalTopology(self, centerLeafInd=None, use_cell_ids=False, center_leaf_id=None, with_times=False):
+        if self.isRoot:
+            self.storeParent()
+        centerLeaf, centerLeafFound = self.getCenterLeaf(centerLeafInd=centerLeafInd, use_cell_ids=use_cell_ids,
+                                                         center_leaf_id=center_leaf_id)
+        if with_times:
+            topology = centerLeaf.getTopologyWithTimes(use_cell_ids=use_cell_ids)
+        else:
+            topology = centerLeaf.getTopology(use_cell_ids=use_cell_ids)
+        center_leaf_info = centerLeaf.nodeId if use_cell_ids else centerLeaf.nodeInd
+        return topology, center_leaf_info
+
+    def getTopology(self, use_cell_ids=False, skip=[]):
+        topologies = []
+        if self.isLeaf:
+            if use_cell_ids:
+                topologies.append(self.nodeId)
+            else:
+                topologies.append(self.nodeInd)
+        for child in self.childNodes:
+            if child.nodeInd not in skip:
+                if child.isLeaf:
+                    if use_cell_ids:
+                        topologies.append(child.nodeId)
+                    else:
+                        topologies.append(child.nodeInd)
+                else:
+                    topologies.append(child.getTopology(use_cell_ids=use_cell_ids, skip=[self.nodeInd]))
+        if not self.isRoot:
+            if self.parentNode.nodeInd not in skip:
+                topologies.append(self.parentNode.getTopology(use_cell_ids=use_cell_ids, skip=[self.nodeInd]))
+        return frozenset(topologies)
+
+    def getTopologyWithTimes(self, use_cell_ids=False, skip=[]):
+        topologies = []
+        if self.isLeaf:
+            if use_cell_ids:
+                topologies.append((self.nodeId, self.tParent))
+            else:
+                topologies.append((self.nodeInd, self.tParent))
+        for child in self.childNodes:
+            if child.nodeInd not in skip:
+                if child.isLeaf:
+                    if use_cell_ids:
+                        topologies.append((child.nodeId, child.tParent))
+                    else:
+                        topologies.append((child.nodeInd, child.tParent))
+                else:
+                    topologies.append(
+                        (child.getTopologyWithTimes(use_cell_ids=use_cell_ids, skip=[self.nodeInd]), child.tParent))
+        if not self.isRoot:
+            if self.parentNode.nodeInd not in skip:
+                time = self.parentNode.tParent if (not self.parentNode.isRoot) else -1
+                topologies.append(
+                    (self.parentNode.getTopologyWithTimes(use_cell_ids=use_cell_ids, skip=[self.nodeInd]), time))
+        return frozenset(topologies)
+
+    def getCenterLeaf(self, centerLeafInd=None, use_cell_ids=False, center_leaf_id=None):
+        if self.isLeaf:
+            if use_cell_ids:
+                if (center_leaf_id is None) or (self.nodeId == center_leaf_id):
+                    return self, True
+                else:
+                    return None, False
+            else:
+                if (centerLeafInd is None) or (self.nodeInd == centerLeafInd):
+                    return self, True
+                else:
+                    return None, False
+        centerLeafFound = False
+        for child in self.childNodes:
+            if not centerLeafFound:
+                centerLeaf, centerLeafFound = child.getCenterLeaf(centerLeafInd=centerLeafInd,
+                                                                  use_cell_ids=use_cell_ids,
+                                                                  center_leaf_id=center_leaf_id)
+        return centerLeaf, centerLeafFound
+
+    def get_longest_path_ds(self, ignore_leaf_edge=True):
+        if self.isLeaf:
+            self.max_dist_ds = 0
+            self.max_summed_dist_ds = 0
+            return
+
+        max_dists = []
+        for child in self.childNodes:
+            child.get_longest_path_ds()
+            if child.isLeaf and ignore_leaf_edge:
+                max_dists.append(0)
+            else:
+                max_dists.append(child.tParent + child.max_dist_ds)
+
+        max_dists = np.array(max_dists)
+        node_idxs_partition = np.argpartition(a=-max_dists,
+                                              kth=1)  # all entries left of the kth element are smaller than the kth element, but not sorted
+        nodes_with_top_edgelength = node_idxs_partition[:2]
+        top_edge_lengths = max_dists[nodes_with_top_edgelength]
+        self.max_summed_dist_ds = np.sum(top_edge_lengths)
+        self.max_dist_ds = np.max(top_edge_lengths)
+
+    def find_midpoint_pair(self, max_summed_dist):
+        # First find child with maximum downstream path
+        for child_ind, child in enumerate(self.childNodes):
+            if abs(child.max_dist_ds + child.tParent - self.max_dist_ds) < 1e-9:
+                break
+        # Check if midpoint is between this node and child
+        if child.max_dist_ds < max_summed_dist / 2:
+            # If so, return this node and the index of the child
+            return self, child_ind
+        else:
+            # Go down to child and repeat
+            max_dist_node, child_ind = child.find_midpoint_pair(max_summed_dist)
+            return max_dist_node, child_ind
+
+    def get_vert_ind_to_node_node(self, vert_ind_to_node):
+        vert_ind_to_node[self.vert_ind] = self
+        for child in self.childNodes:
+            vert_ind_to_node = child.get_vert_ind_to_node_node(vert_ind_to_node)
+        return vert_ind_to_node
+
+    def reorderChildrenRoot(self, maxChild=8, verbose=False):
+        # Gather mean of ltqs of children
+        nChild = len(self.childNodes)
+        childrenLtqs = np.zeros((bs_glob.nGenes, len(self.childNodes)))
+        for ind, child in enumerate(self.childNodes):
+            childrenLtqs[:, ind] = child.ltqs
+        # Get distances between children
+        childDists = np.log(1e-6 + distance.pdist(childrenLtqs.T))
+
+        if nChild <= 3:  # In case there is only 3 children, there are no re-orderings possible
+            childSeq = self.childNodes
+        elif nChild <= maxChild:  # If the root does not have too many children, we can try all configurations
+            # Get all permutations of childInds up to cyclic permutations
+            allOrders = list(permutations(range(1, nChild)))
+            cyclicOrders = np.concatenate(
+                (np.array([0] * len(allOrders))[:, np.newaxis], np.array(allOrders)), axis=1)
+            # Get rid of orderings that are mirror images
+            child1 = cyclicOrders[0, 1]
+            child2 = cyclicOrders[0, 2]
+            cleanOrders = np.array(list(
+                filter(lambda ordering: np.where(ordering == child1)[0] < np.where(ordering == child2)[0],
+                       np.array(cyclicOrders))))
+            # We minimize the total distance between neighbours
+            totalDist = np.zeros(len(cleanOrders))
+            for order_ind, ordering in enumerate(cleanOrders):
+                for ind in range(len(ordering)):
+                    totalDist[order_ind] += childDists[get_pdist_inds(nChild, ordering[ind], ordering[ind - 1])]
+            childSeq = [self.childNodes[ind] for ind in cleanOrders[np.argmin(totalDist), :]]
+        else:
+            if verbose:
+                print("Too many branches from root to try all combinations."
+                      "Using greedy approach that might not reach global optimum.")
+            graph_kruskal = OwnGraph(nChild)
+            for cell1 in range(nChild):  # We add all child-child pairs as edges with as length their pdist
+                for cell2 in range(cell1 + 1, nChild):
+                    graph_kruskal.add_edge(cell1, cell2, childDists[get_pdist_inds(nChild, cell1, cell2)])
+            edges = graph_kruskal.kruskal_algo_maxdegree_two(very_verbose=False)  # Then we find the MST using Kruskal
+            edges = np.array(edges)
+            tmp, counts = np.unique(edges, return_counts=True)
+            childSeq = [tmp[counts == 1][0]]  # Find the node with only 1 connection, to start the cycle
+            while len(childSeq) < nChild:
+                row, col = np.where(childSeq[-1] == edges)
+                childSeq = childSeq + list(edges[row, 1 - col])
+                edges = np.delete(edges, row, axis=0)
+            childSeq = [self.childNodes[ind] for ind in childSeq]
+        self.childNodes = childSeq
+
+        # Now order grandchildren according to a similar scheme
+        for childInd, child in enumerate(self.childNodes):
+            child.reorderChildren(leftNeighbour=self.childNodes[(childInd - 1) % nChild], maxChild=maxChild,
+                                  rightNeighbour=self.childNodes[(childInd + 1) % nChild])
+
+    def ladderize_in_main(self):
+        if self.dsLeafs is None:
+            self.get_ds_info_for_ladderize(verbose=False)
+
+        if self.isLeaf:
+            return
+
+        # First get ladderized order
+        ds_leafs_ch = np.zeros(len(self.childNodes), dtype=int)
+        for ind, child in enumerate(self.childNodes):
+            ds_leafs_ch[ind] = child.dsLeafs
+        sorted_ch_inds_ladder = np.argsort(ds_leafs_ch)
+
+        # Then arrange the children in that order
+        self.childNodes = [self.childNodes[ind] for ind in sorted_ch_inds_ladder]
+
+        # Move on to do children
+        for child in self.childNodes:
+            child.ladderize_in_main()
+
+    def get_ds_info_for_ladderize(self, verbose=False):
+        if verbose and (self.vert_ind % 100000 == 0) and (self.vert_ind != 0):
+            logger.debug("Getting downstream information at vertex number {c:d}.".format(c=self.vert_ind))
+        if self.isLeaf:
+            self.dsLeafs = 1
+        else:
+            self.dsLeafs = 0
+            for child in self.childNodes:
+                dsLeafsCh = child.get_ds_info_for_ladderize(verbose=verbose)
+                self.dsLeafs += dsLeafsCh
+        return self.dsLeafs
+
+    def get_ds_node_counts(self):
+        if self.isLeaf:
+            self.n_ds_nodes = 1
+        else:
+            self.n_ds_nodes = 1
+            for child in self.childNodes:
+                n_ds_nodes_ch = child.get_ds_node_counts()
+                self.n_ds_nodes += n_ds_nodes_ch
+        return self.n_ds_nodes
+
+    def select_nth_node_df(self, nth_node, counter):
+        if counter == nth_node:
+            return self
+        for child in self.childNodes:
+            # Check if this child contains the desired node. This is only true when
+            # nth_node <= child.n_ds_nodes + counter
+            if nth_node <= counter + child.n_ds_nodes:
+                selected_node = child.select_nth_node_df(nth_node, counter + 1)
+                return selected_node
+            else:
+                counter += child.n_ds_nodes
+        exit("Something went wrong! Couldn't find the {} node on this tree.".format(nth_node))
+
+    def reset_root_node(self, parent_ind=None, old_tParent=None):
+        # Get all connecting nodes
+        new_children = []
+        new_parent = None
+        old_tParents = []
+        self.isRoot = False
+        for node in self.childNodes:
+            if node.vert_ind == parent_ind:
+                new_parent = node
+            else:
+                new_children.append(node)
+                old_tParents.append(node.tParent)
+        if self.parentNode is not None:
+            if self.parentNode.vert_ind == parent_ind:
+                new_parent = self.parentNode
+            else:
+                old_tParents.append(self.parentNode.tParent)
+                self.parentNode.tParent = old_tParent
+                new_children.append(self.parentNode)
+        if new_parent is not None:
+            self.parentNode = new_parent
+        else:
+            self.parentNode = None
+            self.tParent = None
+            self.isRoot = True
+        if len(new_children) == 0:
+            self.childNodes = []
+            # self.isLeaf = True
+        else:
+            self.isLeaf = False
+            self.childNodes = new_children
+        for ind, child in enumerate(self.childNodes):
+            child.reset_root_node(parent_ind=self.vert_ind, old_tParent=old_tParents[ind])
+
+    def reorderChildren(self, leftNeighbour, rightNeighbour, maxChild=8):
+        starryCounter = 0
+        # Gather mean of ltqs of children and left and rightNeighbour
+        if self.isLeaf:
+            return
+        nChild = len(self.childNodes)
+        childrenLtqs = np.zeros((bs_glob.nGenes, nChild + 2))
+        for ind, child in enumerate(self.childNodes):
+            childrenLtqs[:, ind + 1] = child.ltqs
+        childrenLtqs[:, 0] = leftNeighbour.ltqs
+        childrenLtqs[:, -1] = rightNeighbour.ltqs
+        # Get distances between children
+        childDists = distance.squareform(np.log(1e-9 + distance.pdist(childrenLtqs.T)))
+        if nChild <= maxChild:
+            # Get all permutations of childInds up to cyclic permutations
+            # Note that we permute 1,..,nChild, since 0 and nChild+1 are given by left and right neighbour
+            allOrders = list(permutations(range(1, nChild + 1)))
+            allOrders = np.concatenate((np.array([0] * len(allOrders))[:, np.newaxis], np.array(allOrders),
+                                        np.array([nChild + 1] * len(allOrders))[:, np.newaxis]), axis=1)
+            # We minimize the total distance between neighbours
+            totalDist = np.zeros(len(allOrders))
+            for order_ind, ordering in enumerate(allOrders):
+                for ind in range(1, len(ordering)):
+                    totalDist[order_ind] += childDists[ordering[ind], ordering[ind - 1]]
+            indSeq = allOrders[np.argmin(totalDist), :][1:-1] - 1
+            childSeq = [self.childNodes[ind] for ind in indSeq]
+        else:
+            starryCounter += 1
+            # Delete rows for leftNeighbour and rightNeighbour (first and last row)
+            leftNeighbourInd = 0
+            rightNeighbourInd = nChild + 1
+            childDists = np.delete(childDists, [leftNeighbourInd, rightNeighbourInd], axis=0)
+            remainingChildren = np.arange(nChild)
+
+            childSeqLeft = []
+            childSeqRight = []
+
+            # Now fill up childSeq by first adding the cell closest to either leftNeighbour or rightNeighbour
+            while childDists.shape[0] > 1:
+                closestLeft = np.argmin(childDists[:, leftNeighbourInd])  # who is closest to leftNeighbour
+                distLeft = childDists[closestLeft, leftNeighbourInd]
+                closestRight = np.argmin(childDists[:, rightNeighbourInd])
+                distRight = childDists[closestRight, rightNeighbourInd]
+
+                if distRight < distLeft:
+                    origChildInd = remainingChildren[closestRight]
+                    childSeqRight = [self.childNodes[
+                                         origChildInd]] + childSeqRight  # Add child on left of right childSeq
+                    rightNeighbourInd = 1 + origChildInd  # Replace rightNeighbourInd by just added child
+                    deletedChildInd = closestRight
+                else:
+                    origChildInd = remainingChildren[closestLeft]
+                    childSeqLeft = childSeqLeft + [
+                        self.childNodes[origChildInd]]  # Add child on right side of childOrder
+                    leftNeighbourInd = 1 + origChildInd  # Replace rightNeighbourInd by just added child
+                    deletedChildInd = closestLeft
+                childDists = np.delete(childDists, deletedChildInd, axis=0)  # Delete row for just added child
+                remainingChildren = np.delete(remainingChildren, deletedChildInd)
+
+            childSeqLeft = childSeqLeft + [self.childNodes[remainingChildren[0]]]  # Add last child in middle
+            childSeq = childSeqLeft + childSeqRight
+
+        self.childNodes = childSeq
+
+        # Now order grandchildren according to a similar scheme
+        for childInd, child in enumerate(self.childNodes):
+            leftNeighbourCh = leftNeighbour if childInd == 0 else self.childNodes[childInd - 1]
+            rightNeighbourCh = rightNeighbour if childInd == (nChild - 1) else self.childNodes[childInd + 1]
+            child.reorderChildren(leftNeighbour=leftNeighbourCh, rightNeighbour=rightNeighbourCh)
+
+    # Used
+    def setLtqsVarsOrW(self, ltqsVars=None, W_g=None, AIRoot=False):
+        if not AIRoot:
+            if ltqsVars is not None:
+                self._ltqsVars = ltqsVars
+                self._W_g = None
+            elif W_g is not None:
+                self._W_g = W_g
+                self._ltqsVars = None
+        else:
+            if ltqsVars is not None:
+                self._ltqsVarsAIRoot = ltqsVars
+                self._W_gAIRoot = None
+            elif W_g is not None:
+                self._W_gAIRoot = W_g
+                self._ltqsVarsAIRoot = None
+
+    # Used
+    def getLtqsVars(self, AIRoot=False, mem_friendly=False):
+        mem_friendly = mem_friendly or bs_glob.mem_friendly
+        if not AIRoot:
+            if self._ltqsVars is None:
+                if self._W_g is not None:
+                    self._ltqsVars = 1 / self._W_g
+                    if mem_friendly:
+                        self._W_g = None
+            return self._ltqsVars
+        else:
+            if self._ltqsVarsAIRoot is None:
+                if self._W_gAIRoot is not None:
+                    self._ltqsVarsAIRoot = 1 / self._W_gAIRoot
+                    if mem_friendly:
+                        self._W_gAIRoot = None
+            return self._ltqsVarsAIRoot
+
+    # Used
+    def getW(self, AIRoot=False, mem_friendly=False):
+        mem_friendly = mem_friendly or bs_glob.mem_friendly
+        if not AIRoot:
+            if self._W_g is None:
+                if self._ltqsVars is not None:
+                    # If ltqsVars is known, return 1/ltqsVars, if that is None as well, then just return None
+                    if mem_friendly and isinstance(self._ltqsVars, np.memmap):
+                        return 1 / self._ltqsVars
+                    else:
+                        self._W_g = 1 / self._ltqsVars
+                        if mem_friendly:
+                            self._ltqsVars = None
+            return self._W_g
+        else:
+            if self._W_gAIRoot is None:
+                if self._ltqsVarsAIRoot is not None:
+                    self._W_gAIRoot = 1 / self._ltqsVarsAIRoot
+                    if mem_friendly:
+                        self._ltqsVarsAIRoot = None
+            return self._W_gAIRoot
+
+    # Used
+    def assignTs(self, t, verbose=False):
+        if not self.isRoot:
+            self.tParent = t[self.nodeInd]
+        for child in self.childNodes:
+            child.assignTs(t)
+
+    # Used
+    def getTs(self, t):
+        if not self.isRoot:
+            t[self.nodeInd] = self.tParent
+        for child in self.childNodes:
+            t = child.getTs(t)
+        return t
+
+    # Used
+    def getGrads(self, grad):
+        if not self.isRoot:
+            grad[self.nodeInd] = self.dLoglikdtParent
+        for child in self.childNodes:
+            grad = child.getGrads(grad)
+        return grad
+
+    # Used
+    def getInfo(self):
+        ltqsVars = self.getLtqsVars()
+        return self.tParent, 1 / (self.tParent + ltqsVars), self.ltqs, ltqsVars, self.nodeInd
+
+    # Used
+    def getChildMergers(self, mergers):
+        if self.isLeaf:
+            return self.nodeInd
+        childInds = []
+        for child in self.childNodes:
+            childInds.append(child.getChildMergers(mergers))
+        if len(childInds) == 0:
+            mp_print("This node was marked as not-a-leaf, but doesn't have children. Check this.")
+            self.isLeaf = True
+            return self.nodeInd
+        myInd = childInds[0]
+        for ind in range(len(childInds) - 1):
+            if ind == 0:
+                tChild1 = self.childNodes[ind].tParent
+                tChild2 = self.childNodes[ind + 1].tParent
+                mergers.append((
+                    childInds[ind], childInds[ind + 1], tChild1,
+                    tChild2))
+            else:
+                tChild = self.childNodes[ind + 1].tParent
+                mergers.append((myInd, childInds[ind + 1], 0., tChild))
+        return myInd
+
+    # Used
+    def getDerivativesDownstream(self, xrAsIfRoot_g, WAsIfRoot_g):
+        # The following is the same calculation for all children:
+        ltqsTimesWAsIfRoot_g = xrAsIfRoot_g * WAsIfRoot_g
+
+        # Then start loop over children to get all diffusion time derivatives
+        for child in self.childNodes:
+            # Calculate node position without contribution of this child
+            wbarChild_g = 1 / (child.tParent + child.getLtqsVars())
+            WWOChild = WAsIfRoot_g - wbarChild_g
+            ltqsWOChild = (ltqsTimesWAsIfRoot_g - wbarChild_g * child.ltqs) / WWOChild
+            ltqsVarsWOChild = 1 / WWOChild
+
+            # Calculate derivative of loglikelihood w.r.t. diff time to child
+            sqDistToChild = (ltqsWOChild - child.ltqs) ** 2
+            totalVars = child.getLtqsVars() + ltqsVarsWOChild
+            child.dLoglikdtParent = der2LeafTree(child.tParent, totalVars, sqDistToChild)
+
+            if not child.isLeaf:
+                # Calculate ltqs and W of child as if root, such that we can move down the tree
+                wbarRoot_g = 1 / (child.tParent + ltqsVarsWOChild)
+                WChildWithRoot = child.getW() + wbarRoot_g
+                ltqsChildWithRoot = (child.ltqs * child.getW() + wbarRoot_g * ltqsWOChild) / WChildWithRoot
+
+                # Move down tree to calculate derivatives from all nodes
+                child.getDerivativesDownstream(ltqsChildWithRoot, WChildWithRoot)
+
+    def assignVs(self, optLambdas):
+        if self.isLeaf:
+            self.ltqs /= np.sqrt(optLambdas)
+            self.setLtqsVarsOrW(ltqsVars=self.getLtqsVars() / optLambdas)
+        else:
+            for child in self.childNodes:
+                child.assignVs(optLambdas)
+
+    # Used
+    def getLtqsComplete(self, mem_friendly=True):
+        if self.isLeaf:
+            self.prefactor = 0.
+            return
+
+        self.prefactor = 0
+        for cInd, child in enumerate(self.childNodes):
+            child.getLtqsComplete(mem_friendly=mem_friendly)
+            self.prefactor += child.prefactor
+        if not mem_friendly:
+            ltqsChildren, ltqsVarsChildren, tChildren = self.getInfoChildren()
+            self.ltqs, W_g, wbar_gi = findNodeLtqsGivenLeafs(ltqs_gi=ltqsChildren, ltqsVars_gi=ltqsVarsChildren,
+                                                             t_i=tChildren, return_wbar_gi=True)
+        else:
+            self.ltqs, W_g = findNodeLtqsGivenLeafs(childNodes=self.childNodes, return_wbar_gi=False)
+            wbar_gi = None
+            # self.ltqs, W_g, wbar_gi = getNodeLtqsGivenChildnodes(self.childNodes, mem_friendly=mem_friendly)
+        self.setLtqsVarsOrW(W_g=W_g)
+        if not mem_friendly:
+            self.prefactor += getLoglikAndGradStarTree(ltqs_gi=ltqsChildren, xr_g=self.ltqs, wbar_gi=wbar_gi,
+                                                       W_g=self.getW(), returnGrad=False, mem_friendly=False)
+        else:
+            self.prefactor += getLoglikAndGradStarTree(childNodes=self.childNodes, xr_g=self.ltqs, wbar_gi=wbar_gi,
+                                                       W_g=self.getW(mem_friendly=True), returnGrad=False,
+                                                       mem_friendly=True)
+
+    def getLogLGradLambdaSingleGene(self, lam, geneInd, loglik, logGrad):
+        nChildren = len(self.childNodes)
+        ltqsNew_i = np.zeros(nChildren)
+        ltqsVarsNew_i = np.zeros(nChildren)
+        t_i = np.zeros(nChildren)
+        if self.isLeaf:
+            # TODO: Maybe make getLtqsVars take gene_ind as argument
+            return loglik, logGrad, self.ltqs[geneInd] / np.sqrt(lam), self.getLtqsVars()[geneInd] / lam, self.tParent
+
+        for child_ind, child in enumerate(self.childNodes):
+            loglik, logGrad, ltqsNew_i[child_ind], ltqsVarsNew_i[child_ind], t_i[
+                child_ind] = child.getLogLGradLambdaSingleGene(lam, geneInd, loglik, logGrad)
+
+        xr, W, wbar_i, wOverW_i = findNodeLtqsGivenLeafsSingleGene(ltqsNew_i, ltqsVarsNew_i, t_i,
+                                                                   return_wbar_i=True,
+                                                                   return_wOverW_i=True)
+        sqDistsTimesWbar_i = wbar_i * (ltqsNew_i - xr) ** 2
+
+        loglik += - np.log(W) + np.sum(np.log(wbar_i) - sqDistsTimesWbar_i)
+        logGrad += - np.sum(wbar_i * (ltqsVarsNew_i * (wOverW_i - 1) - t_i * sqDistsTimesWbar_i))
+        return loglik, logGrad, xr, 1 / W, self.tParent
+
+    def getLogLGradLambda(self, lam, loglik, logGrad, nGenes):
+        if self.isLeaf:
+            # TODO: Maybe make getLtqsVars take gene_ind as argument
+            return loglik, logGrad, self.ltqs / np.sqrt(lam), self.getLtqsVars() / lam, self.tParent
+
+        nChildren = len(self.childNodes)
+        ltqsNew_gi = np.zeros((nGenes, nChildren))
+        ltqsVarsNew_gi = np.zeros((nGenes, nChildren))
+        t_i = np.zeros(nChildren)
+        for child_ind, child in enumerate(self.childNodes):
+            loglik, logGrad, ltqsNew_gi[:, child_ind], ltqsVarsNew_gi[:, child_ind], t_i[
+                child_ind] = child.getLogLGradLambda(lam, loglik, logGrad, nGenes)
+
+        xr_g, W_g, wbar_gi, wOverW_gi = findNodeLtqsGivenLeafs(ltqs_gi=ltqsNew_gi, ltqsVars_gi=ltqsVarsNew_gi, t_i=t_i,
+                                                               return_wbar_gi=True,
+                                                               return_wOverW_gi=True)
+        sqDistsTimesWbar_gi = wbar_gi * (ltqsNew_gi - xr_g[:, None]) ** 2
+
+        loglik += np.sum(- np.log(W_g) + np.sum(np.log(wbar_gi) - sqDistsTimesWbar_gi, axis=1))
+        logGrad += - np.sum(wbar_gi * (ltqsVarsNew_gi * (wOverW_gi - 1) - t_i * sqDistsTimesWbar_gi), axis=1)
+        return loglik, logGrad, xr_g, 1 / W_g, self.tParent
+
+    # Used
+    def getLtqsNoneOnly(self):
+        if self.isLeaf:
+            return
+
+        for cInd, child in enumerate(self.childNodes):
+            if child.ltqs is None:
+                child.getLtqsNoneOnly()
+        # ltqsChildren, ltqsVarsChildren, tChildren = self.getInfoChildren()
+        # self.ltqs, W_g = findNodeLtqsGivenLeafs(ltqsChildren, ltqsVarsChildren, tChildren, return_wbar_gi=False)
+        self.ltqs, W_g = findNodeLtqsGivenLeafs(childNodes=self.childNodes)
+        self.setLtqsVarsOrW(W_g=W_g)
+
+    # Used
+    def setLtqsUpstream(self):
+        # This assumes that the ltqs of this node and all of its siblings are already correct
+        if self.isRoot:
+            return
+        parent = self.parentNode
+        # ltqsChilds, ltqsVarsChilds, tChilds = parent.getInfoChildren()
+        # parent.ltqs, W_g = findNodeLtqsGivenLeafs(ltqsChilds, ltqsVarsChilds, tChilds, return_wbar_gi=False)
+        parent.ltqs, W_g = findNodeLtqsGivenLeafs(childNodes=parent.childNodes, return_wbar_gi=False)
+        parent.setLtqsVarsOrW(W_g=W_g)
+        parent.setLtqsUpstream()
+
+    # Used
+    def add_n_nodes_upstream(self, n_nodes_added):
+        self.n_ds_nodes += n_nodes_added
+        # This assumes that the ltqs of this node and all of its siblings are already correct
+        if self.isRoot:
+            return
+        else:
+            self.parentNode.add_n_nodes_upstream(n_nodes_added)
+
+    # Used
+    def getLtqsUponMerge(self):
+        # ltqsChilds, ltqsVarsChilds, tChilds = self.getInfoChildren()
+        self.ltqs, W_g = findNodeLtqsGivenLeafs(childNodes=self.childNodes, return_wbar_gi=False)
+        self.setLtqsVarsOrW(W_g=W_g)
+
+    def gatherInfoDepthFirst(self, info):
+        info.append(len(self.childNodes))
+        for child in self.childNodes:
+            info = child.gatherInfoDepthFirst(info)
+        return info
+
+    def gatherInfoDepthFirstGeneral(self, info):
+        if self.isLeaf:
+            info.append(self.ltqs[:2])
+        for child in self.childNodes:
+            info = child.gatherInfoDepthFirstGeneral(info)
+        return info
+
+    def reset_version_numbers(self, version_attr_str):
+        setattr(self, version_attr_str, -1)
+        for child in self.childNodes:
+            child.reset_version_numbers(version_attr_str)
+
+    def deleteParentsWithOneChild(self, recalc_ltqs=True):
+        toBeDeleted = []
+        toBeAdded = []
+        for ind, child in enumerate(self.childNodes):
+            child.deleteParentsWithOneChild()
+            if (len(child.childNodes) <= 1) and (not child.isCell):
+                toBeDeleted.append(ind)
+                child.parentNode = None
+                if len(child.childNodes) == 1:
+                    gchild = child.childNodes[0]
+                    toBeAdded.append(gchild)
+                    gchild.tParent += child.tParent
+                    gchild.parentNode = self
+        self.childNodes = [child for ind, child in enumerate(self.childNodes) if ind not in toBeDeleted]
+        for child in toBeAdded:
+            self.childNodes.append(child)
+
+        if self.isRoot:
+            while len(self.childNodes) == 1:
+                # In this case, the root itself has only a single child. Then remove the child and add the
+                # children as children of the root
+                child = self.childNodes[0]
+                for gchild in child.childNodes:
+                    gchild.tParent += child.tParent
+                    gchild.parentNode = self
+                self.childNodes = child.childNodes
+            # self.renumberNodes()
+            vertIndToNode, bs_glob.nNodes = self.renumber_verts(vertIndToNode={}, vert_count=0)
+            if recalc_ltqs:
+                self.getLtqsComplete(mem_friendly=True)
+
+    # Used
+    def mergeZeroTimeChilds(self):
+        # This function finds edges with zero length, then deletes the node downstream of this edge and adds the
+        # children of the deleted node as children of the node upstream of the edge
+        childrenToBeAdded = []
+        childIndsToBeDeleted = []
+        for ind, child in enumerate(self.childNodes):
+            if not child.isLeaf:
+                child.mergeZeroTimeChilds()
+                if child.tParent == 0:
+                    if child.isCell and (not self.isCell):
+                        self.nodeId = child.nodeId
+                    childrenToBeAdded += child.childNodes
+                    childIndsToBeDeleted.append(ind)
+                    child.parentNode = None
+        if len(childIndsToBeDeleted) > 0:
+            for child in childrenToBeAdded:
+                child.parentNode = self
+            self.childNodes = [child for ind, child in enumerate(self.childNodes) if ind not in childIndsToBeDeleted]
+            self.childNodes += childrenToBeAdded
+
+    # Used
+    def renumberNodes(self, change_node_inds=False):
+        # This function renumbers internal nodes to make these indices consistent again after nodes were deleted
+        # If change_node_inds=True, it assumes that the cells have nodeInds from 0 to nCells - 1, and doesn't change it
+        # If change_node_inds=False, then this function is just re-counting the nodes for bs_glob.nNodes
+        if self.isRoot:
+            bs_glob.nNodes = bs_glob.nCells + 1
+            if change_node_inds:
+                self.nodeInd = -1
+                self.nodeId = 'root'
+        if not self.isRoot:
+            is_cell = self.isCell if (self.isCell is not None) else self.isLeaf
+            if not is_cell:
+                bs_glob.nNodes += 1
+                if change_node_inds:
+                    # self.nodeInd = bs_glob.nNodes - 1
+                    self.nodeInd = bs_glob.max_node_ind + 1
+                    bs_glob.max_node_ind += 1
+                    self.nodeId = 'internal_' + str(self.nodeInd)
+            if self.nodeId is None:
+                self.nodeId = 'internal_' + str(self.nodeInd)
+        for child in self.childNodes:
+            child.renumberNodes(change_node_inds=change_node_inds)
+
+    def renumber_verts(self, vertIndToNode, vert_count, include_nodeInd=False, old_ind_to_new_ind=None):
+        if old_ind_to_new_ind is not None:
+            old_ind_to_new_ind[self.vert_ind] = vert_count
+        self.vert_ind = vert_count
+        if include_nodeInd:
+            self.nodeInd = vert_count
+        vertIndToNode[self.vert_ind] = self
+        vert_count += 1
+        for child in self.childNodes:
+            if old_ind_to_new_ind is not None:
+                vertIndToNode, vert_count, old_ind_to_new_ind = child.renumber_verts(vertIndToNode, vert_count,
+                                                                                     include_nodeInd=include_nodeInd,
+                                                                                     old_ind_to_new_ind=old_ind_to_new_ind)
+            else:
+                vertIndToNode, vert_count = child.renumber_verts(vertIndToNode, vert_count,
+                                                                 include_nodeInd=include_nodeInd,
+                                                                 old_ind_to_new_ind=old_ind_to_new_ind)
+        if old_ind_to_new_ind is not None:
+            return vertIndToNode, vert_count, old_ind_to_new_ind
+        else:
+            return vertIndToNode, vert_count
+
+    # Used
+    def getInfoChildren(self):
+        nChildren = len(self.childNodes)
+        ltqsChildren = np.zeros((bs_glob.nGenes, nChildren))
+        ltqsVarsChildren = np.zeros((bs_glob.nGenes, nChildren))
+        tChildren = np.zeros(nChildren)
+        # nodeIndChilds = np.zeros(nChildren + 1, dtype=int)
+        for cInd, child in enumerate(self.childNodes):
+            ltqsChildren[:, cInd] = child.ltqs
+            ltqsVarsChildren[:, cInd] = child.getLtqsVars()
+            tChildren[cInd] = child.tParent
+        return ltqsChildren, ltqsVarsChildren, tChildren
+
+    def get_posterior_info_children(self, xrAIRoot, WRoot, minimum_time=None):
+        nChildren = len(self.childNodes)
+        ltqsChildren = np.zeros((bs_glob.nGenes, nChildren))
+        WChildren = np.zeros((bs_glob.nGenes, nChildren))
+        tChildren = np.zeros(nChildren)
+        # nodeIndChilds = np.zeros(nChildren + 1, dtype=int)
+        for cInd, child in enumerate(self.childNodes):
+            ltqsChildren[:, cInd] = child.ltqs
+            WChildren[:, cInd] = child.getW()
+            tChildren[cInd] = child.tParent
+
+        if minimum_time is not None:
+            # We here enforce that children should be at least <minimum_time> away from the root. Otherwise, the difference
+            # between root-position and posterior-ltqs for this child is zero, which is undesired for knn-search.
+            # Set minimum_time=None if you don't want this
+            tChildren = np.maximum(tChildren, minimum_time)
+
+        post_ltqsCh, _ = getLtqsAsIfRoot_vectorized(ltqsChildren, WChildren, tChildren, xrAIRoot, WRoot)
+        # Get posterior best guess for coordinates by integrating out everything but the root
+        post_ltqsCh, _ = getLtqsAsIfRoot_vectorized(ltqsChildren, WChildren, tChildren, xrAIRoot, WRoot)
+        return post_ltqsCh
+
+    def addClosenessNNN(self, dist, src=np.nan):
+        dist += 1
+        if not self.isRoot:
+            nbs = self.childNodes + [self.parentNode]
+        else:
+            nbs = self.childNodes
+        for nb in nbs:
+            if (not nb.isLeaf) and (not nb.isRoot) and (nb.nodeInd != src):
+                nb.cumClosenessNNN += 1 / dist
+                nb.addClosenessNNN(dist=dist, src=self.nodeInd)
+
+    # Used
+    def mergeDownstreamChildren(self, xrAsIfRoot_g, WAsIfRoot_g, sequential=True, verbose=False, ellipsoidSize=1.0,
+                                nChildNN=-1, kNN=5, mergeDownstream=True, tree=None, single_process=False):
+        # If we update the node's position in the process, we keep the old position here. This will help in updating the
+        # parent's position. Also, we store in the boolean "someMergeHappened" whether there was an update
+        oldLtqs = None
+        oldLtqsVars = None
+        someMergeHappened = False
+        for ind, child in enumerate(self.childNodes):
+            if not child.isLeaf:
+                mergeHappened, newLtqs, newLtqsVars, oldLtqsChild, oldLtqsVarsChild = child.mergeChildrenRecursive(
+                    xrAsIfRoot_g, WAsIfRoot_g, sequential=sequential, verbose=verbose, ellipsoidSize=ellipsoidSize,
+                    nChildNN=nChildNN, kNN=kNN,
+                    mergeDownstream=mergeDownstream, tree=tree, single_process=single_process)
+                if mergeHappened:  # If merge happened downstream, we need to recalculate W_g and ltqs of current node
+                    someMergeHappened = True
+                    xrAsIfRoot_g, WAsIfRoot_g = getLtqsAfterChildUpdate(xrAsIfRoot_g, WAsIfRoot_g, child.tParent,
+                                                                        oldLtqsChild, oldLtqsVarsChild,
+                                                                        child.ltqs, child.getLtqsVars())
+                    if not self.isRoot:
+                        if oldLtqs is None:
+                            oldLtqs = self.ltqs.copy()
+                            oldLtqsVars = self.getLtqsVars().copy()
+                        self.ltqs, W_g = getLtqsAfterChildUpdate(self.ltqs, self.getW(), child.tParent, oldLtqsChild,
+                                                                 oldLtqsVarsChild, child.ltqs, child.getLtqsVars())
+                        self.setLtqsVarsOrW(W_g=W_g)
+
+        if someMergeHappened:
+            if self.isRoot:
+                self.setLtqsVarsOrW(W_g=WAsIfRoot_g)
+                self.ltqs = xrAsIfRoot_g
+        return someMergeHappened, xrAsIfRoot_g, WAsIfRoot_g, oldLtqs, oldLtqsVars
+
+    # Used
+    def mergeDownstreamChildrenSingle(self, xrAsIfRoot_g, WAsIfRoot_g, childNInd, gchildNInd, sequential=True,
+                                      verbose=False, ellipsoidSize=1.0, singleProcess=False, random=False,
+                                      runConfigs_inherited=None):
+        # If we update the node's position in the process, we keep the old position here. This will help in updating the
+        # parent's position. Also, we store in the boolean "someMergeHappened" whether there was an update
+        oldLtqs = None
+        oldLtqsVars = None
+        someMergeHappened = False
+        for ind, child in enumerate(self.childNodes):  # TODO: Do for-loop just using child-ind instead of childNodeInd
+            if child.nodeInd == childNInd:
+                mergeHappened, newLtqs, newLtqsVars, oldLtqsChild, oldLtqsVarsChild = child.mergeChildrenRecursiveSingle(
+                    xrAsIfRoot_g, WAsIfRoot_g, gchildNInd, sequential=sequential, verbose=verbose,
+                    ellipsoidSize=ellipsoidSize, singleProcess=singleProcess, random=random,
+                    runConfigs_inherited=runConfigs_inherited)
+                if mergeHappened:  # If merge happened downstream, we need to recalculate W_g and ltqs of current node
+                    someMergeHappened = True
+                    xrAsIfRoot_g, WAsIfRoot_g = getLtqsAfterChildUpdate(xrAsIfRoot_g, WAsIfRoot_g, child.tParent,
+                                                                        oldLtqsChild, oldLtqsVarsChild,
+                                                                        child.ltqs, child.getLtqsVars())
+                    if not self.isRoot:
+                        if oldLtqs is None:
+                            oldLtqs = self.ltqs.copy()
+                            oldLtqsVars = self.getLtqsVars().copy()
+                        self.ltqs, W_g = getLtqsAfterChildUpdate(self.ltqs, self.getW(), child.tParent, oldLtqsChild,
+                                                                 oldLtqsVarsChild, child.ltqs, child.getLtqsVars())
+                        self.setLtqsVarsOrW(W_g=W_g)
+        if someMergeHappened:
+            if self.isRoot:
+                self.setLtqsVarsOrW(W_g=WAsIfRoot_g)
+                self.ltqs = xrAsIfRoot_g
+        return someMergeHappened, xrAsIfRoot_g, WAsIfRoot_g, oldLtqs, oldLtqsVars
+
+    # Used
+    def mergeChildrenRecursive(self, parentLtqs, parentW_g, sequential=True, verbose=False, ellipsoidSize=1.0,
+                               mpiInfo=None, nChildNN=-1, kNN=5, mergeDownstream=True, tree=None, single_process=False):
+        """This function loops over all candidate pairs between nodes that are children of the root-node, and checks what
+        the likelihood becomes when they are merged."""
+        if mpiInfo is None:
+            mpiInfo = mpi_wrapper.get_mpi_info()
+        if (mpiInfo.rank == 0) or single_process:
+            if not self.isRoot:
+                # Get the mean and precision of this node's posterior when all other node-positions are integrated out
+                xrAsIfRoot_g, WAsIfRoot_g = getLtqsAsIfRoot(self.ltqs, self.getW(), self.tParent, parentLtqs, parentW_g)
+            else:
+                # For the root we do not need calculation, because already all its connecting nodes were integrated over
+                xrAsIfRoot_g = self.ltqs
+                WAsIfRoot_g = self.getW()
+        else:
+            xrAsIfRoot_g = None
+            WAsIfRoot_g = None
+
+        # Check whether children can be merged on some downstream node. If so, correct ltqs and W of current node for
+        # downstream change
+        someMergeHappened, xrAsIfRoot_g, WAsIfRoot_g, oldLtqs, oldLtqsVars = self.mergeDownstreamChildren(
+            xrAsIfRoot_g, WAsIfRoot_g, sequential=sequential, verbose=verbose, ellipsoidSize=ellipsoidSize,
+            nChildNN=nChildNN, kNN=kNN, single_process=single_process,
+            mergeDownstream=mergeDownstream, tree=tree)
+
+        # Check whether we want to merge any of the children of this node
+        nChild = len(self.childNodes)
+        expNChild = 3 if self.isRoot else 2
+        if nChild <= expNChild:
+            return someMergeHappened, self.ltqs, self.getLtqsVars(), oldLtqs, oldLtqsVars
+        # if (bs_glob.getHessStarTreeJax_jit is None) and (not sequential):
+        #     bs_glob.getHessStarTreeJax_jit = jax.jit(getHessStarTreeJax)
+
+        if (oldLtqs is None) and (mpiInfo.rank == 0):
+            oldLtqs = self.ltqs.copy()
+            oldLtqsVars = self.getLtqsVars().copy()
+        changedSomething = self.mergeChildrenUB(xrAsIfRoot_g, WAsIfRoot_g, sequential=sequential, verbose=verbose,
+                                                ellipsoidSize=ellipsoidSize, nChildNN=nChildNN, kNN=kNN,
+                                                mergeDownstream=mergeDownstream, tree=tree,
+                                                singleProcess=single_process)
+        if mpiInfo.rank == 0:
+            someMergeHappened = (len(self.childNodes) < nChild) or changedSomething or someMergeHappened
+        else:
+            someMergeHappened = None
+        return someMergeHappened, self.ltqs, self.getLtqsVars(), oldLtqs, oldLtqsVars
+
+    # Used
+    def mergeChildrenRecursiveSingle(self, parentLtqs, parentW_g, gchildNInd, sequential=True, verbose=False,
+                                     ellipsoidSize=1.0, singleProcess=False, random=False, runConfigs_inherited=None):
+        """This function loops over all candidate pairs between nodes that are children of the root-node, and checks
+        what the likelihood becomes when they are merged."""
+        if not self.isRoot:
+            # Get the mean and precision of this node's posterior when all other node-positions are integrated out
+            xrAsIfRoot_g, WAsIfRoot_g = getLtqsAsIfRoot(self.ltqs, self.getW(), self.tParent, parentLtqs, parentW_g)
+        else:
+            # For the root we do not have to calculate, because already all its connecting nodes were integrated over
+            xrAsIfRoot_g = self.ltqs
+            WAsIfRoot_g = self.getW()
+
+        oldLtqs = self.ltqs.copy()
+        oldLtqsVars = self.getLtqsVars().copy()
+
+        changedSomething = self.mergeChildrenUB(xrAsIfRoot_g, WAsIfRoot_g, sequential=sequential, verbose=verbose,
+                                                random=random,
+                                                ellipsoidSize=ellipsoidSize, specialChild=gchildNInd,
+                                                singleProcess=singleProcess,
+                                                outputFolder=runConfigs_inherited['outputFolder'])
+        someMergeHappened = changedSomething
+        return someMergeHappened, self.ltqs, self.getLtqsVars(), oldLtqs, oldLtqsVars
+
+    # Used
+    def mergeChildrenUB(self, xrAsIfRoot_g, WAsIfRoot_g, sequential=True, verbose=False, ellipsoidSize=None,
+                        nChildUB=10, nChildNN=-1, nNewPairsPar=1000, nDonePairsPar=3000, kNN=5, outputFolder=None,
+                        tree=None, redoTimeFrac=0.05, redoNNFrac=0.1, specialChild=None, mergeDownstream=True,
+                        singleProcess=False, random=False, tmpTreeInd=None, scData=None, n_mem_friendly=500):
+        """This function loops over all candidate pairs between nodes that are children of the root-node, and checks
+        what the likelihood becomes when they are merged.
+        :param singleProcess: This boolean variable determines whether many processes work together to calculate such
+        that mergeChildrenUB can again be parallelized, or whether different processes are doing different instances
+        of this function.
+        """
+        functionStart = time.time()
+        # Get number of parallel processes + rank of current process. If singleProcess, it means that this function is
+        # run from a single process without communication. In that case, we set mpiInfo.rank = 0, mpiInfo.size=1.
+        # In general, only process 0 will keep track of the tree, and will report the correct results. The other
+        # processes are just employed when necessary, and given the correct information then.
+        mpiInfo = mpi_wrapper.get_mpi_info(singleProcess=singleProcess)
+        leaderOfMany = (mpiInfo.rank == 0) and (mpiInfo.size > 1)
+
+        # Process the run configurations, and initialize some variables (only on process 0).
+        if mpiInfo.rank == 0:
+            changedSomething = False
+            infoTuple, initVars, initNoneVars = self.initializeMergeGeneral(sequential=sequential,
+                                                                            ellipsoidSize=ellipsoidSize,
+                                                                            mpiInfo=mpiInfo, specialChild=specialChild,
+                                                                            random=random, nChildNN=nChildNN, kNN=kNN,
+                                                                            redoTimeFrac=redoTimeFrac,
+                                                                            nChildUB=nChildUB, redoNNFrac=redoNNFrac,
+                                                                            nNewPairsPar=nNewPairsPar,
+                                                                            nDonePairsPar=nDonePairsPar,
+                                                                            outputFolder=outputFolder, tree=tree,
+                                                                            tmpTreeInd=tmpTreeInd,
+                                                                            n_mem_friendly=n_mem_friendly)
+            newAnc, del_node_inds, oldRoot, UBInfo, pairs = initNoneVars
+            mergeCounter, tree_folder, tmp_tree_ind, breakOut, pairsDoneInfo = initVars
+            chInfo, NNInfo, runConfigs, timeOptInfo = infoTuple
+        else:
+            epsTuple = None
+            breakOut = None
+
+        # Start the merge rounds. This loop will only break once breakOut will become True. All processes start this
+        # loop, but process 0 will decide whether the other processes are necessary in this round, or if they can send
+        # to the next round already.
+        while True:
+            # We start timing for this round.
+            # if verbose:
+            # mp_print("Starting this round, the memory usage of this process is ",
+            #          psutil.Process(os.getpid()).memory_info().rss / 1024 ** 2, " MB.", ALL_RANKS=True)
+            if mpiInfo.rank == 0:
+                if verbose:
+                    mp_print("Merge round start. %d children left." % chInfo['nChild'])
+                mergeRoundStart = time.time()
+
+            # At this point, we stop all processes except for process 0. These processes will only continue whenever it
+            # gets a message to either A) break out of the while-loop, because the function is done, or B) move to the
+            # part of the function where parallel computing is required.
+            if mpiInfo.rank != 0:
+                computeOrBreak = None
+                computeOrBreak = mpi_wrapper.bcast(computeOrBreak, root=0)
+                # This will be a string, that can be either "break" or "continue", which mean that the process should
+                # quit the function or continue to the parallel part, respectively.
+                if computeOrBreak == 'break':
+                    changedSomething = None
+                    break
+                elif computeOrBreak != 'continue':
+                    mp_print("That's weird. I got this message: ", computeOrBreak, ALL_RANKS=True)
+
+            # We check whether this function is done, stored in "breakOut" on process 0. If so, all processes break out.
+            if (mpiInfo.rank == 0) and breakOut:
+                if leaderOfMany:
+                    computeOrBreak = 'break'
+                    mpi_wrapper.bcast(computeOrBreak, root=0)
+                    # chInfo['expNChild'] = chInfo['nChild']
+                break
+
+            # TODO: Remove this eventually
+            # if manualMerges is not None:
+            #     if manualMergeCounter < (len(manualMerges) - 1):
+            #         manualMergeCounter += 1
+            #         manMergeInd1 = manualMerges[manualMergeCounter, 0]
+            #         manMergeInd2 = manualMerges[manualMergeCounter, 1]
+            #         maxdLogL = (mergeIndToNodeInd[manMergeInd1], mergeIndToNodeInd[manMergeInd2], 1e9)
+            #         foundMax = True
+            #     else:
+            #         manualMerges = None
+            #         runConfigs['useUB'] = True
+            #         runConfigs['useUBNow'] = False
+            #         runConfigs['getNewUB'] = True
+
+            # We should now decide whether all processes are needed in this round, or only process 0. For that, we need
+            # to know whether A) a pairwise comparison will be done, instead of a time-optimisation, B) how many pairs
+            # will be treated. If the number of pairs is low, it is faster to do it with only one process.
+            # The following function finds out what needs to be done in this round (only has to be done by proc. 0).
+            if mpiInfo.rank == 0:
+                runConfigs, pairInfoTuple, oldRoot, UBInfo, pairsDoneInfo = self.initializeMergeRound(xrAsIfRoot_g,
+                                                                                                      WAsIfRoot_g,
+                                                                                                      chInfo['nChild'],
+                                                                                                      runConfigs,
+                                                                                                      mpiInfo, UBInfo,
+                                                                                                      oldRoot,
+                                                                                                      specialChild=specialChild,
+                                                                                                      timeOptInfo=timeOptInfo,
+                                                                                                      newAnc=newAnc,
+                                                                                                      del_node_inds=del_node_inds,
+                                                                                                      verbose=verbose,
+                                                                                                      NNInfo=NNInfo,
+                                                                                                      oldPairs=pairs,
+                                                                                                      pairsDoneInfo=pairsDoneInfo,
+                                                                                                      redoNNFrac=redoNNFrac,
+                                                                                                      chInfo=chInfo)
+
+                # If periodic time-optimisation is necessary, do this, store new times, then continue to next round.
+                if runConfigs['reoptTimesNow']:
+                    if verbose:
+                        mp_print("Process %d: Doing a periodic re-optimising of branch lengths "
+                                 "connected to the root." % mpiInfo.rank, ALL_RANKS=True)
+                    runConfigs['redoTimeAt'] = max(int(chInfo['nChild'] * redoTimeFrac), 10)
+                    timeOptInfo['timeOptRoundsAgo'] = 0
+                    optimisedTimes, WAsIfRoot_g, xrAsIfRoot_g = self.optimiseConnected(mpiInfo, verbose=verbose,
+                                                                                       singleProcess=True)
+                    newAnc = None
+                    changedSomething = True
+                    continue
+
+                if not runConfigs['parNow']:  # So we perform a merge in this round, but not in parallel.
+                    mpiInfoTmp = mpi_wrapper.get_mpi_info(singleProcess=True)
+                else:  # In this case, we do this round in parallel.
+                    if verbose:
+                        mp_print("This round will be done in parallel! Number of children left: ", chInfo['nChild'])
+                    mpiInfoTmp = mpiInfo
+                    # The following command makes the other processes run further to below, to receive necessary info
+                    computeOrBreak = 'continue'
+                    mpi_wrapper.bcast(computeOrBreak, root=0)
+                    # start_comm = time.time()
+                    runConfigs, tChildren, ltqsChildren, ltqsVarsChildren = self.sendMergeChildrenInfo(runConfigs,
+                                                                                                       pairInfoTuple,
+                                                                                                       UBInfo,
+                                                                                                       chInfo,
+                                                                                                       xrAsIfRoot_g,
+                                                                                                       WAsIfRoot_g)
+            else:  # i.e. if mpiInfo.rank != 0. The process coming here already means this round will be parallel
+                # start_comm = time.time()
+                very_verbose = True
+                # mp_print("This process is being used in the merge-children computation!", ALL_RANKS=True)
+                mpiInfoTmp = mpiInfo
+                infoTuple, tChildren, coordsTuple = self.receiveMergeChildrenInfo()
+                pairInfoTuple, UBInfo, runConfigs, chInfo = infoTuple
+                xrAsIfRoot_g, WAsIfRoot_g, ltqsChildren, ltqsVarsChildren = coordsTuple
+                # CoordsTuple references the mmap'ed file. Will only be closed when all references are gone.
+                del coordsTuple
+
+            # if runConfigs['parNow']:
+            # mp_print("After communication, the memory usage of this process is ",
+            #          psutil.Process(os.getpid()).memory_info().rss / 1024 ** 2, " MB.", ALL_RANKS=True)
+            # mp_print("This communication took %.2f seconds." % (time.time() - start_comm),
+            #          ALL_RANKS=True)
+
+            """Every process that reached this point will go through the same procedure below."""
+            # We should only pay attention that process 0 does not try to communicate when mpiInfo.size>1 but
+            # runConfigs['parNow'] = False.
+
+            # if useUBNow: Distribute tasks over different CPUs such that all nodes move down the sorted list
+            # of UBs else: Distribute tasks over different computing cores, such that we maximize the
+            # computational benefit of doing pairs with the same first node on the same CPU
+            # mp_print("Memory 0 ", psutil.Process(os.getpid()).memory_info().rss / 1024 ** 2, " MB.", ONLY_RANK=1)
+            pairs, nPairs, nNewPairs = pairInfoTuple
+            myTasks = getMyTaskNumbers(nPairs, mpiInfoTmp.size, mpiInfoTmp.rank, skippingSteps=runConfigs['useUBNow'])
+            nTasks = len(myTasks)
+
+            # mp_print("Memory 1 ", psutil.Process(os.getpid()).memory_info().rss / 1024 ** 2, " MB.", ONLY_RANK=1)
+
+            # if (manualMerges is not None) and (manualMergeCounter < (len(manualMerges) - 1)):
+            #     nNewPairs = -1
+            #     runConfigs['useUBNow'] = True
+
+            # Prepare variable that keeps track of maximal dLogL so far.
+            maxdLogL = (-1, -1, 1e-9)
+            maxdLogLZeroRoot = (-1, -1, 1e-9)
+
+            # When we do random merges, we keep track of the dLogLs of different merges and then do Gibbs-sampling
+            dLogLDict = {} if random else None
+
+            # Initialize boolean that will keep track whether current maximum is higher than next upper bound
+            foundMax = False
+            # Keep track of current ind1, such that if same ind1 is in next pair, some calculations can be skipped
+            oldInd1 = -1
+            indTask = -1
+            task = -1
+            pairsDone = 0
+            oldPairsDone = 0
+            # mp_print("Memory 2 ", psutil.Process(os.getpid()).memory_info().rss / 1024 ** 2, " MB.", ONLY_RANK=1)
+            start_testing_merges = time.time()
+            while True:
+                if (indTask + 1) == nTasks:  # This was the last task
+                    if not runConfigs['useUBNow']:
+                        break  # This process is done.
+                    foundMax = True  # This process has found its maximum. Communicate this with others.
+                # mp_print("Memory 3 ", psutil.Process(os.getpid()).memory_info().rss / 1024 ** 2, " MB.", ONLY_RANK=1)
+                # Communicate if maximum was found
+                if runConfigs['useUBNow'] and (foundMax or ((indTask + 1 % 100 == 0) and (task >= nNewPairs))):
+                    # Communicate maximum when: this process found maximum or 100 tasks have passed, but only after the
+                    # newPairs have all been calculated, i.e., the pairs that include the new ancestor
+                    foundMax, allFoundMax, maxdLogL, maxdLogLZeroRoot = communicateMaxs(maxdLogL, maxdLogLZeroRoot,
+                                                                                        foundMax, task, nNewPairs,
+                                                                                        UBInfo, mpiInfoTmp)
+                    if allFoundMax:  # When all processes have found the maximum, quit the while-loop
+                        break
+                    if foundMax:  # When this process found max but others not, immediately return to communication
+                        continue
+
+                # Since no maximum was found, go to next task.
+                indTask += 1
+                skip, task, nodeInd1, nodeInd2, ind1, ind2 = initializeTask(indTask, myTasks, pairs,
+                                                                            chInfo['nodeIndToChildInd'], verbose,
+                                                                            mpiInfoTmp, runConfigs)
+                if skip:
+                    continue
+
+                # First check whether next biggest UB is smaller than currently found max
+                if runConfigs['useUBNow'] and (task >= nNewPairs) and (maxdLogL[2] > UBInfo['UBs'][task - nNewPairs]):
+                    foundMax = True
+                    if verbose:
+                        mp_print("Process %d found an optimal solution after comparing %d pairs for which UB was known "
+                                 "out of %.0f" % (mpiInfoTmp.rank, oldPairsDone, nTasks - nNewPairs / mpiInfoTmp.size),
+                                 ALL_RANKS=True)
+                    continue
+
+                # Calculate loglikelihood for current pair and (if runConfigs allow) estimate UB
+                # Gather all necessary information on the candidate pair.
+                # mp_print("Memory 5 ", psutil.Process(os.getpid()).memory_info().rss / 1024 ** 2, " MB.", ONLY_RANK=1)
+                if ind1 != oldInd1:  # If child1 is the same as before, we re-use some information.
+                    if not runConfigs['parNow']:
+                        # If this round is not run in parallel, information needs to be collected from child-objects
+                        child2, sortedNodeInds, child1, child1Tuple, rootMinusFirst_ltqs, rootMinusFirst_W_g = self.getChildInfo(
+                            xrAsIfRoot_g, WAsIfRoot_g, ind1, ind2, nodeInd1, recalcInd1=True)
+                        tOld1, wbar1_g, ltqs1, ltqsVars1, nodeInd1 = child1Tuple
+                    else:
+                        # If this round is run in parallel, information was already stored in numpy-objects
+                        tOld1 = tChildren[ind1]
+                        ltqs1 = ltqsChildren[:, ind1]
+                        ltqsVars1 = ltqsVarsChildren[:, ind1]
+                        wbar1_g = 1 / (tOld1 + ltqsVars1)
+                        rootMinusFirst_W_g = WAsIfRoot_g - wbar1_g
+                        rootMinusFirst_ltqs = xrAsIfRoot_g * WAsIfRoot_g - wbar1_g * ltqs1
+                        # mp_print("Memory 5a ", psutil.Process(os.getpid()).memory_info().rss / 1024 ** 2, " MB.", ONLY_RANK=1)
+                    oldInd1 = ind1
+                elif not runConfigs['parNow']:
+                    # If this round is not run in parallel, but child1 remained, we get child2 info from child-objects
+                    child2, sortedNodeInds = self.getChildInfo(xrAsIfRoot_g, WAsIfRoot_g, ind1, ind2, nodeInd1,
+                                                               recalcInd1=False)
+                # Finally, we get child2-info in the same way depending on parallelization.
+                if runConfigs['parNow']:
+                    tOld2 = tChildren[ind2]
+                    ltqs2 = ltqsChildren[:, ind2]
+                    ltqsVars2 = ltqsVarsChildren[:, ind2]
+                    wbar2_g = 1 / (tOld2 + ltqsVars2)
+                    sortedNodeInds = tuple(sorted([nodeInd1, nodeInd2]))
+                else:
+                    tOld2, wbar2_g, ltqs2, ltqsVars2, nodeInd2 = child2.getInfo()
+                # Calculate increase in loglikelihood at optimal diff. times for this pair
+                dLogLPair, optTimes, ltqs_gi, ltqsVars_gi, wir_gi = calcSingleDLogL(xrAsIfRoot_g, WAsIfRoot_g, ltqs1,
+                                                                                    ltqsVars1, wbar1_g, tOld1,
+                                                                                    rootMinusFirst_W_g,
+                                                                                    rootMinusFirst_ltqs, ltqs2,
+                                                                                    ltqsVars2, wbar2_g, tOld2,
+                                                                                    sequential=sequential, tol=1e-4,
+                                                                                    returnAll=True)
+                pairsDone += 1
+                # If useUB, make UB-estimate
+                if runConfigs['useUB'] and (task < nNewPairs):
+                    # TODO: Decide if you want to use old root position for estimating upper bound or not.
+                    # Currently I just use the current root-position to determine a new upper bound. This will only go
+                    # wrong when the root is moving out of the ellipsoid centered around the current position, before
+                    # it will run out of the original ellipsoid. This is very unlikely.
+                    justUseNewRoot = True
+                    if justUseNewRoot:
+                        rootInfo = {"pos": xrAsIfRoot_g, "prec": WAsIfRoot_g, "nChild": chInfo['nChild']}
+                        dLogLOld, ddLogLPerEpsx, ddLogLPerEpsW = estimateDerBasedDLogLUB(rootInfo,
+                                                                                         optTimes,
+                                                                                         ltqs_gi=ltqs_gi,
+                                                                                         ltqsVars_gi=ltqsVars_gi,
+                                                                                         wir_gi=wir_gi)
+                        UBInfo['tuples'][sortedNodeInds] = (dLogLPair, ddLogLPerEpsx, ddLogLPerEpsW)
+                    # else:
+                    #     if runConfigs['getNewUB']:  # Using this we use the just calculated optTimes
+                    #         dLogLOld, ddLogLPerEpsx, ddLogLPerEpsW = estimateDerBasedDLogLUB(oldRoot,
+                    #                                                                          optTimes,
+                    #                                                                          ltqs_gi=ltqs_gi,
+                    #                                                                          ltqsVars_gi=ltqsVars_gi,
+                    #                                                                          wir_gi=wir_gi)
+                    #         UBInfo['tuples'][sortedNodeInds] = (dLogLPair, ddLogLPerEpsx, ddLogLPerEpsW)
+                    #     else:  # This re-optimises the times based on the old-root position
+                    #         dLogLOld, ddLogLPerEpsx, ddLogLPerEpsW = estimateDerBasedDLogLUB(oldRoot,
+                    #                                                                          optTimes, child1=child1,
+                    #                                                                          child2=child2,
+                    #                                                                          sequential=sequential)
+                    #     UBInfo['tuples'][sortedNodeInds] = (dLogLOld, ddLogLPerEpsx, ddLogLPerEpsW)
+                else:
+                    oldPairsDone += 1
+
+                # Compare calculated dLogL with current maximum, and replace if larger
+                # TODO: Store optTimes for this pair as well. Saves a recompute at the end.
+                if random:
+                    dLogLDict[sortedNodeInds] = dLogLPair
+                if optTimes[-1] > 1e-6:
+                    if dLogLPair > maxdLogL[2]:
+                        maxdLogL = (sortedNodeInds[0], sortedNodeInds[1], dLogLPair)
+                else:
+                    if dLogLPair > maxdLogLZeroRoot[2]:
+                        maxdLogLZeroRoot = (sortedNodeInds[0], sortedNodeInds[1], dLogLPair)
+
+            # mp_print("Testing the merge pairs took {} seconds.".format(time.time() - start_testing_merges), DEBUG=True)
+            start_post_process = time.time()
+            """Optimal pair was found. Processing merge starts here."""
+            # Process other than proc. 0 are now only here to communicate their gathered information:
+            # - maximum pair
+            # - gathered upper bound estimates
+
+            # Communicate maximum
+            if mpiInfoTmp.size > 1:
+                commTuple = (pairsDone, maxdLogL, maxdLogLZeroRoot)
+                allCommTuples = mpi_wrapper.gather(commTuple, root=0)
+                if mpiInfo.rank == 0:
+                    allPairsDone, maxdLogLTuples, maxdLogLTuplesZeroRoot = tuple(zip(*allCommTuples))
+                    pairsDoneInfo['totalPairsDone'] = sum(allPairsDone)
+                if random:
+                    dLogLDictAll = mpi_wrapper.gather(dLogLDict, root=0)
+                    if mpiInfoTmp.rank == 0:
+                        for dLogLs in dLogLDictAll:
+                            dLogLDict.update(dLogLs)
+            else:
+                pairsDoneInfo['totalPairsDone'] = pairsDone
+                maxdLogLTuples = [maxdLogL]
+                maxdLogLTuplesZeroRoot = [maxdLogLZeroRoot]
+
+            if runConfigs['parNow']:
+                # if verbose:
+                #     mp_print("After this round and before deletion, the memory usage of this process is ",
+                #              psutil.Process(os.getpid()).memory_info().rss / 1024 ** 2, " MB.", ALL_RANKS=True)
+                # Numpy arrays are no longer needed, and will be recalculated in next round anyhow
+                # The variables below are all pointing to the mmap'ed-file that was used for communication. These
+                # pointers need to be deleted before the mmap'ed-file can be deleted from memory
+                if mpiInfo.rank == 0:
+                    empty_folder(runConfigs['mem_friendly_folder'])
+                try:
+                    del ltqsChildren
+                    del ltqsVarsChildren
+                    del ltqs2
+                    del ltqsVars2
+                    del ltqs1
+                    del ltqsVars1
+                    # The following variables are also re-computed, but do not take much memory. Probably not worth deleting
+                    # del tChildren
+                    # del wbar1_g
+                    # del rootMinusFirst_W_g
+                    # del rootMinusFirst_ltqs
+                    gc.collect()
+                except UnboundLocalError:
+                    pass
+                # if verbose:
+                #     mp_print("After this round and after deletion, the memory usage of this process is ",
+                #              psutil.Process(os.getpid()).memory_info().rss / 1024 ** 2, " MB.", ALL_RANKS=True)
+
+            # Processing of this information is only done on process 0.
+            if mpiInfoTmp.rank == 0:
+                # rightList = np.all([self.childNodes[childInd].nodeInd == nodeInd
+                #                     for nodeInd, childInd in chInfo['nodeIndToChildInd'].items()])
+                # if not rightList:
+                #     print("This went wrong, chInfo was %r \n, self.childNodes was %r " % (chInfo, self.childNodes))
+                #     raise_exception = 1 / 0
+                # Find optimal inds to merge, and calculate optimal times for this merge
+                optNodeInd1, optNodeInd2, newTDict, timeOptInfo, dLogLOpt = self.getOptimalDLogLPairInfoNew(
+                    xrAsIfRoot_g, WAsIfRoot_g, maxdLogLTuples, maxdLogLTuplesZeroRoot, chInfo['nodeIndToChildInd'],
+                    timeOptInfo, sequential=sequential, verbose=verbose, random=random, dLogLDict=dLogLDict)
+
+                # From the optimal information, it can be concluded that a time-optimization is necessary (for example,
+                # when the optimal merge has zero distance from root to new ancestor). In this case, we do this here.
+                if timeOptInfo['doTimeOpt']:
+                    if runConfigs['useNN']:
+                        runConfigs['getNewNN'] = True
+                    if optNodeInd1 is None:
+                        if verbose:
+                            mp_print("Re-optimising branch lengths connected to the root.")
+                        runConfigs['redoTimeAt'] = max(int(chInfo['nChild'] * redoTimeFrac), 10)
+                        timeOptInfo['timeOptRoundsAgo'] = 0
+                        optimisedTimes, WAsIfRoot_g, xrAsIfRoot_g = self.optimiseConnected(mpiInfoTmp, verbose=False,
+                                                                                           singleProcess=True)
+                    else:
+                        xrAsIfRoot_g, WAsIfRoot_g = self.resetChildTimes(xrAsIfRoot_g, WAsIfRoot_g, optNodeInd1,
+                                                                         optNodeInd2, newTDict,
+                                                                         chInfo['nodeIndToChildInd'])
+                        optimisedTimes = True
+                    newAnc = None
+                else:
+                    optimisedTimes = False
+                changedSomething = True if optimisedTimes else changedSomething
+
+                if (optNodeInd1 is None) and (not optimisedTimes):
+                    if runConfigs['useUBNow']:
+                        if verbose:
+                            mp_print("No pair could be merged that increased the loglikelihood. Trying again with new"
+                                     "UB estimates.")
+                        runConfigs['useUBNow'] = False
+                        runConfigs['getNewUB'] = True
+                        runConfigs['getNewNN'] = True
+                        breakOut = True
+                    else:
+                        if verbose:
+                            mp_print("Process " + str(mpiInfoTmp.rank) + ": No pair could be merged that increased"
+                                                                         " the loglikelihood, while the root still has " + str(
+                                chInfo['nChild']) +
+                                     " children. Leaving the tree as it is now.", ALL_RANKS=singleProcess)
+                        chInfo['expNChild'] = chInfo['nChild']
+                        breakOut = True
+
+                # if runConfigs['timeStamps']:  # Print message on timing
+                #     mergeStart = printTiming("Getting optimal node info", processingStart)
+                #     storeStart = mergeStart
+
+                if (not optimisedTimes) and (not breakOut):
+                    # Merge these nodes by adding new parent of the two nodes as a child to the current node.
+                    # We make sure all position information is updated correctly
+                    xrAsIfRoot_g, WAsIfRoot_g, newAnc, del_node_inds = self.mergeNodes(xrAsIfRoot_g, WAsIfRoot_g,
+                                                                                       optNodeInd1, optNodeInd2,
+                                                                                       newTDict,
+                                                                                       chInfo['nodeIndToChildInd'],
+                                                                                       dLogLOpt, sequential=sequential,
+                                                                                       verbose=verbose,
+                                                                                       ellipsoidSize=ellipsoidSize,
+                                                                                       mergeDownstream=mergeDownstream,
+                                                                                       singleProcess=True,
+                                                                                       random=random,
+                                                                                       runConfigs=runConfigs,
+                                                                                       NNInfo=NNInfo)
+
+                    # if manualMerges is not None:
+                    #     # Update mergeIndToNodeInd by overwriting mergeInd1 with direction to ancestor
+                    #     mergeIndToNodeInd[manMergeInd1] = self.childNodes[-1].nodeInd
+                    # TODO: Optimize this by keeping track of it
+                    chInfo['nodeIndToChildInd'] = {child.nodeInd: childInd for childInd, child in
+                                                   enumerate(self.childNodes)}
+                    chInfo['nChild'] -= 1
+                    changedSomething = True
+                    # if runConfigs['timeStamps']:  # Print message on timing
+                    #     storeStart = printTiming("Merging optimal nodes", mergeStart)
+                else:
+                    newAnc = None
+                    del_node_inds = []
+
+                # if runConfigs['timeStamps']:  # Print message on timing
+                #     getUBStart = printTiming("Storing W and xr info", storeStart)
+                #     newUBStart = getUBStart
+
+                if runConfigs['getNewUB'] and (not breakOut):
+                    pairsDoneInfo[
+                        'totalPairsDone'] = -1  # In next round, we do not want to be led by pair-count on previous UB-estimates
+                    if verbose:
+                        mp_print("Estimating ellipsoid size from root movement in last step.")
+                    targeted_UB_steps = max(ellipsoidSize * oldRoot['nChild'], 2)
+                    epsx = np.linalg.norm((oldRoot['pos'] - xrAsIfRoot_g) * np.sqrt(oldRoot['prec']),
+                                          2) * np.sqrt(targeted_UB_steps)
+                    epsW = np.linalg.norm((oldRoot['prec'] - WAsIfRoot_g) / oldRoot['prec'],
+                                          2) * targeted_UB_steps
+                    # if runConfigs['timeStamps']:  # Print message on timing
+                    #     getUBStart = printTiming("Estimating new ellipsoid size", newUBStart)
+
+            # If it was above decided that this round can be stopped, all processes can continue to next round here.
+            if mpiInfoTmp.size > 1:
+                breakOut = mpi_wrapper.bcast(breakOut, root=0)
+            if breakOut:
+                continue
+            # If no UBs are used, processes other than 0 can continue
+            if (mpiInfoTmp.rank > 0) and (not runConfigs['useUB']):
+                continue
+
+            # Finally, we use the calculated epsx and epsW to calculate the new upper bounds and add them into the list
+            if runConfigs['useUB']:
+                if mpiInfoTmp.size > 1:
+                    if mpiInfoTmp.rank == 0:
+                        epsTuple = (epsx, epsW)
+                    epsx, epsW = mpi_wrapper.bcast(epsTuple, root=0)
+                # Get upper bounds by combining precalculated information with the chosen epsx and epsW
+                if len(UBInfo['tuples']):
+                    pairKeys, dLogLUBInfo = zip(*UBInfo['tuples'].items())
+                    dLogLDictUB = dict(zip(pairKeys, np.matmul(np.array(dLogLUBInfo), np.array([1, epsx, epsW]))))
+                else:
+                    dLogLDictUB = {}
+
+                # if runConfigs['timeStamps']:  # Print message on timing
+                #     sortingStart = printTiming("Getting upper bounds into dict", getUBStart)
+
+                # Sorting new upper bounds calculated on this process
+                if len(dLogLDictUB):
+                    pairsUB, dLogLUBs = zip(*sorted(dLogLDictUB.items(), key=lambda x: x[1], reverse=True))
+                else:
+                    pairsUB = ()
+                    dLogLUBs = ()
+
+                # if runConfigs['timeStamps']:  # Print message on timing
+                #     communicationStart = printTiming("Sorting upper bounds", sortingStart)
+
+                # Gather the computed upper bounds from all processes
+                if mpiInfoTmp.size > 1:  # (not singleProcess) and parallelInfo['parNow']:
+                    allPairsUB = mpi_wrapper.gather(pairsUB, root=0)
+                    alldLogLsUB = mpi_wrapper.gather(dLogLUBs, root=0)
+                    if mpiInfoTmp.rank != 0:
+                        # The memory where UBs are stored can be freed up on processes other than zero, because
+                        # probably they'll be idle for quite some rounds.
+                        try:
+                            del pairsUB
+                            del dLogLUBs
+                            del dLogLDictUB
+                            del UBInfo
+                            del pairKeys
+                            del dLogLUBInfo
+                            del myTasks
+                            del pairs
+                            gc.collect()
+                        except UnboundLocalError:
+                            pass
+                else:
+                    allPairsUB = [pairsUB]
+                    alldLogLsUB = [dLogLUBs]
+
+                # if runConfigs['timeStamps']:  # Print message on timing
+                #     insertStart = printTiming("Communicating UB info", communicationStart)
+
+                # Processes other than 0 have communicated everything. Can proceed to next round.
+                if mpiInfoTmp.rank == 0:
+                    UBInfo, runConfigs['getNewUB'], ellipsoidSize = getNewUBInfo(xrAsIfRoot_g, WAsIfRoot_g, epsx, epsW,
+                                                                                 alldLogLsUB, UBInfo, allPairsUB,
+                                                                                 oldRoot, del_node_inds,
+                                                                                 nChild=chInfo['nChild'], kNN=kNN,
+                                                                                 pairsDoneInfo=pairsDoneInfo,
+                                                                                 ellipsoidSize=ellipsoidSize,
+                                                                                 verbose=verbose,
+                                                                                 newUBObtained=runConfigs[
+                                                                                     'obtainedNewPairs'],
+                                                                                 mpiInfo=mpiInfo)
+
+                # if runConfigs['timeStamps']:  # Print message on timing
+                #  ubCommunicationStart = printTiming("Inserting new UBs and testing if out of ellipsoid", insertStart)
+
+                # if not singleProcess:
+                #     bcastUBTuple = mpi_wrapper.bcast(bcastUBTuple, root=0)
+                # UBInfo, runConfigs['getNewUB'] = bcastUBTuple
+
+                # if runConfigs['timeStamps']:  # Print message on timing
+                #     printTiming("Communicating sorted upper bound lists", ubCommunicationStart)
+
+            if mpiInfo.rank == 0:
+                # TODO: Remove eventually, only uncomment this for making animations
+                # if (mpiInfo.rank == 0) and bs_glob.nwk_counter and (tree is not None):
+                #     tree.to_newick(use_ids=True,
+                #                    results_path=os.path.join(bs_glob.nwk_folder,
+                #                                              'tree_{}.nwk'.format(bs_glob.nwk_counter)))
+                #     bs_glob.nwk_counter += 1
+
+                breakOut = breakOut or (chInfo['nChild'] <= chInfo['expNChild'])
+                if verbose:
+                    print_text = ", %d pairs were compared using %d processes." % (
+                        pairsDoneInfo['totalPairsDone'], mpiInfoTmp.size) \
+                        if pairsDoneInfo['totalPairsDone'] >= 0 else '.'
+                    mp_print("This round took %.2f seconds%s" % (time.time() - mergeRoundStart, print_text))
+                if chInfo['nChild'] % 100 == 0:
+                    mp_print("Now %d children left. Function runtime now %.5f seconds." %
+                             (chInfo['nChild'], time.time() - functionStart))
+                mergeCounter += 1
+                if (mergeCounter % 1000 == 0) and (tree is not None) and (tree_folder is not None):
+                    scData.storeTreeInFolder(os.path.join(tree_folder, 'greedy_tree_%d' % tmp_tree_ind),
+                                             with_coords=False, verbose=verbose, cleanup_tree=False)
+                    remove_tree_folders(tree_folder, removeDir=False, notRemove=tmp_tree_ind, base='greedy')
+                    tmp_tree_ind += 1
+            # mp_print("Post-processing in this round took: {} seconds.".format(time.time() - start_post_process),
+            #          DEBUG=True)
+
+        if (mpiInfo.rank == 0) and (tree_folder is not None):
+            # scData.storeTreeInFolder(os.path.join(tree_folder, 'greedy_tree_%d' % 1e5), with_coords=False,
+            #                          verbose=verbose, nwk=False)
+            remove_tree_folders(tree_folder, removeDir=True, base='greedy')
+        if (mpiInfo.rank == 0) and (runConfigs['mem_friendly_folder'] is not None):
+            remove_folder(runConfigs['mem_friendly_folder'])
+        return changedSomething
+
+    def getNewPairs(self, xrAsIfRoot_g, xrVarsAsIfRoot_g, runConfigs, NNInfo=None, newAnc=None, verbose=False,
+                    UBInfo=None, specialChild=None, oldPairs=None, chInfo=None, del_node_inds=[]):
+        if not runConfigs['useUBNow']:
+            # This means we need to recalculate UBs for all pairs
+            if not runConfigs['useNN']:
+                # This means we need to get all pairs, not only NNs. However, only if we don't have a special node:
+                if specialChild is None:
+                    new_pairs = list(itertools.combinations([child.nodeInd for child in self.childNodes], 2))
+                else:
+                    new_pairs = [(specialChild, child.nodeInd) for child in self.childNodes if
+                                 child.nodeInd != specialChild]
+            else:
+                # This means we will use nearest-neighbours
+                if runConfigs['getNewNN']:
+                    # In this case we calculate new NNs
+                    new_pairs, NNInfo = self.getNNPairs(xrAsIfRoot_g, xrVarsAsIfRoot_g, NNInfo, runConfigs['kNN'],
+                                                        verbose=verbose)
+                    runConfigs['getNewNN'] = False
+                    NNInfo['NNcounter'] = 0
+                else:
+                    oldPairs_array = np.array(oldPairs)
+                    rows_to_be_del = np.where(np.isin(oldPairs_array, del_node_inds).any(axis=1))[0]
+                    oldPairs = list(map(tuple, np.delete(oldPairs_array, rows_to_be_del, axis=0)))
+                    if newAnc is None:
+                        # When no new ancestor was added (e.g. when optimised times instead of merge) -> old UB-pairs
+                        new_pairs = oldPairs
+                    else:
+                        # In this case we should add NN-pairs involving the ancestor
+                        new_pairs, oldPairsList = self.get_new_nn_pairs(newAnc, NNInfo, runConfigs, UBInfo=UBInfo,
+                                                                        old_pairs_list=[oldPairs],
+                                                                        xrAIRoot=xrAsIfRoot_g,
+                                                                        xrVarsAIRoot=xrVarsAsIfRoot_g)
+                        oldPairs = oldPairsList[0]
+                        # index, nns = getApproxNNs(newAnc.ltqs[:, None], index=NNInfo['index'],
+                        #                           k=2 * runConfigs['kNN'],
+                        #                           pointsIds=[newAnc.nodeInd], addPoints=False)
+                        # nns = np.array(index.IDs)[nns]
+                        # pairs = [(newAnc.nodeInd, NNInfo['leafToChild'][nb]) for nb in nns[0, :] if
+                        #          NNInfo['leafToChild'][nb] != newAnc.nodeInd]
+                        # if len(pairs) > 0:
+                        #     # Update the connectivity matrix for the nearest neighbors with these new pairs
+                        #     pairs_array = np.array(pairs)
+                        #     NNInfo['conn_mat'][pairs_array[:, 0], pairs_array[:, 1]] = True
+                        #     NNInfo['conn_mat'][pairs_array[:, 1], pairs_array[:, 0]] = True
+                        #
+                        # pairs = [(newAnc.nodeInd, nb_nodeInd) for nb_nodeInd in
+                        #          NNInfo['conn_mat'][[newAnc.nodeInd], :].nonzero()[1]]
+                        # pairs += list(map(tuple, UBInfo['pairs']))
+
+                        # Then we add the old-NN-pairs, but we sort them efficiently
+                        # for del_node_ind in del_node_inds:
+                        #     oldPairs = [old_pair for old_pair in oldPairs if del_node_ind not in old_pair]
+                        new_pairs += oldPairs
+                        new_pairs = sorted(new_pairs)
+            # No UBs are used, so all pairs are new
+            old_pairs = []
+        else:
+            # We will use our pre-calculated UBs here. The UB-pairs are ordered descending in dLogLUB, in UBInfo
+            if newAnc is None:
+                if not runConfigs['getNewNN']:
+                    # When no new ancestor was added (e.g. optimised times instead of merge) -> sorted UB-pairs
+                    old_pairs = list(map(tuple, UBInfo['pairs']))
+                    new_pairs = []
+                else:
+                    # so we re-use UBs, recalculate NNs
+                    # First get all NNs
+                    new_pairs, NNInfo = self.getNNPairs(xrAsIfRoot_g, xrVarsAsIfRoot_g, NNInfo, runConfigs['kNN'],
+                                                        verbose=verbose)
+                    runConfigs['getNewNN'] = False
+                    NNInfo['NNcounter'] = 0
+                    # Then we test which UBs were already in the UB-pairs and which ones are new
+                    existingUBPairs = []
+                    existingUBs = []
+                    new_pairs_to_ind = {new_pair: ind for ind, new_pair in enumerate(new_pairs)}
+                    inds_to_be_del = []
+                    for ind, pair in enumerate(map(tuple, np.array(UBInfo['pairs']))):
+                        if pair in new_pairs:
+                            new_ind = new_pairs_to_ind[pair]
+                            # newInd = new_pairs.index(pair)
+                            existingUBPairs.append(pair)
+                            existingUBs.append(UBInfo['UBs'][ind])
+                            inds_to_be_del.append(new_ind)
+
+                    new_pairs = [pair for ind, pair in enumerate(new_pairs) if ind != inds_to_be_del]
+
+                    if len(existingUBPairs) == 0:
+                        UBInfo['pairs'] = np.zeros((0, 2))
+                    else:
+                        UBInfo['pairs'] = np.array(existingUBPairs)
+                    UBInfo['UBs'] = np.array(existingUBs)
+                    # nNewPairs = len(pairs)
+                    old_pairs = list(map(tuple, UBInfo['pairs']))
+            else:
+                # We need to add new pairs (e.g. with new ancestor) first, then the sorted UB-pairs
+                if not runConfigs['useNN']:
+                    # In this case we just add all new pairs with the new ancestor
+                    new_pairs = [(newAnc.nodeInd, child.nodeInd) for child in self.childNodes if
+                                 newAnc.nodeInd != child.nodeInd]
+                    old_pairs = [*UBInfo['pairs']]
+                elif not runConfigs['getNewNN']:
+                    new_pairs = self.get_new_nn_pairs(newAnc, NNInfo, runConfigs, UBInfo=UBInfo, xrAIRoot=xrAsIfRoot_g,
+                                                      xrVarsAIRoot=xrVarsAsIfRoot_g)
+                    old_pairs = list(map(tuple, UBInfo['pairs']))
+                else:
+                    # so we re-use UBs, recalculate NNs
+                    # First get all NNs
+                    new_pairs, NNInfo = self.getNNPairs(xrAsIfRoot_g, xrVarsAsIfRoot_g, NNInfo, runConfigs['kNN'],
+                                                        verbose=verbose)
+                    runConfigs['getNewNN'] = False
+                    NNInfo['NNcounter'] = 0
+
+                    # I here put all new NN-pairs on top, and only after it the ones for which I know a UB already.
+                    # Pairs may be listed that are not NN anymore, but these will drop out at next UB calculation round
+                    # start = time.time()
+                    # pairs = list(set(pairs) - set(map(tuple, np.array(UBInfo['pairs']))))
+                    # nNewPairs = len(pairs)
+                    # pairs += list(map(tuple, UBInfo['pairs']))
+                    # nPairs = len(pairs)
+                    # if verbose:
+                    #     mp_print(
+                    #         "Finding nearest neighbour pairs for which UB is already known with setdiff took %f seconds." % (
+                    #                 time.time() - start))
+
+                    start_keeping_known_UBs = time.time()
+                    # Then we test which UBs were already in the UB-pairs and which ones are new
+                    existingUBPairs = []
+                    existingUBs = []
+
+                    # start = time.time()
+                    new_pairs_to_ind = {new_pair: ind for ind, new_pair in enumerate(new_pairs)}
+                    inds_to_be_del = []
+                    for ind, pair in enumerate(map(tuple, np.array(UBInfo['pairs']))):
+                        if pair in new_pairs:
+                            new_ind = new_pairs_to_ind[pair]
+                            # newInd = new_pairs.index(pair)
+                            existingUBPairs.append(pair)
+                            existingUBs.append(UBInfo['UBs'][ind])
+                            inds_to_be_del.append(new_ind)
+
+                    new_pairs = [pair for ind, pair in enumerate(new_pairs) if ind != inds_to_be_del]
+                    # for ind, pair in enumerate(map(tuple, np.array(UBInfo['pairs']))):
+                    #     try:
+                    #         newInd = new_pairs.index(pair)
+                    #         existingUBPairs.append(pair)
+                    #         existingUBs.append(UBInfo['UBs'][ind])
+                    #         del new_pairs[newInd]
+                    #     except ValueError:
+                    #         # This pair is no longer in the NN-list
+                    #         pass
+
+                    # print("This took {} seconds.".format(time.time() - start))
+                    # print(existingUBPairs[-5:])
+                    # print(existingUBs[-5:])
+                    # print(inds_to_be_del)
+
+                    if len(existingUBPairs) == 0:
+                        UBInfo['pairs'] = np.zeros((0, 2))
+                    else:
+                        UBInfo['pairs'] = np.array(existingUBPairs)
+                    UBInfo['UBs'] = np.array(existingUBs)
+                    if verbose:
+                        mp_print("Finding nearest neighbour pairs for which UB is already known took %f seconds." % (
+                                time.time() - start_keeping_known_UBs), DEBUG=True)
+                    old_pairs = list(map(tuple, UBInfo['pairs']))
+
+        if runConfigs['useNN']:
+            # Test whether there are enough nearest neighbours for each node. Otherwise, get new NNs next round
+            unq_node_inds, counts = np.unique(np.array(old_pairs + new_pairs), return_counts=True)
+            # TODO: Check if we cannot just keep track of these counts
+            few_nn_inds = unq_node_inds[
+                np.where(counts <= 0.2 * runConfigs['kNN'])[0]]  # TODO: Only do those problematic ones
+            for few_nn_node_ind in few_nn_inds:
+                if few_nn_node_ind in chInfo['nodeIndToChildInd']:  # Check if this node is still a child
+                    mp_print("NN: Node {} has few nns, recalculating some new NNs for it.".format(few_nn_node_ind),
+                             DEBUG=True)
+                    child_ind = chInfo['nodeIndToChildInd'][few_nn_node_ind]
+                    new_nn_pairs, pairs_list = self.get_new_nn_pairs(self.childNodes[child_ind], NNInfo, runConfigs,
+                                                                     UBInfo=UBInfo, xrAIRoot=xrAsIfRoot_g,
+                                                                     xrVarsAIRoot=xrVarsAsIfRoot_g,
+                                                                     old_pairs_list=[new_pairs, old_pairs])
+                    new_pairs = new_nn_pairs + pairs_list[0]
+                    old_pairs = pairs_list[1]
+                    if len(new_nn_pairs) <= 0.4 * runConfigs['kNN']:
+                        mp_print("NN: Finding new NN-pairs did not succeed. Updating index for calculating NNs.")
+                        new_nn_pairs, pairs_list = self.get_new_nn_pairs(self.childNodes[child_ind], NNInfo, runConfigs,
+                                                                         old_pairs_list=[new_pairs],
+                                                                         update_nn_index=True,
+                                                                         xrAIRoot=xrAsIfRoot_g,
+                                                                         xrVarsAIRoot=xrVarsAsIfRoot_g)
+                        new_pairs = new_nn_pairs + pairs_list[0]
+
+                else:
+                    mp_print("NN: Somehow, node {} occurs in a pair, "
+                             "but it is not a child of the root anymore. "
+                             "Check this at some point.".format(few_nn_node_ind), DEBUG=True)
+
+        # if newAnc is not None:
+        #     # When using UBs, we should start by computing all dLogLs of the new ancestor with the rest:
+        #     # When getNewNN, calculate new NN-pairs, then select those without UB and add them on the top as new pairs
+        #     if boolArgs['useNN']:
+        #         if not boolArgs['getNewNN']:
+        #             NNInfo['NNcounter'] += 1
+        #             for deletedInd in del_node_inds:  # Map all nb-connections of merged leafs to their ancestor
+        #                 if deletedInd in NNInfo['leafToChild']:
+        #                     NNInfo['leafToChild'][deletedInd] = newAnc.nodeInd
+        #                 else:
+        #                     downstreamLeafs = [leaf for leaf, child in NNInfo['leafToChild'].items() if
+        #                                        child == deletedInd]
+        #                     for leaf in downstreamLeafs:
+        #                         NNInfo['leafToChild'][leaf] = newAnc.nodeInd
+        #
+        #             # Get nearest neighbours of new ancestor. Take twice as many neighbours as for the other nodes,
+        #             # to compensate for no other nodes adding connections to ancestor, and for merged nodes being part
+        #             # of ancestor-neighbours
+        #             index, nns = getApproxNNs(newAnc.ltqs[:, None], index=NNInfo['index'], k=2 * NNInfo['kNN'],
+        #                                       pointsIds=[newAnc.nodeInd], addPoints=False)
+        #             nns = np.array(index.IDs)[nns]
+        #             pairs = [sorted((newAnc.nodeInd, NNInfo['leafToChild'][nb])) for nb in nns[0, :] if
+        #                      NNInfo['leafToChild'][nb] != newAnc.nodeInd]
+        #             # Sort pairs to make computation faster
+        #             pairs = sorted(pairs)
+        #         else:
+        #             pairs, NNInfo = self.getNNPairs(xrAsIfRoot_g, NNInfo, verbose=verbose)
+        #             boolArgs['getNewNN'] = False
+        #             NNInfo['NNcounter'] = 0
+        #     else:
+        #         # If no NNs are used, just pair the new ancestor to all existing root-children
+        #         pairs = [(newAnc.nodeInd, child.nodeInd) for child in self.childNodes[:-1]]
+        # else:
+        #     # In this case no new ancestor was added because only the times were re-optimised
+        #     pairs = []
+        #
+        # if not boolArgs['useUBNow']:
+        #     if boolArgs['useNN'] and boolArgs['getNewNN']:
+        #         pairs, NNInfo = self.getNNPairs(xrAsIfRoot_g, NNInfo, verbose=verbose)
+        #         boolArgs['getNewNN'] = False
+        #         NNInfo['NNcounter'] = 0
+        #     # Create a list of all pairs, over which we will loop
+        #     elif specialChild is None:
+        #         pairs = list(itertools.combinations([child.nodeInd for child in self.childNodes], 2))
+        #     # Since we are not using upper bounds. All pairs are new.
+        #     nNewPairs = len(pairs)
+        # else:
+        #     # "pairs" currently contains all pairs with the newly created ancestor. These should be done first.
+        #     nNewPairs = len(pairs)
+        #     # Append list of ind-pairs ordered descending in dLogLUB. These will be done until dLogLMax>dLogLUB
+        #     pairs += [*UBInfo['pairs']]
+        #     if boolArgs['useNN']:
+        #         # Test whether there are enough nearest neighbours for each node. Otherwise, get new NNs next round
+        #         _, counts = np.unique(np.array(pairs), return_counts=True)
+        #         boolArgs['getNewNN'] = np.any(counts < 0.2 * NNInfo['kNN'])
+        #
+        # nPairs = len(pairs)
+        nNewPairs = len(new_pairs)
+        pairs = new_pairs + old_pairs
+        nPairs = len(pairs)
+        return pairs, nPairs, nNewPairs
+
+    def initializeMergeRound(self, xrAsIfRoot_g, WAsIfRoot_g, nChild, runConfigs, mpiInfo, UBInfo, oldRoot,
+                             timeOptInfo=None, specialChild=None, newAnc=None, del_node_inds=[], verbose=True,
+                             NNInfo=None, oldPairs=None, redoNNFrac=0.1, pairsDoneInfo=None, chInfo=None):
+        # Determine if the use of UBs and NNs should be stopped because too few children are left
+        if nChild <= runConfigs['nChildUB']:
+            # If too few children are left we do not use upper bound calculation anymore since it is not helping
+            runConfigs['useUB'] = False
+            runConfigs['getNewUB'] = False
+        if nChild <= runConfigs['nChildNN']:
+            # The same holds for using nearest neighbors. It is only necessary for large numbers of children.
+            runConfigs['useNN'] = False
+        if nChild <= runConfigs['n_mem_friendly']:
+            # Under a certain number of children, it is faster to communicate ltqs directly using mpi,
+            # not via memmapped file
+            runConfigs['mem_friendly'] = False
+        # Initialize a dictionary to store pairs and UBs sorted by UB
+        UBInfo = {'pairs': np.zeros((0, 2), dtype=int), 'UBs': np.zeros(0)} if (
+                runConfigs['getNewUB'] or (not runConfigs['useUB'])) else UBInfo
+        # Make new dict to store newly gathered upper bound information (for the pairs including new ancestor)
+        UBInfo['tuples'] = {}
+
+        # Determine whether we will use the upper bound information in this round
+        if runConfigs['getNewUB'] or (not runConfigs['useUB']):
+            # In this round we do not use upper bound information
+            runConfigs['useUBNow'] = False
+            pairsDoneInfo['pairsDoneList'] = []
+            if verbose:
+                mp_print("\nStarting new merge round. %s" % (
+                    "Estimating new upper bounds." if runConfigs['useUB'] else "Not using upper bound estimation."),
+                         ALL_RANKS=(mpiInfo.size == 1))
+            if runConfigs['useUB']:
+                # In this case, this round will calculate new upper bounds. Therefore we store the current
+                # root-information, such that we can notice when the root moves out of the allowed ellipsoid
+                oldPos = xrAsIfRoot_g.copy()
+                oldPrec = WAsIfRoot_g.copy()
+                oldNChild = nChild
+                oldRoot = {'pos': oldPos, 'prec': oldPrec, 'nChild': oldNChild}
+            else:
+                # In this case we do not use upper bounds ever, so no need to store root information.
+                oldRoot = None
+        else:
+            if verbose:
+                mp_print("\nStarting new merge round. Using calculated upper bounds.")
+            runConfigs['useUBNow'] = True
+
+        # We periodically reoptimize the edge lengths, they may have become sub-optimal due to merges.
+        runConfigs['reoptTimesNow'] = (timeOptInfo['timeOptRoundsAgo'] > runConfigs['redoTimeAt']) and (
+            not runConfigs['useUBNow']) and self.isRoot
+
+        # TODO: Check whether getting new pairs is handled correctly when time optimization is done.
+        # Update NN information when new ancestor was added
+        NNInfo = updateNNInfo(runConfigs, NNInfo, del_node_inds, newAnc)
+
+        # Given the information we now have on whether to calc. new UBs, and whether to use NNs. We can now get a list
+        # of pairs, in the order that we want to consider them.
+        runConfigs['obtainedNewPairs'] = runConfigs['getNewUB'] or runConfigs['getNewNN']
+        start_new_pairs = time.time()
+        pairs, nPairs, nNewPairs = self.getNewPairs(xrAsIfRoot_g, 1 / WAsIfRoot_g, runConfigs, NNInfo=NNInfo,
+                                                    newAnc=newAnc, verbose=verbose, oldPairs=oldPairs,
+                                                    UBInfo=UBInfo, specialChild=specialChild, chInfo=chInfo,
+                                                    del_node_inds=del_node_inds)
+        if verbose:
+            mp_print("Finding new pairs took: {} seconds.".format(time.time() - start_new_pairs), DEBUG=True)
+        pairInfoTuple = (pairs, nPairs, nNewPairs)
+        runConfigs['parNow'] = (mpiInfo.size > 1) and (
+                (nNewPairs > runConfigs['nNewPairsPar']) or (
+                pairsDoneInfo['totalPairsDone'] > runConfigs['nDonePairsPar']))
+
+        if runConfigs['useNN'] and (NNInfo['NNcounter'] > runConfigs['redoNNAt']):
+            if verbose:
+                mp_print("Will do a periodic recalculation of nearest neighbours at next round.")
+            runConfigs['redoNNAt'] = max(int(nChild * redoNNFrac), 10)
+            runConfigs['getNewNN'] = True
+
+        # if nChild == parallelInfo['nextTry']:
+        #     parallelInfo['parTry'] = True
+        #     parallelInfo['timingCheck'] = 3
+        #     parallelInfo['par'] = True
+        #     parallelInfo['parNow'] = True
+        # # Determine whether we will distribute the tasks over different CPUs or not (communication may be too costly)
+        # if parallelInfo['parTry']:
+        #     if mpiInfo.rank == 0:
+        #         if parallelInfo['timingCheck'] == 0:
+        #             if parallelInfo['par']:
+        #                 parallelInfo['parTiming'] = np.mean(parallelInfo['timingList'][-2:])
+        #                 if parallelInfo['nonparTiming'] is None:  # Check how long non-parallel takes
+        #                     parallelInfo['par'] = False
+        #                     parallelInfo['timingCheck'] = 3
+        #                 else:
+        #                     parallelInfo['par'] = parallelInfo['parTiming'] < parallelInfo['nonparTiming']
+        #                     mp_print("Time for parallel computing was estimated at %f seconds.\n"
+        #                              "Time for non-parallel was estimated at %f seconds." %
+        #                              (parallelInfo['parTiming'], parallelInfo['nonparTiming']))
+        #                     mp_print("The past 4 merge rounds show that it is faster to run the code %s parallelization." % (
+        #                         "with" if parallelInfo['par'] else "without"), ALL_RANKS=True)
+        #                     parallelInfo['parTiming'] = None
+        #                     parallelInfo['nonparTiming'] = None
+        #                     parallelInfo['parTry'] = False
+        #                     parallelInfo['nextTry'] = max(int(nChild / 10), 50)
+        #             else:
+        #                 parallelInfo['nonparTiming'] = np.mean(parallelInfo['timingList'][-2:])
+        #                 if parallelInfo['parTiming'] is None:  # Check how long non-parallel takes
+        #                     parallelInfo['par'] = True
+        #                     parallelInfo['timingCheck'] = 3
+        #                 else:
+        #                     parallelInfo['par'] = parallelInfo['parTiming'] < parallelInfo['nonparTiming']
+        #                     mp_print("Time for parallel computing was estimated at %f seconds.\n"
+        #                              "Time for non-parallel was estimated at %f seconds." %
+        #                              (parallelInfo['parTiming'], parallelInfo['nonparTiming']))
+        #                     mp_print("The past 4 merge rounds show that it is faster to run the code %s parallelization." % (
+        #                         "with" if parallelInfo['par'] else "without"), ALL_RANKS=True)
+        #                     parallelInfo['parTiming'] = None
+        #                     parallelInfo['nonparTiming'] = None
+        #                     parallelInfo['parTry'] = False
+        #                     parallelInfo['nextTry'] = max(int(nChild / 10), 50)
+        #
+        #         parallelInfo['parNow'] = (parallelInfo['par'] or (nNewPairs > 1000))  # and (not nNewPairs < 100)
+        #
+        #     parallelInfo = mpi_wrapper.bcast(parallelInfo, root=0)
+
+        return runConfigs, pairInfoTuple, oldRoot, UBInfo, pairsDoneInfo
+
+    def sendMergeChildrenInfo(self, runConfigs, pairInfoTuple, UBInfo, chInfo, xrAsIfRoot_g, WAsIfRoot_g):
+        # Gather all information that should be sent into a tuple containing generic Python-objects, and
+        # into some numpy-arrays that will be sent separately (because these can be communicated faster).
+        # mp_print("Before communication, memory usage on this process is %.2f MB."
+        #          % (psutil.Process(os.getpid()).memory_info().rss / 1024 ** 2),
+        #          ALL_RANKS=True)
+        if runConfigs['mem_friendly']:
+            empty_folder(runConfigs['mem_friendly_folder'])
+            runConfigs['mem_friendly_files'] = os.path.join(runConfigs['mem_friendly_folder'],
+                                                            'data%d' % np.random.randint(1e6))
+        infoTuple = (pairInfoTuple, UBInfo, runConfigs, chInfo)
+        mpi_wrapper.bcast(infoTuple, root=0)
+
+        ltqsChildren, ltqsVarsChildren, tChildren = self.getInfoChildren()
+        if runConfigs['mem_friendly']:
+            # This process will store the necessary arrays in binary files using the numpy.save-function.
+            # These arrays can then be read using memmap, such that only those parts have to be loaded into
+            # memory that are actually required
+            files_sent = False
+            tries = 0
+            while (not files_sent) and (tries <= 10):
+                np.save(runConfigs['mem_friendly_files'] + '_ltqs.npy', ltqsChildren, allow_pickle=False)
+                np.save(runConfigs['mem_friendly_files'] + '_ltqsVars.npy', ltqsVarsChildren,
+                        allow_pickle=False)
+                try:
+                    ltqsChildren = np.load(runConfigs['mem_friendly_files'] + '_ltqs.npy', mmap_mode='r',
+                                           allow_pickle=False)
+                    ltqsVarsChildren = np.load(runConfigs['mem_friendly_files'] + '_ltqsVars.npy', mmap_mode='r',
+                                               allow_pickle=False)
+                    files_sent = True
+                    mpi_wrapper.bcast(files_sent, root=0)
+                except FileNotFoundError:
+                    tries += 1
+
+            if not files_sent:
+                mpi_wrapper.bcast(files_sent, root=0)
+                mp_print("Trying to communicate data: ltqsChildren with shape {}, and ltqsVarsChildren with"
+                         " shape {}, at filepaths: {}, "
+                         "but it does not work.".format(ltqsChildren.shape, ltqsVarsChildren.shape,
+                                                        runConfigs['mem_friendly_files'] + '_ltqs.npy'),
+                         ERROR=True)
+                mp_print("Resorting to a less memory-friendly way of communicating.")
+            else:
+                # Send some smaller numpy arrays (concerning coordinates of root)
+                # This sending also functions as a start signal for the other process to start loading the .npy-files
+                rootInfo = np.vstack((xrAsIfRoot_g, WAsIfRoot_g))
+                mpi_wrapper.Bcast(rootInfo, root=0, type='double')
+                mpi_wrapper.Bcast(tChildren, root=0, type='double')
+                del rootInfo
+                gc.collect()
+
+        if not runConfigs['mem_friendly'] or (not files_sent):
+            # The following communication should be faster, but requires the whole numpy arrays to be loaded
+            # into memory, instead of loading only what's necessary using the memmap
+            # We will communicate 2 numpy arrays with the following layout:
+            # ltqsInfo = [ltqsChildren, ltqsAIRoot, ltqsVarsChildren, WAIRoot]
+            # and
+            # tChildren = [tChildren]
+            ltqsInfo = np.concatenate(
+                (ltqsChildren, xrAsIfRoot_g[:, None], ltqsVarsChildren, WAsIfRoot_g[:, None]), axis=1)
+            mpi_wrapper.Bcast(ltqsInfo, root=0, type='double')
+            del ltqsInfo
+            gc.collect()
+            mpi_wrapper.Bcast(tChildren, root=0, type='double')
+        mpi_wrapper.barrier()
+        return runConfigs, tChildren, ltqsChildren, ltqsVarsChildren
+
+    def receiveMergeChildrenInfo(self):
+        # mp_print("Before communication, memory usage on this process is %.2f MB."
+        #          % (psutil.Process(os.getpid()).memory_info().rss / 1024 ** 2),
+        #          ALL_RANKS=True)
+        infoTuple = None
+        infoTuple = mpi_wrapper.bcast(infoTuple, root=0)
+        pairInfoTuple, UBInfo, runConfigs, chInfo = infoTuple
+        nChild = chInfo['nChild']
+        files_sent = False
+        if runConfigs['mem_friendly']:
+            # Receive root coordinates
+            files_sent = mpi_wrapper.bcast(files_sent, root=0)
+            if files_sent:
+                rootInfo = np.empty((2, bs_glob.nGenes))
+                tChildren = np.empty(nChild)
+                mpi_wrapper.Bcast(rootInfo, root=0, type='double')
+                mpi_wrapper.Bcast(tChildren, root=0, type='double')
+                xrAsIfRoot_g = rootInfo[0, :]
+                WAsIfRoot_g = rootInfo[1, :]
+                ltqsChildren = np.load(runConfigs['mem_friendly_files'] + '_ltqs.npy', mmap_mode='r',
+                                       allow_pickle=False)
+                ltqsVarsChildren = np.load(runConfigs['mem_friendly_files'] + '_ltqsVars.npy', mmap_mode='r',
+                                           allow_pickle=False)
+                del rootInfo
+                gc.collect()
+
+        if not runConfigs['mem_friendly'] or (not files_sent):
+            # Prepare numpy arrays to be obtained.
+            ltqsInfo = np.empty((bs_glob.nGenes, 2 * nChild + 2))
+            tChildren = np.empty(nChild)
+            # Receive numpy arrays
+            mpi_wrapper.Bcast(ltqsInfo, root=0, type='double')
+            mpi_wrapper.Bcast(tChildren, root=0, type='double')
+
+            # Compile child information
+            ltqsChildren, xrAsIfRoot_g, ltqsVarsChildren, WAsIfRoot_g = \
+                np.array_split(ltqsInfo, indices_or_sections=[nChild, nChild + 1, 2 * nChild + 1], axis=1)
+            del ltqsInfo
+            gc.collect()
+            xrAsIfRoot_g = xrAsIfRoot_g.flatten()
+            WAsIfRoot_g = WAsIfRoot_g.flatten()
+
+        coordsTuple = (xrAsIfRoot_g, WAsIfRoot_g, ltqsChildren, ltqsVarsChildren)
+        mpi_wrapper.barrier()
+        return infoTuple, tChildren, coordsTuple
+
+    def getNNPairs(self, xrAIRoot, xrVarsAIRoot, NNInfo, kNN, verbose=False):
+        start = time.time()
+
+        # We first gather all ltq-information about the children
+        # post_ltqsCh = self.get_posterior_info_children(xrAIRoot, 1 / xrVarsAIRoot) # SARAH: Before I added min time
+        post_ltqsCh = self.get_posterior_info_children(xrAIRoot, 1 / xrVarsAIRoot, minimum_time=1e-4) # SARAH fix
+        # We center the ltq-information around the root
+        post_ltqsCh -= xrAIRoot[:, None]
+        NNInfo['subtracted_mean'] = xrAIRoot
+
+        # # (Re-)introduce the Gaussian prior to get posterior estimates for the child-positions
+        # post_ltqsCh_old = lik_to_post_coords(ltqsCh, ltqsVarsCh)
+        # # Also get the posterior position for the root
+        # post_xrAIRoot_old = lik_to_post_coords(xrAIRoot, xrVarsAIRoot)
+        # # We center the ltq-information around the root
+        # post_ltqsCh_old -= post_xrAIRoot_old[:, None]
+
+        # We ask for the nearest neighbours
+        nodeInds = [child.nodeInd for child in self.childNodes]
+        # TODO: Check how to get approxNNs beyond the brute-force sklearn one
+        # Instead of taking cosine metric, we can also normalize the vectors and use squared-euclidean
+        norms = np.linalg.norm(post_ltqsCh, axis=0)
+        np.divide(post_ltqsCh, norms, out=post_ltqsCh)
+        index, nns = getApproxNNs(post_ltqsCh, index=None, k=kNN + 1, n_bits_factor=100, metric='sqeuclidean',
+                                  pointsIds=nodeInds, addPoints=True, th1=1e9, th2=1e9)
+        nns = np.array(nodeInds)[nns]
+        # Create unique set of all pairs with at least one nn-connection
+        pairs = set()
+        for row, nodeInd in enumerate(nodeInds):
+            pairs.update(
+                [tuple(sorted(pair)) for pair in zip([nodeInd] * (kNN + 1), nns[row, :]) if pair[0] != pair[1]])
+        pairs = sorted(pairs)
+        # We store the nearest neighbor-information in a connectivity matrix
+        # TODO: Clean this up, check if it can be done more efficient
+        pairs_array = np.array(pairs)
+        # Note that we make the sparse matrix dimensions twice the number of cells. In this way we can store the
+        # adjacency between nodes even when we have the maximal number of nodes (in a fully binary tree).
+        connectivity_mat = csr_array((np.ones(pairs_array.shape[0]), (pairs_array[:, 0], pairs_array[:, 1])),
+                                     shape=(2 * bs_glob.nCells, 2 * bs_glob.nCells), dtype=bool)
+        connectivity_mat_T = csr_array((np.ones(pairs_array.shape[0]), (pairs_array[:, 1], pairs_array[:, 0])),
+                                       shape=(2 * bs_glob.nCells, 2 * bs_glob.nCells), dtype=bool)
+        connectivity_mat = connectivity_mat + connectivity_mat_T
+        connectivity_mat = lil_array(connectivity_mat)
+
+        # Take old nearest neighbors and add the newly calculated ones
+        NNInfo['conn_mat'] += connectivity_mat
+
+        # We also store information of to what current child-node each node in the knn-index is mapped
+        NNInfo['leafToChild'] = {nodeInd: nodeInd for nodeInd in nodeInds}
+        NNInfo['index'] = index
+        if verbose:
+            mp_print("Getting nearest neighbour pairs took %f seconds." % (time.time() - start))
+        return pairs, NNInfo
+
+    def get_new_nn_pairs(self, new_node, NNInfo, runConfigs, UBInfo=None, old_pairs_list=None, update_nn_index=False,
+                         xrAIRoot=None, xrVarsAIRoot=None):
+        if UBInfo is not None:
+            # TODO: Check if this is necessary: # In this case also delete old UB-information on the "new_node",
+            #  since we're going to calculate that again.
+            to_be_deleted = np.where(UBInfo['pairs'] == new_node.nodeInd)[0]
+            UBInfo['pairs'] = np.delete(UBInfo['pairs'], to_be_deleted, axis=0)
+            UBInfo['UBs'] = np.delete(UBInfo['UBs'], to_be_deleted)
+        if old_pairs_list is not None:
+            for ind_pairs, old_pairs in enumerate(old_pairs_list):
+                new_node_ind = new_node.nodeInd
+                # In this case, we also delete all pairs with the new_node from the old set of pairs
+                old_pairs_list[ind_pairs] = [old_pair for old_pair in old_pairs if new_node_ind not in old_pair]
+        # Here, we should just get NN-pairs with the new ancestor. Take twice as many neighbours as for the
+        # other nodes to compensate for no other nodes adding connections to ancestor
+        if update_nn_index:
+            # We first gather all ltq-information about the children
+            # post_ltqsCh = self.get_posterior_info_children(xrAIRoot, 1 / xrVarsAIRoot) # SARAH: before adding min_time
+            post_ltqsCh = self.get_posterior_info_children(xrAIRoot, 1 / xrVarsAIRoot, minimum_time=1e-4) # SARAH FIX
+            # We center the ltq-information around the root
+            post_ltqsCh -= xrAIRoot[:, None]
+            NNInfo['subtracted_mean'] = xrAIRoot
+
+            # Instead of taking cosine metric, we can also normalize the vectors and use squared-euclidean
+            norms = np.linalg.norm(post_ltqsCh, axis=0)
+            np.divide(post_ltqsCh, norms, out=post_ltqsCh)
+
+            # We update the index for the nearest neighbours
+            nodeInds = [child.nodeInd for child in self.childNodes]
+            pointsT = post_ltqsCh.T
+            NNInfo['index'].fit(pointsT)
+            NNInfo['index'].IDs = nodeInds
+            NNInfo['leafToChild'] = {nodeInd: nodeInd for nodeInd in nodeInds}
+
+        # Get the posterior coordinates for the new node
+        # post_ltqs = self.get_posterior_info_children(xrAIRoot, 1 / xrVarsAIRoot)
+        # post_ltqs, _ = getLtqsAsIfRoot_vectorized(new_node.ltqs[:, None], new_node.getW()[:, None], new_node.tParent,
+        #                                           xrAIRoot, 1 / xrVarsAIRoot) # SARAH before adding new_time=1e-4
+
+        t_parent = max(new_node.tParent, 1e-4) # SARAH new
+        post_ltqs, _ = getLtqsAsIfRoot_vectorized(new_node.ltqs[:, None], new_node.getW()[:, None], t_parent, xrAIRoot,
+                                                  1 / xrVarsAIRoot) # SARAH new
+
+        post_ltqs = post_ltqs.flatten()
+
+        # post_ltqs_old = lik_to_post_coords(new_node.ltqs, new_node.getLtqsVars())
+        centered_query = (post_ltqs - NNInfo['subtracted_mean'])[:, None]
+        normalized_query = centered_query / np.linalg.norm(centered_query)
+        index, nns = getApproxNNs(normalized_query, index=NNInfo['index'],
+                                  k=20 * runConfigs['kNN'], pointsIds=[new_node.nodeInd], addPoints=False)
+
+        nns = np.array(index.IDs)[nns]
+        # Make list of unique neighbors that are not the node itself
+        non_unique_partners = np.array(
+            [NNInfo['leafToChild'][nb] for nb in nns[0, :] if NNInfo['leafToChild'][nb] != new_node.nodeInd])
+        seen = set()
+        partners = []
+        for item in non_unique_partners:
+            if item not in seen:
+                seen.add(item)
+                partners.append(item)
+
+        pairs = [(new_node.nodeInd, partner) for partner in partners]
+        if len(pairs) > 0:
+            if len(pairs) > runConfigs['kNN']:
+                pairs = pairs[:runConfigs['kNN']]
+            # Update the connectivity matrix for the nearest neighbors with these new pairs
+            pairs_array = np.array(pairs)
+            NNInfo['conn_mat'][pairs_array[:, 0], pairs_array[:, 1]] = True
+            NNInfo['conn_mat'][pairs_array[:, 1], pairs_array[:, 0]] = True
+
+        pairs = [(new_node.nodeInd, nb_nodeInd) for nb_nodeInd in
+                 NNInfo['conn_mat'][[new_node.nodeInd], :].nonzero()[1]]
+        if old_pairs_list is not None:
+            return pairs, old_pairs_list
+        return pairs
+
+    def optimiseConnected(self, mpiInfo, singleProcess=False, verbose=True):
+        if (mpiInfo.rank == 0) or singleProcess:
+            ltqsCh, ltqsVarsCh, tCh = self.getInfoChildren()
+            tStar, loglik, W_g, xr_g = optimiseTStar(ltqsCh, ltqsVarsCh, verbose=verbose, nChilds=len(self.childNodes))
+        else:
+            tStar = None
+            W_g = None
+            xr_g = None
+        if (not singleProcess) and (mpiInfo.size > 1):
+            tStar = mpi_wrapper.bcast(tStar, root=0)
+            W_g = mpi_wrapper.bcast(W_g, root=0)
+            xr_g = mpi_wrapper.bcast(xr_g, root=0)
+        for ind, child in enumerate(self.childNodes):
+            child.tParent = tStar[ind]
+        self.getLtqsComplete(mem_friendly=True)
+        return True, W_g, xr_g
+
+    def getChildInfo(self, xrAsIfRoot_g, WAsIfRoot_g, ind1, ind2, nodeInd1, recalcInd1=True):
+        # Gather information on second node
+        child2 = self.childNodes[ind2]
+
+        sortedNodeInds = tuple(sorted([nodeInd1, child2.nodeInd]))
+        # We check whether for this pair of nodes we already have some reasonable diff. time guess
+        # tInit = getNodePairInfo(sortedNodeInds)
+        # In case we do sequential optimisation, we also check if t_12 = t_1a+t_2a is known already
+        # t12Opt = getNodePairInfo(sortedNodeInds) if boolArgs['sequential'] else None
+        if not recalcInd1:
+            return child2, sortedNodeInds
+        else:
+            # Gather information on first node
+            child1 = self.childNodes[ind1]
+            tOld1, wbar1_g, ltqs1, ltqsVars1, nodeInd1 = child1.getInfo()
+            child1Tuple = (tOld1, wbar1_g, ltqs1, ltqsVars1, nodeInd1)
+
+            # Do some computations that are independent of second node:
+            rootMinusFirst_W_g = WAsIfRoot_g - wbar1_g
+            rootMinusFirst_ltqs = xrAsIfRoot_g * WAsIfRoot_g - wbar1_g * ltqs1
+            return child2, sortedNodeInds, child1, child1Tuple, rootMinusFirst_ltqs, rootMinusFirst_W_g
+
+    def initializeMergeGeneral(self, sequential=True, ellipsoidSize=None, mpiInfo=None, specialChild=None,
+                               random=False, nChildNN=-1, nChildUB=-1, kNN=50, redoTimeFrac=0.05, redoNNFrac=0.1,
+                               outputFolder=None, tree=None, nNewPairsPar=1000, nDonePairsPar=3000, tmpTreeInd=None,
+                               n_mem_friendly=500):
+        runConfigs = {'sequential': sequential}
+        runConfigs['outputFolder'] = outputFolder
+
+        # Initialize boolean that determines if we are estimating dLogL-upper bounds for all pairs
+        runConfigs['useUB'] = runConfigs['getNewUB'] = (ellipsoidSize is not None) and (specialChild is None) and (
+            not random)
+
+        # Determine what number of children should be merged before ending this loop
+        nChild = len(self.childNodes)
+        expNChild = 3 if self.isRoot else 2
+        # specialChild indicates that we only want to compare merges with a single node
+        if specialChild is not None:
+            expNChild = max(nChild - 1, expNChild)
+        # nodeIndToMergeInd = {child.nodeInd: ind for ind, child in enumerate(self.childNodes)}
+        chInfo = {'nChild': nChild, 'expNChild': expNChild}  # , 'nodeIndToMergeInd': nodeIndToMergeInd}
+
+        # Determine if we should use nearest-neighbours as candidates for merges
+        runConfigs['useNN'] = (nChildNN >= 0) and (nChild > nChildNN) and (specialChild is None)
+        runConfigs['getNewNN'] = runConfigs['useNN']
+
+        # Prepare some information for using only nearest neighbours
+        runConfigs['nChildNN'] = nChildNN
+        runConfigs['nChildUB'] = nChildUB
+        runConfigs['kNN'] = kNN
+        # We initialize NNInfo, even if NNs are not used, to prevent bugs, but initializing the lil_array takes time
+        NNInfo = {'NNcounter': 0, 'conn_mat': None, 'subtracted_mean': None}
+        if runConfigs['useNN']:
+            NNInfo['conn_mat'] = lil_array((2 * bs_glob.nCells, 2 * bs_glob.nCells), dtype=bool)
+
+        # Determine how we communicate data between processes (mem-friendly, using memmap) or not
+        runConfigs['n_mem_friendly'] = n_mem_friendly
+        runConfigs['mem_friendly'] = nChild > n_mem_friendly
+        runConfigs['mem_friendly_folder'] = None
+        if runConfigs['mem_friendly']:
+            if outputFolder is not None:
+                runConfigs['mem_friendly_folder'] = os.path.join(outputFolder,
+                                                                 'shared_data_%d' % np.random.randint(1e8))
+            else:
+                runConfigs['mem_friendly_folder'] = os.path.abspath('shared_data_%d' % np.random.randint(1e8))
+            Path(runConfigs['mem_friendly_folder']).mkdir(parents=True, exist_ok=True)
+
+        # Create a dictionary that points from unique nodeInd to the index of that node in the list of root-children
+        chInfo['nodeIndToChildInd'] = {child.nodeInd: childInd for childInd, child in enumerate(self.childNodes)}
+
+        # TODO: Maybe remove timestamps-option eventually
+        timeStamps = False
+        runConfigs['timeStamps'] = timeStamps if (mpiInfo.rank == 0) else False
+
+        # Prepare some information for deciding whether to use parallel computing or not
+        # parTry = (mpiInfo.size > 1) and (chInfo['nChild'] > 10)
+        # parallelInfo = {'timingList': [], 'par': parTry, 'parNow': parTry, 'timingCheck': 2,
+        #                 'parTiming': None, 'nonparTiming': None, 'parTry': parTry, 'nextTry': 1e9}
+        runConfigs['nNewPairsPar'] = nNewPairsPar
+        runConfigs['nDonePairsPar'] = nDonePairsPar
+        runConfigs['parNow'] = mpiInfo.size > 1
+
+        # Initialize some more variables
+        newAnc = None
+        del_node_inds = []
+        oldRoot = None
+        UBInfo = None
+        pairs = None
+        timeOptInfo = {'doTimeOpt': False, 'timeOptRoundsAgo': 0}
+        if specialChild:
+            timeOptInfo['timeOptRoundsAgo'] = 1
+        runConfigs['redoTimeAt'] = max(int(chInfo['nChild'] * redoTimeFrac), 10)
+        runConfigs['redoNNAt'] = int(chInfo['nChild'] * redoNNFrac)
+        # if manualMerges is not None:
+        #     manualMergeCounter = -1
+        #     mergeIndToNodeInd = {ind: child.nodeInd for ind, child in enumerate(self.childNodes)}
+
+        # Store initial version of the tree in an intermediate folder where we track the progress
+        mergeCounter = 0
+        tmp_folder = None
+        tmp_tree_ind = None
+        if (outputFolder is not None) and (specialChild is None):
+            tmp_folder = os.path.join(outputFolder, 'tmp_trees')
+            Path(tmp_folder).mkdir(parents=True, exist_ok=True)
+            if mpiInfo.rank == 0:
+                if tmpTreeInd is not None:
+                    tmp_tree_ind = tmpTreeInd + 1
+                else:
+                    tmp_tree_ind = 0
+        breakOut = False or (chInfo['nChild'] <= chInfo['expNChild'])
+        pairsDoneInfo = {'totalPairsDone': 0, 'pairsDoneList': []}
+
+        initNoneVars = (newAnc, del_node_inds, oldRoot, UBInfo, pairs)
+        initVars = (mergeCounter, tmp_folder, tmp_tree_ind, breakOut, pairsDoneInfo)
+        infoTuple = (chInfo, NNInfo, runConfigs, timeOptInfo)
+        return infoTuple, initVars, initNoneVars
+
+    # Used
+    def getOptimalDLogLPairInfoNew(self, xrAsIfRoot_g, WAsIfRoot_g, maxdLogLTuples, maxdLogLTuplesZeroRoot,
+                                   nodeIndToChildInd, timeOptInfo, sequential=True, verbose=True,
+                                   random=False, dLogLDict=None):
+        ind1s, ind2s, maxdLogLs = zip(*maxdLogLTuples)
+        optdLogL = maxdLogLTuples[np.argmax(maxdLogLs)]
+        dLogLOpt = optdLogL[2]
+
+        ind1sZeroRoot, ind2sZeroRoot, maxdLogLsZeroRoot = zip(*maxdLogLTuplesZeroRoot)
+        optdLogLZeroRoot = maxdLogLTuplesZeroRoot[np.argmax(maxdLogLsZeroRoot)]
+        dLogLOptZeroRoot = optdLogLZeroRoot[2]
+
+        optimiseTimes = (dLogLOptZeroRoot > dLogLOpt) and (timeOptInfo['timeOptRoundsAgo'] > 0)
+
+        if random:
+            pairs, dLogLs = zip(*dLogLDict.items())
+            dLogLs = np.array(dLogLs)
+            posDLogLInds = np.where(dLogLs > 1e-6)[0]
+            if not len(posDLogLInds):
+                posDLogLInds = np.arange(len(dLogLs))
+            posDLogL = dLogLs[posDLogLInds]
+            dLogLsCorr = posDLogL - posDLogL.max()
+            dLs = np.exp(dLogLsCorr)
+            opt = np.random.choice(posDLogLInds, p=dLs / np.sum(dLs))
+            dLogLOpt = dLogLs[opt]
+            optdLogL = (pairs[opt][0], pairs[opt][1], dLogLOpt)
+            optimiseTimes = False
+
+        if optimiseTimes:
+            timeOptInfo['doTimeOpt'] = True
+            timeOptInfo['timeOptRoundsAgo'] = 0
+            if self.isRoot:
+                if verbose:
+                    mp_print("It is now optimal to re-optimise the times between nodes %d and %d. \n"
+                             "Instead, we will optimise all edge lengths from the root "
+                             "and then re-calculate the dLogLs." % (optdLogLZeroRoot[0], optdLogLZeroRoot[1]),
+                             ALL_RANKS=True)
+                getOptInfo = False
+            else:
+                if verbose:
+                    mp_print("It is now optimal to re-optimise the times between nodes %d and %d. \n"
+                             "We will reset these times, without merging them." % (
+                                 optdLogLZeroRoot[0], optdLogLZeroRoot[1]), ALL_RANKS=True)
+                getOptInfo = True
+                optdLogL = optdLogLZeroRoot
+        else:
+            timeOptInfo['doTimeOpt'] = False
+            timeOptInfo['timeOptRoundsAgo'] += 1
+            getOptInfo = (dLogLOpt > 1e-6)
+
+        if not getOptInfo:
+            newTDict = None
+            optNodeInd1 = None
+            optNodeInd2 = None
+        else:
+            optNodeInd1 = optdLogL[0]
+            optNodeInd2 = optdLogL[1]
+            optInd1 = nodeIndToChildInd[optNodeInd1]
+            optInd2 = nodeIndToChildInd[optNodeInd2]
+
+            optChild1 = self.childNodes[optInd1]
+            optChild2 = self.childNodes[optInd2]
+            # Find optimal times for optimal pair (we repeat this here, while we could look it up but this doesn't
+            # significantly increase computation time, and this is useful for later (when we may approximate the
+            # optTimes in the first calculation))
+            optTimes = getOptTimesSingleDLogLWrapper(xrAsIfRoot_g, WAsIfRoot_g, optChild1, optChild2,
+                                                     sequential=sequential, verbose=verbose, tol=1e-9)
+            newTDict = {optNodeInd1: optTimes[0], optNodeInd2: optTimes[1], bs_glob.max_node_ind + 1: optTimes[2]}
+
+        # Communicate merge information with other computing processes
+        # if mpiInfo.size > 1:
+        #     newTDict = bcast(newTDict, root=0)
+        #     optNodeInd1 = bcast(optNodeInd1, root=0)
+        #     optNodeInd2 = bcast(optNodeInd2, root=0)
+        #     timeOptInfo = bcast(timeOptInfo, root=0)
+        #     dLogLOpt = bcast(dLogLOpt, root=0)
+        return optNodeInd1, optNodeInd2, newTDict, timeOptInfo, dLogLOpt
+
+    # Used
+    def mergeNodes(self, xrAsIfRoot_g, WAsIfRoot_g, nodeInd1, nodeInd2, newTDict, nodeIndToChildInd, dLogLOpt,
+                   sequential=True, verbose=False, ellipsoidSize=None, mergeDownstream=True, singleProcess=False,
+                   random=False, runConfigs=None, NNInfo=None):
+
+        # TODO: Remove this later. Only uncomment this for printing cell-annotations
+        # celltype_info = hasattr(self, 'celltype')
+
+        addAsChild = False
+        if (newTDict[nodeInd1] < 1e-6) and (not self.childNodes[nodeIndToChildInd[nodeInd1]].isCell):
+            addAsChild = True
+            ancNodeInd = nodeInd1
+            gchildInds = [nodeInd2]
+        elif (newTDict[nodeInd2] < 1e-6) and (not self.childNodes[nodeIndToChildInd[nodeInd2]].isCell):
+            addAsChild = True
+            ancNodeInd = nodeInd2
+            gchildInds = [nodeInd1]
+        if addAsChild:
+            newNode = self.childNodes[nodeIndToChildInd[ancNodeInd]]
+
+            # Print message on which nodes are merged
+            if verbose:
+                mp_print("Adding {} as child of {}.".format(self.childNodes[nodeIndToChildInd[gchildInds[0]]].nodeId,
+                                                            self.childNodes[nodeIndToChildInd[ancNodeInd]].nodeId))
+                # TODO: Remove this later. Only uncomment this for printing cell-annotations
+                # if celltype_info:
+                #     mp_print(
+                #         "Adding {} as child of {}.".format(self.childNodes[nodeIndToChildInd[gchildInds[0]]].celltype,
+                #                                            self.childNodes[nodeIndToChildInd[ancNodeInd]].celltype))
+                mp_print("\nAdding %d as child of %d with the following times: root -> %d = %f, %d -> %d = %f. "
+                         "Increase in loglikelihood: %f per gene.\n" % (
+                             gchildInds[0], ancNodeInd, ancNodeInd, newTDict[bs_glob.max_node_ind + 1], ancNodeInd,
+                             gchildInds[0], newTDict[gchildInds[0]], dLogLOpt / bs_glob.nGenes),
+                         ALL_RANKS=singleProcess)
+        else:
+            # Create new node that will be added as ancestor of the children with nodeInd1, nodeInd2
+            ancNodeInd = bs_glob.max_node_ind + 1
+            newNode = TreeNode(nodeInd=ancNodeInd)
+            newNode.childNodes = []
+            gchildInds = [nodeInd1, nodeInd2]
+            # Print message on which nodes are merged
+            if verbose:
+                mp_print("Merging {} and {}.".format(self.childNodes[nodeIndToChildInd[nodeInd1]].nodeId,
+                                                     self.childNodes[nodeIndToChildInd[nodeInd2]].nodeId))
+                mp_print(
+                    "Merging nodes " + str(nodeInd1) + " and " + str(nodeInd2) + " into ancestor " + str(
+                        bs_glob.max_node_ind + 1) + ', with times ' + str(
+                        [newTDict[nodeInd1], newTDict[nodeInd2], newTDict[
+                            bs_glob.max_node_ind + 1]]) + '. Increase in loglikelihood: ' + str(
+                        dLogLOpt / bs_glob.nGenes) + ' per gene.', ALL_RANKS=singleProcess)
+
+                # TODO: Remove this later. Only uncomment this for printing cell-annotations
+                # if celltype_info:
+                #     mp_print("Merging celltypes {} and {}".format(self.childNodes[nodeIndToChildInd[nodeInd1]].celltype,
+                #                                                   self.childNodes[
+                #                                                       nodeIndToChildInd[nodeInd2]].celltype))
+
+        newNode.isLeaf = False
+        delInds = []
+        del_node_inds = []
+        W_g = self.getW()
+        newSelfLtqs = self.ltqs * W_g
+        if not self.isRoot:
+            newSelfLtqsAIRoot = xrAsIfRoot_g * WAsIfRoot_g
+
+        if addAsChild:
+            # If one child-node remains child of root, its contribution to the root-ltqs should be subtracted here,
+            # so that it can be added again when it is updated
+            wbarChild_g = 1 / (newNode.tParent + newNode.getLtqsVars())
+            W_g -= wbarChild_g
+            newSelfLtqs -= wbarChild_g * newNode.ltqs
+            if not self.isRoot:
+                WAsIfRoot_g -= wbarChild_g
+                newSelfLtqsAIRoot -= wbarChild_g * newNode.ltqs
+
+        # Loop over the children that should be merged
+        for nodeInd in gchildInds:
+            ind = nodeIndToChildInd[nodeInd]
+            child = self.childNodes[ind]
+            delInds.append(ind)
+            del_node_inds.append(nodeInd)
+            newNode.childNodes.append(child)
+
+            # We subtract the contribution to the root-ltqs from the children that will be below ancestor
+            wbarChild_g = 1 / (child.tParent + child.getLtqsVars())
+            W_g -= wbarChild_g
+            newSelfLtqs -= wbarChild_g * child.ltqs
+            if not self.isRoot:
+                WAsIfRoot_g -= wbarChild_g
+                newSelfLtqsAIRoot -= wbarChild_g * child.ltqs
+            # We store the calculated optimal time from these children to their new ancestor
+            child.tParent = newTDict[child.nodeInd]
+
+        # TODO: Remove this later. Only uncomment this for printing cell-annotations
+        # if celltype_info:
+        #     child_celltypes = [child_node.celltype for child_node in newNode.childNodes]
+        #     if len(np.unique(child_celltypes)) == 1:
+        #         newNode.celltype = child_celltypes[0]
+        #         plot_ciphers = (len(self.childNodes) % 1000) == 0
+        #     else:
+        #         newNode.celltype = 'unknown'
+        #         plot_ciphers = True
+        #     plot_ciphers = False
+
+        # We add the optimal time from the new ancestor to the root
+        newNode.tParent = newTDict[bs_glob.max_node_ind + 1]
+        # We get the ltqs of the ancestor based on the ltqs of the two merged children
+        # TODO: Maybe do the following more efficiently by updating the node-ltqs already above
+        newNode.getLtqsUponMerge()
+
+        # TODO: Remove this later. Only uncomment this for printing cell-annotations
+        # if celltype_info and plot_ciphers:
+        #     root_now = self
+        #     if addAsChild:
+        #         gchild1 = newNode
+        #         gchild2 = self.childNodes[nodeIndToChildInd[gchildInds[0]]]
+        #         labels = ['root', 'new ancestor', 'grandchild', 'new ancestor']
+        #     else:
+        #         gchild1 = self.childNodes[nodeIndToChildInd[gchildInds[0]]]
+        #         gchild2 = self.childNodes[nodeIndToChildInd[gchildInds[1]]]
+        #         labels = ['root', 'child 1', 'child 2', 'new ancestor']
+        #     gene_numbers = np.array([int(gene_id[5:]) for gene_id in bs_glob.geneIds])
+        #     fig, ax = plt.subplots(ncols=4, nrows=1)
+        #     for gchild_ind, gchild_iter in enumerate([root_now, gchild1, gchild2, newNode]):
+        #         image = np.zeros(28 * 28)
+        #         image[gene_numbers] = gchild_iter.ltqs
+        #         image = np.reshape(image, newshape=(28, 28))
+        #         ax[gchild_ind].imshow(image, cmap='gray_r')
+        #         ax[gchild_ind].set_title(labels[gchild_ind])
+        #
+        #         # image = np.zeros(28 * 28)
+        #         # image[gene_numbers] = np.sqrt(gchild_iter.getLtqsVars())
+        #         # image = np.reshape(image, newshape=(28, 28))
+        #         # ax[1, gchild_ind].imshow(image, cmap='gray_r')
+        #     plt.tight_layout()
+        #     plt.show()
+
+        # We add the contribution of the new ancestor to the position of the root
+        wbarParent_g = 1 / (newNode.tParent + newNode.getLtqsVars())
+        W_g += wbarParent_g
+        self.setLtqsVarsOrW(W_g=W_g)
+        newSelfLtqs += wbarParent_g * newNode.ltqs
+        self.ltqs = newSelfLtqs / self.getW()
+        if not self.isRoot:
+            WAsIfRoot_g += wbarParent_g
+            newSelfLtqsAIRoot += wbarParent_g * newNode.ltqs
+            xrAsIfRoot_g = newSelfLtqsAIRoot / WAsIfRoot_g
+        else:
+            xrAsIfRoot_g = self.ltqs
+            WAsIfRoot_g = self.getW()
+
+        # We make the new ancestor inherit the nearest neighbors from the merged child-nodes
+        if runConfigs['useNN'] and (NNInfo is not None):
+            # First add the neighbor-connections from the merged children
+            NN_conn_mat = NNInfo['conn_mat']
+            for gchild_nodeInd in gchildInds:
+                # TODO: Check if this is necessary
+                # NN_conn_mat[:, [newNode.nodeInd]] += NN_conn_mat[:, [gchild_nodeInd]]
+                # Then delete the neighbor-information for the already merged children (out of efficiency)
+                NN_conn_mat[:, [gchild_nodeInd]] = 0
+                NN_conn_mat[[gchild_nodeInd], :] = 0
+            NN_conn_mat[[newNode.nodeInd], :] += NN_conn_mat.T[[newNode.nodeInd], :]
+            NN_conn_mat[newNode.nodeInd, newNode.nodeInd] = 0
+        # Lastly, we delete the two merged children from the root-childnodes and add the new node
+        self.childNodes = [child for ind, child in enumerate(self.childNodes) if ind not in delInds]
+        if not addAsChild:
+            self.childNodes.append(newNode)
+            bs_glob.max_node_ind += 1
+
+        # If one of children was added below the other. Ask if it wants to merge with one of the other grand-children
+        if addAsChild and mergeDownstream:
+            someMergeHappened, xrAsIfRoot_g, WAsIfRoot_g, oldLtqs, oldLtqsVars = self.mergeDownstreamChildrenSingle(
+                xrAsIfRoot_g, WAsIfRoot_g, childNInd=newNode.nodeInd, gchildNInd=gchildInds[0], sequential=sequential,
+                verbose=False, ellipsoidSize=ellipsoidSize, singleProcess=singleProcess, random=random,
+                runConfigs_inherited=runConfigs)
+
+        if self.isRoot:
+            return self.ltqs, self.getW(), newNode, del_node_inds
+        else:
+            return xrAsIfRoot_g, WAsIfRoot_g, newNode, del_node_inds
+
+    # Used
+    def resetChildTimes(self, xrAsIfRoot_g, WAsIfRoot_g, nodeInd1, nodeInd2, newTDict, nodeIndToChildInd):
+        W_g = self.getW()
+        newAncestorLtqs = self.ltqs * W_g
+        if not self.isRoot:
+            newAncLtqsAIRoot = xrAsIfRoot_g * WAsIfRoot_g
+
+        # Loop over the two children that should be merged
+        for nodeInd in [nodeInd1, nodeInd2]:
+            ind = nodeIndToChildInd[nodeInd]
+            child = self.childNodes[ind]
+
+            # We subtract the contribution to the root-ltqs from the two children that will be merged
+            wbarChild_g = 1 / (child.tParent + child.getLtqsVars())
+            W_g -= wbarChild_g
+            newAncestorLtqs -= wbarChild_g * child.ltqs
+            if not self.isRoot:
+                WAsIfRoot_g -= wbarChild_g
+                newAncLtqsAIRoot -= wbarChild_g * child.ltqs
+            # We store the calculated optimal time from these children to their new ancestor
+            child.tParent = newTDict[child.nodeInd]
+
+            # We add the contribution of the new ancestor to the position of the root
+            wbarChild_gNew = 1 / (child.tParent + child.getLtqsVars())
+            W_g += wbarChild_gNew
+            newAncestorLtqs += wbarChild_gNew * child.ltqs
+            if not self.isRoot:
+                WAsIfRoot_g += wbarChild_gNew
+                newAncLtqsAIRoot += wbarChild_gNew * child.ltqs
+
+        self.setLtqsVarsOrW(W_g=W_g)
+        self.ltqs = newAncestorLtqs / self.getW()
+        if not self.isRoot:
+            xrAsIfRoot_g = newAncLtqsAIRoot / WAsIfRoot_g
+
+        if self.isRoot:
+            return self.ltqs, self.getW()
+        else:
+            return xrAsIfRoot_g, WAsIfRoot_g
+
+    def storeParent(self):
+        for child in self.childNodes:
+            child.parentNode = self
+            if not child.isLeaf:
+                child.storeParent()
+
+    def getAIRootInfo(self, ltqsParent, W_gParent):
+        if self.isRoot:
+            if self.ltqs is None:
+                self.getLtqsComplete(mem_friendly=True)
+            ltqsAIRoot = self.ltqs.copy()
+            WAIRoot = self.getW().copy()
+        else:
+            ltqsAIRoot, WAIRoot = getLtqsAsIfRoot(self.ltqs, self.getW(), self.tParent, ltqsParent, W_gParent)
+        self.ltqsAIRoot = ltqsAIRoot
+        self.setLtqsVarsOrW(W_g=WAIRoot, AIRoot=True)
+        for child in self.childNodes:
+            child.getAIRootInfo(ltqsAIRoot, WAIRoot)
+
+    def getAIRootUpstream(self, as_if_root_version=None):
+        if (as_if_root_version is not None) and (self._AIRoot_version == as_if_root_version):
+            return
+        if self.isRoot:
+            self.ltqsAIRoot = self.ltqs.copy()
+            self.setLtqsVarsOrW(W_g=self.getW().copy(), AIRoot=True)
+        else:
+            self.parentNode.getAIRootUpstream(as_if_root_version=as_if_root_version)
+            self.ltqsAIRoot, WAIRoot = getLtqsAsIfRoot(self.ltqs, self.getW(), self.tParent,
+                                                       self.parentNode.ltqsAIRoot,
+                                                       self.parentNode.getW(AIRoot=True))
+            self.setLtqsVarsOrW(W_g=WAIRoot, AIRoot=True)
+        if as_if_root_version is not None:
+            self._AIRoot_version = as_if_root_version
+
+    def clear_AIRoot(self):
+        self.ltqsAIRoot = None
+        self._W_gAIRoot = None
+        self._ltqsVarsAIRoot = None
+        self._AIRoot_version = -1
+        for child in self.childNodes:
+            child.clear_AIRoot()
+
+    def keep_one_ltqsvars_or_W(self, keep_ltqsvars=True):
+        if keep_ltqsvars:
+            if self._ltqsVars is not None:
+                self._W_g = None
+        else:
+            if self._W_g is not None:
+                self._ltqsVars = None
+        for child in self.childNodes:
+            child.keep_one_ltqsvars_or_W(keep_ltqsvars=keep_ltqsvars)
+
+    def getNodeList(self, nodeList, returnLeafs=True, returnRoot=True):
+        if self.isLeaf and not returnLeafs:
+            pass
+        elif self.isRoot and not returnRoot:
+            pass
+        else:
+            nodeList.append(self)
+        for child in self.childNodes:
+            nodeList = child.getNodeList(nodeList, returnLeafs=returnLeafs, returnRoot=returnRoot)
+        return nodeList
+
+    def getNodeDict(self, nodeDict, returnLeafs=True, returnRoot=True):
+        if self.isLeaf and not returnLeafs:
+            pass
+        elif self.isRoot and not returnRoot:
+            pass
+        else:
+            nodeDict[self.nodeId] = self
+        for child in self.childNodes:
+            nodeDict = child.getNodeDict(nodeDict, returnLeafs=returnLeafs, returnRoot=returnRoot)
+        return nodeDict
+
+    def getEdgesComplete(self, edgeList, src=np.nan, indMap=None):
+        # Store per edge in the tree 1) the source nodeInd, 2) the dst nodeInd, 3) the time between, 4) if dst is leaf
+        if self.parentNode is not None:
+            if self.parentNode.nodeInd != src:
+                nodeInd = self.nodeInd if indMap is None else indMap[self.nodeInd]
+                parentNodeInd = self.parentNode.nodeInd if indMap is None else indMap[self.parentNode.nodeInd]
+                edgeList.append((nodeInd, parentNodeInd, self.tParent, self.parentNode.isLeaf))
+                edgeList = self.parentNode.getEdgesComplete(edgeList, src=self.nodeInd, indMap=indMap)
+        for child in self.childNodes:
+            if child.nodeInd != src:
+                nodeInd = self.nodeInd if indMap is None else indMap[self.nodeInd]
+                childNodeInd = child.nodeInd if indMap is None else indMap[child.nodeInd]
+                edgeList.append((nodeInd, childNodeInd, child.tParent, child.isLeaf))
+                edgeList = child.getEdgesComplete(edgeList, src=self.nodeInd, indMap=indMap)
+        return edgeList
+
+    def do_spr_search(self, ltqs_cand_g, ltqsVars_cand_g, dlogl_self=None, prev_dlogl=-1e9,
+                      prev_node_ind=None, opt_node=None, opt_t=None, opt_dlogl=-1e9, as_if_root_version=None,
+                      spr_target_version=None, do_local_search=True, search_tol=2, search_count=0):
+
+        search_count += 1
+        # First calculate the loglikelihood when adding the candidate on this node
+        if dlogl_self is None:
+            # We only enter this if-statement if we do not get this information from the parent process, which is when
+            # the search actually starts at this node
+            dlogl_self, opt_t_self = self.get_dlogl_spr_move(ltqs_cand_g, ltqsVars_cand_g,
+                                                             as_if_root_version=as_if_root_version,
+                                                             spr_target_version=spr_target_version)
+
+            # If this node is better than anything we've seen before, replace the opt-info
+            if dlogl_self > opt_dlogl:
+                opt_dlogl = dlogl_self
+                opt_node = self
+                opt_t = opt_t_self
+
+            # Make sure prev_dlogl is keeping track of the highest dlogl seen in this search
+            if dlogl_self > prev_dlogl:
+                prev_dlogl = dlogl_self
+
+        # Loop over neighbors, except for the node that you're coming from; calculate the dlogls for those targets
+        added_neighbor = [self.parentNode] if (self.parentNode is not None) else []
+        targets_info = []  # Will contain tuples (target_node, target_dlogl)
+        for target in self.childNodes + added_neighbor:
+            if target.nodeInd == prev_node_ind:
+                continue
+            dlogl_target, opt_t_target = target.get_dlogl_spr_move(ltqs_cand_g, ltqsVars_cand_g,
+                                                                   as_if_root_version=as_if_root_version,
+                                                                   spr_target_version=spr_target_version)
+            targets_info.append((target, dlogl_target))
+
+            # We keep track of two things:
+            # - opt_dlogl. This is the dlogl for the optimal target that we've ever seen for this candidate
+            # - prev_dlogl. This captures the highest dlogl that we've seen during *this* search (i.e. starting from
+            # this initial point)
+            # If this target is better than anything we've seen before, replace the opt-info
+            if dlogl_target > opt_dlogl:
+                opt_dlogl = dlogl_target
+                opt_node = target
+                opt_t = opt_t_target
+
+            # If this node is better than previous in the search starting from this initial point, replace that info
+            if dlogl_target > prev_dlogl:
+                prev_dlogl = dlogl_target
+
+        # Now, we loop over the targets again, and only for those nodes that are within a tolerance below prev_dlogl,
+        # we continue the search.
+        for target, dlogl_target in targets_info:
+            if dlogl_target < prev_dlogl - search_tol:
+                continue
+            opt_node, opt_dlogl, opt_t, search_count = target.do_spr_search(ltqs_cand_g, ltqsVars_cand_g,
+                                                                            dlogl_self=dlogl_target,
+                                                                            prev_dlogl=prev_dlogl,
+                                                                            prev_node_ind=self.nodeInd,
+                                                                            opt_node=opt_node, opt_t=opt_t,
+                                                                            opt_dlogl=opt_dlogl,
+                                                                            as_if_root_version=as_if_root_version,
+                                                                            spr_target_version=spr_target_version,
+                                                                            do_local_search=do_local_search,
+                                                                            search_tol=search_tol,
+                                                                            search_count=search_count)
+
+        return opt_node, opt_dlogl, opt_t, search_count
+
+    def detach_subtree(self, candidate):
+        cand_node_ind = candidate.nodeInd
+        orig_t = candidate.tParent
+        ltqs_cand_g = candidate.ltqs
+        ltqsVars_cand_g = candidate.getLtqsVars(AIRoot=False)
+        wbar_cand_g = 1 / (orig_t + ltqsVars_cand_g)
+
+        self.childNodes = [child for child in self.childNodes if child.nodeInd != cand_node_ind]
+        candidate.parentNode = None
+
+        # Update the ltq-coordinates (non-ai-root) as well for removing the node
+        ltqs_wo_old_parent_g, ltqsVars_wo_old_parent_g = subtract_contrib_ltqs(self.ltqs, self.getW(AIRoot=False),
+                                                                               ltqs_cand_g, wbar_cand_g)
+        self.ltqs = ltqs_wo_old_parent_g
+        self.setLtqsVarsOrW(ltqsVars=ltqsVars_wo_old_parent_g)
+        # Then update everything upstream of the parent, up to the root
+        self.setLtqsUpstream()
+        # Also update the n_ds_node variables upstream of the old_parent
+        n_nodes_in_subtree = candidate.n_ds_nodes
+        self.add_n_nodes_upstream(-n_nodes_in_subtree)
+
+        return cand_node_ind, orig_t, ltqs_cand_g, ltqsVars_cand_g
+
+    def add_subtree(self, candidate, opt_t, ltqs_cand_g, ltqsVars_cand_g):
+        self.childNodes.append(candidate)
+        self.isLeaf = False
+        candidate.parentNode = self
+        candidate.tParent = opt_t
+
+        # Replace the new parent ltqs (not AIRoot), by adding the contribution of the added candidate
+        wbar_cand_g = 1 / (opt_t + ltqsVars_cand_g)
+        ltqs_w_new_parent_g, ltqsVars_w_new_parent_g = add_contrib_ltqs(self.ltqs,
+                                                                        self.getW(AIRoot=False),
+                                                                        ltqs_cand_g, wbar_cand_g)
+
+        self.ltqs = ltqs_w_new_parent_g
+        self.setLtqsVarsOrW(ltqsVars=ltqsVars_w_new_parent_g)
+        # Then update everything upstream of the parent, up to the root
+        self.setLtqsUpstream()
+
+        # Also update the n_ds_node variables upstream of the old_parent
+        if self.n_ds_nodes is not None:
+            n_nodes_in_subtree = candidate.n_ds_nodes
+            self.add_n_nodes_upstream(n_nodes_in_subtree)
+
+    def get_dlogl_spr_move(self, ltqs_cand_g, ltqsVars_cand_g, as_if_root_version=None, spr_target_version=None):
+        if self._spr_target_version == spr_target_version:
+            return self._spr_target_dlogl, self._spr_target_opt_t
+        # First, we have to get the coords at the target as if it's the root. The below function only calculates
+        # these coords for nodes between the target and the real root, and stores them for later use
+        self.getAIRootUpstream(as_if_root_version=as_if_root_version)
+
+        # Then, finally, we are ready to go.
+        opt_t, converged = getOptTime2LeafTree(ltqs1_g=self.ltqsAIRoot, ltqsVars1_g=self.getLtqsVars(AIRoot=True),
+                                               ltqs2_g=ltqs_cand_g, ltqsVars2_g=ltqsVars_cand_g, tol=1e-4)
+        # opt_t = orig_ti
+        if not converged:
+            logger.warning("Somehow, the optimization of the branch length in an SPR move diverged, setting branch "
+                           "length to 1.")
+            opt_t = 1
+
+        dlogl_target = getLoglik2LeafTree(ltqs1_g=self.ltqsAIRoot, ltqsVars1_g=self.getLtqsVars(AIRoot=True),
+                                          ltqs2_g=ltqs_cand_g, ltqsVars2_g=ltqsVars_cand_g, t=opt_t)
+        if spr_target_version is not None:
+            self._spr_target_version = spr_target_version
+            self._spr_target_dlogl = dlogl_target
+            self._spr_target_opt_t = opt_t
+        return dlogl_target, opt_t
+
+    def get_twin_parent(self):
+        ancNodeInd = bs_glob.max_node_ind + 1
+        bs_glob.max_node_ind += 1
+        new_parent = TreeNode(nodeInd=ancNodeInd)
+        new_parent.ltqs = self.ltqs.copy()
+        new_parent.setLtqsVarsOrW(ltqsVars=self.getLtqsVars().copy())
+        new_parent.tParent = self.tParent
+        new_parent.nodeId = 'internal_{}'.format(ancNodeInd)
+        if self.n_ds_nodes is not None:
+            new_parent.n_ds_nodes = 1
+        bs_glob.nNodes += 1
+
+        # New node is created, now add "opt_node" as child
+        new_parent.childNodes = [self]
+        new_parent.isLeaf = False
+        self.tParent = 0.
+        new_parent.parentNode = self.parentNode
+        self.parentNode = new_parent
+
+        # Also, replace opt_node in the child-nodes of the original parent
+        gparent = new_parent.parentNode
+        gparent.childNodes = [child for ind, child in enumerate(gparent.childNodes) if
+                              child.nodeInd != self.nodeInd]
+        gparent.childNodes.append(new_parent)
+
+        # Since we're effectively adding a node, we should add the n_ds_nodes-values on the upstream nodes
+        if self.n_ds_nodes is not None:
+            new_parent.add_n_nodes_upstream(1)
+
+        return new_parent
+
+    def get_tree_info(self, edge_lst, dist_lst, vert_info, int_counter):
+        """
+        Function that works per node, recursively. Should build up the lists edge_lst, dist_lst, and the dict vert_info.
+        """
+        if (self.nodeId is None) or (self.nodeId[:9] == 'internal_'):
+            self.nodeId = "internal_%d" % int_counter
+            int_counter += 1
+
+        vert_info[self.vert_ind] = (self.nodeInd, self.nodeId)
+
+        for child in self.childNodes:
+            edge_lst.append([self.vert_ind, child.vert_ind])
+            dist_lst.append(child.tParent)
+            edge_lst, dist_lst, vert_info, int_counter = child.get_tree_info(edge_lst, dist_lst, vert_info, int_counter)
+
+        return edge_lst, dist_lst, vert_info, int_counter
+
+    def store_coords(self, ltqs_vg, ltqs_vars_vg):
+        ltqs_vg[self.vert_ind] = self.ltqs
+        ltqs_vars_vg[self.vert_ind] = self.getLtqsVars()
+        for child in self.childNodes:
+            child.store_coords(ltqs_vg, ltqs_vars_vg)
+
+    def store_coords_posterior(self, ltqs_vg, ltqs_vars_vg, geneDiffusionScaling, variances=None):
+
+        if geneDiffusionScaling == 'geneVariances':
+            # This means we have to undo the rescaling by variance that was done before
+            node_ltqs_post = self.ltqsAIRoot * np.sqrt(variances)
+            node_ltqsVars_post = self.getLtqsVars(AIRoot=True) * variances
+        else:
+            # This means we have to undo the rescaling by *average* variance that was done before
+            node_ltqs_post = self.ltqsAIRoot * np.sqrt(geneDiffusionScaling)
+            node_ltqsVars_post = self.getLtqsVars(AIRoot=True) * geneDiffusionScaling
+
+        ltqs_vg[self.vert_ind] = node_ltqs_post
+        ltqs_vars_vg[self.vert_ind] = node_ltqsVars_post
+        for child in self.childNodes:
+            child.store_coords_posterior(ltqs_vg, ltqs_vars_vg, geneDiffusionScaling=geneDiffusionScaling,
+                                         variances=variances)
+
+    def store_coords_posterior_memfriendly(self, ltqs_vg, ltqs_vars_vg, ltqs_parent, W_g_parent,
+                                           geneDiffusionScaling, variances=None):
+        if self.isRoot:
+            ltqs_ai_root = self.ltqs.copy()
+            W_ai_root = self.getW().copy()
+        else:
+            ltqs_ai_root, W_ai_root = getLtqsAsIfRoot(self.ltqs, self.getW(), self.tParent, ltqs_parent, W_g_parent)
+        for child in self.childNodes:
+            child.store_coords_posterior_memfriendly(ltqs_vg, ltqs_vars_vg, ltqs_ai_root, W_ai_root,
+                                                     geneDiffusionScaling, variances=variances)
+
+        if geneDiffusionScaling == 'geneVariances':
+            # This means we have to undo the rescaling by variance that was done before
+            node_ltqs_post = ltqs_ai_root * np.sqrt(variances)
+            node_ltqsVars_post = (1 / W_ai_root) * variances
+        else:
+            # This means we have to undo the rescaling by *average* variance that was done before
+            node_ltqs_post = ltqs_ai_root * np.sqrt(geneDiffusionScaling)
+            node_ltqsVars_post = (1 / W_ai_root) * geneDiffusionScaling
+
+        ltqs_vg[self.vert_ind] = node_ltqs_post
+        ltqs_vars_vg[self.vert_ind] = node_ltqsVars_post
+
+    def clear_memory(self, verbose=True, mem_friendly=False):
+        # print_memory("Starting to clear memory.")
+        mem_friendly = mem_friendly or bs_glob.mem_friendly
+        self.clear_AIRoot()
+        if mem_friendly:
+            self.keep_one_ltqsvars_or_W(keep_ltqsvars=True)
+        # print_memory("Finished clearing memory.")
+
+
+class Tree:
+    root = None
+    loglik = None
+    starryYN = None
+    nNodes = None
+    max_node_ind = None
+
+    vert_ind_to_node = None
+
+    def __init__(self):
+        self.root = TreeNode(nodeInd=-1, isRoot=True, nodeId='root')
+        bs_glob.nNodes = 1
+        # bs_glob.max_node_ind = -1
+        # self.max_node_ind = -1
+
+    def __repr__(self):
+        return "Tree(root=%r\n\nloglik=%r,nNodes=%r)" % (self.root, self.loglik, self.nNodes)
+
+    def initialize_star_tree(self, ltqs, ltqsvars, metadata, opt_times=True, verbose=False):
+        self.buildTree(ltqs, ltqsvars, metadata.cellIds)
+
+        # TODO: Remove eventually, only uncomment this for making animations
+        # if (mpiInfo.rank == 0) and bs_glob.nwk_counter:
+        #     self.to_newick(use_ids=True,
+        #                         results_path=os.path.join(bs_glob.nwk_folder, 'tree_{}.nwk'.format(bs_glob.nwk_counter)))
+        #     bs_glob.nwk_counter += 1
+
+        # Do initial optimisation of diffusion times along branches of star-tree
+        start_timeopt = time.time()
+        if opt_times:
+            t_star, opt_loglik, W_g, self.root.ltqs = optimiseTStar(ltqs, ltqsvars, verbose=verbose)
+            self.root.setLtqsVarsOrW(W_g=W_g)
+        else:
+            t_star = np.ones(bs_glob.nCells)
+            opt_loglik = -1e9
+
+        d_timeopt = time.time() - start_timeopt
+        self.root.assignTs(t_star)
+
+        if verbose and opt_times:
+            mp_print("Initial optimisation of times with EM took " + str(d_timeopt) + " seconds.")
+            mp_print("Loglikelihood after time optimization is: " + str(
+                self.calcLogLComplete(mem_friendly=True, loglikVarCorr=metadata.loglikVarCorr)) + '\n')
+
+        # TODO: Remove eventually, only uncomment this for making animations
+        # if (mpiInfo.rank == 0) and bs_glob.nwk_counter:
+        #     self.to_newick(use_ids=True,
+        #                         results_path=os.path.join(bs_glob.nwk_folder, 'tree_{}.nwk'.format(bs_glob.nwk_counter)))
+        #     bs_glob.nwk_counter += 1
+
+    # Used
+    def buildTree(self, ltqs, ltqsVars, cellIds):
+        self.root.childNodes = []
+        n_cells = len(cellIds)
+        for ind in range(n_cells):
+            self.root.childNodes.append(
+                TreeNode(nodeInd=ind, childNodes=[], isLeaf=True, ltqs=ltqs[:, ind], tParent=1,
+                         ltqsVars=ltqsVars[:, ind], nodeId=cellIds[ind], isCell=True))
+        bs_glob.nNodes = n_cells + 1
+        bs_glob.max_node_ind = n_cells - 1
+        self.nNodes = bs_glob.nNodes
+        self.max_node_ind = bs_glob.max_node_ind
+
+    def copy_tree_topology(self):
+        tree_copy = Tree()
+        tree_copy.nNodes = self.nNodes
+        tree_copy.max_node_ind = self.max_node_ind
+        tree_copy.root = self.root.copy_node_topology()
+        return tree_copy
+
+    def to_newick(self, use_ids=True, results_path=None):
+        nwk_str = self.root.to_newick_node(use_ids=use_ids)
+        if results_path is not None:
+            with open(results_path, 'w') as f:
+                f.write(nwk_str)
+        return nwk_str
+
+    def get_edge_dataframe(self, nodeIdToVertInd=None):
+        if nodeIdToVertInd is None:
+            edge_dict = {'source': [], 'target': [], 'dist': []}
+        else:
+            edge_dict = {'source': [], 'source_ind': [], 'target': [], 'target_ind': [], 'dist': []}
+        edge_dict = self.root.get_edge_dict_node(edge_dict, nodeIdToVertInd=nodeIdToVertInd)
+        edge_df = pd.DataFrame(edge_dict)
+        return edge_df
+
+    # Used
+    def compile_tree_from_scData_tree(self):
+        edge_list = []
+        dist_list = []
+        if self.root.nodeId is None:
+            self.root.nodeId = 'root'
+        rootId = self.root.nodeId
+        orig_vert_names = {self.root.nodeInd: rootId}
+        intCounter = 0
+        starryYN = len(self.root.childNodes) > 3
+        nodeIndToNode = {}
+        edge_list, dist_list, orig_vert_names, intCounter, nodeIndToNode = getEdgeDistVertNamesFromNode(self.root,
+                                                                                                        edge_list,
+                                                                                                        dist_list,
+                                                                                                        orig_vert_names,
+                                                                                                        intCounter,
+                                                                                                        nodeIndToNode)
+        return edge_list, dist_list, orig_vert_names, starryYN, nodeIndToNode
+
+    def store_tree_info_and_coords(self, tree_folder, coords_folder=None, verbose=False, store_posterior_ltqs=False,
+                                   geneDiffusionScaling=None, variances=None):
+        """
+        Should store coordinates of all nodes, and return lists that capture the tree structure.
+
+        :param coords_folder: Gives path to where coordinates should be stored.
+        :param verbose:
+        :param store_posterior_ltqs: Whether coordinates should be AIRoot (as-if-root) for each node
+        :param geneDiffusionScaling: Whether coordinates were rescaled in preprocessing or not
+        :param variances: (Optional) variances with which they were rescaled
+
+        :return edge_lst: List of 2-lists, one for each edge, giving the vert-indices for the edge
+        :return dist_lst: Gives the corresponding distances for each edge
+        :return vert_info: For each vertex, this is a dictionary from vert_ind to tuple (node_ind, vert_id)
+        """
+        start = time.time()
+        # print_memory("Start getEdgeVertInfo")
+        # edgeList, distList, nodeIndToVertId, _, nodeIndToNode = self.compile_tree_from_scData_tree()
+        # edge_list, dist_list, orig_vert_names, starryYN, nodeIndToNode
+        edge_lst = []
+        dist_lst = []
+        vert_info = {}
+
+        if self.root.nodeId is None:
+            self.root.nodeId = 'root'
+
+        # First make sure each node has a vert_ind that is depth-first increasing
+        _, vert_count = self.root.renumber_verts(vertIndToNode={}, vert_count=0, include_nodeInd=False)
+
+        if self.nNodes != vert_count:
+            mp_print("Watch out, the number of nodes stored in tree.nNodes is not equal to the number I just counted.",
+                     WARNING=True)
+            self.nNodes = vert_count
+            bs_glob.nNodes = vert_count
+
+        int_counter = 0
+        # Then do depth-search run to get edge_list, dist_list
+        edge_lst, dist_lst, vert_info, int_counter = self.root.get_tree_info(edge_lst, dist_lst, vert_info, int_counter)
+
+        with open(os.path.join(tree_folder, 'edgeInfo.txt'), "w") as file:
+            for ind, edge in enumerate(edge_lst):
+                file.write('%d\t%d\t%.8e\n' % (edge[0], edge[1], dist_lst[ind]))
+        with open(os.path.join(tree_folder, 'vertInfo.txt'), "w") as file:
+            file.write("vertInd\tnodeInd\tvertName\n")
+            for vert in vert_info:
+                file.write('%d\t%d\t%s\n' % (vert, vert_info[vert][0], vert_info[vert][1]))
+
+        # Finally, we do another depth-first search to store the coordinates at the rows given by the vert_inds
+        if coords_folder is not None:
+            # First, we need to make sure that ltqs are calculated at the nodes
+            if self.root.ltqs is None:
+                self.root.getLtqsComplete(mem_friendly=bs_glob.mem_friendly)
+
+            # We initialize the filenames first
+            if not store_posterior_ltqs:
+                ltqs_file = os.path.join(coords_folder, 'ltqs_vertByGene.npy')
+                ltqsVars_file = os.path.join(coords_folder, 'ltqsVars_vertByGene.npy')
+            else:
+                ltqs_file = os.path.join(coords_folder, 'posterior_ltqs_vertByGene.npy')
+                ltqsVars_file = os.path.join(coords_folder, 'posterior_ltqsVars_vertByGene.npy')
+
+            # If memory-friendly mode, we reserve a memmap-region and write row-by-row
+            if bs_glob.mem_friendly:
+                # Pre-allocate room for the matrices that we are going to write on the disk
+                ltqs = np.lib.format.open_memmap(ltqs_file, dtype='float64', mode='w+',
+                                                 shape=(self.nNodes, bs_glob.nGenes))
+                ltqs_vars = np.lib.format.open_memmap(ltqsVars_file, dtype='float64', mode='w+',
+                                                      shape=(self.nNodes, bs_glob.nGenes))
+            else:
+                # If not mem-friendly, we just build up a numpy array and store it at once. This may be slightly faster.
+                # TODO: Test if we can get rid of this option alltogether
+                ltqs = np.zeros((self.nNodes, bs_glob.nGenes))
+                ltqs_vars = np.zeros((self.nNodes, bs_glob.nGenes))
+
+            if not store_posterior_ltqs:
+                # In this case, simply loop through the nodes and store the ltqs in the arrays
+                self.root.store_coords(ltqs, ltqs_vars)
+            else:
+                # In this case, we should calculate the posterior-coordinates at each node
+                if not bs_glob.mem_friendly:
+                    # In this case, first get all the posterior-LTQs at the nodes, then store them all in the array
+                    self.root.getAIRootInfo(None, None)
+                    self.root.store_coords_posterior(ltqs, ltqs_vars, geneDiffusionScaling=geneDiffusionScaling,
+                                                     variances=variances)
+                else:
+                    # In this case, get posterior-LTQs, but delete them once you don't need them anymore.
+                    self.root.store_coords_posterior_memfriendly(ltqs, ltqs_vars, None, None,
+                                                                 geneDiffusionScaling=geneDiffusionScaling,
+                                                                 variances=variances)
+
+            if bs_glob.mem_friendly:
+                del ltqs
+                del ltqs_vars
+            else:
+                np.save(ltqs_file, ltqs, allow_pickle=False)
+                np.save(ltqsVars_file, ltqs_vars, allow_pickle=False)
+            # print_memory("Wrote ltqs and ltqsVars to file")
+        mp_print("Storing tree in folder took %.2f seconds." % (time.time() - start))
+
+        return edge_lst, dist_lst, vert_info
+
+    def getEdgeVertInfo_memfriendly(self, coords_folder=None, verbose=False, store_posterior_ltqs=False,
+                                    geneDiffusionScaling=None, variances=None):
+        # print_memory("Start getEdgeVertInfo")
+        edgeList, distList, nodeIndToVertId, _, nodeIndToNode = self.compile_tree_from_scData_tree()
+        # print_memory("Got Tree")
+        if coords_folder is not None:
+            if not store_posterior_ltqs:
+                ltqs_file = os.path.join(coords_folder, 'ltqs_vertByGene.npy')
+                ltqsVars_file = os.path.join(coords_folder, 'ltqsVars_vertByGene.npy')
+            else:
+                ltqs_file = os.path.join(coords_folder, 'posterior_ltqs_vertByGene.npy')
+                ltqsVars_file = os.path.join(coords_folder, 'posterior_ltqsVars_vertByGene.npy')
+            # Pre-allocate room for the matrices that we are going to write on the disk
+            ltqs_mm = np.lib.format.open_memmap(ltqs_file, dtype='float64', mode='w+',
+                                                shape=(self.nNodes, bs_glob.nGenes))
+            ltqs_vars_mm = np.lib.format.open_memmap(ltqsVars_file, dtype='float64', mode='w+',
+                                                     shape=(self.nNodes, bs_glob.nGenes))
+        vertInfo = {}
+        nodeIndToVertInd = {}
+        vertIndCounter = 0
+
+        if coords_folder is not None:
+            # if store_posterior_ltqs:
+            #     self.root.getAIRootInfo(None, None)
+            start = time.time()
+            ltqs = []
+            ltqsVars = []
+            for edge in edgeList:
+                for ind, nodeInd in enumerate(edge):
+                    if nodeInd not in nodeIndToVertInd:
+                        nodeIndToVertInd[nodeInd] = vertIndCounter
+                        vertInfo[vertIndCounter] = (nodeInd, nodeIndToVertId[nodeInd])
+                        if verbose and (vertIndCounter % 1000 == 0):
+                            mp_print("Writing coords of vertex %d to file." % vertIndCounter)
+                            # print_memory("Getting coords at vert {}".format(vertIndCounter))
+                        if not store_posterior_ltqs:
+                            ltqs_mm[vertIndCounter] = nodeIndToNode[nodeInd].ltqs
+                            ltqs_vars_mm[vertIndCounter] = nodeIndToNode[nodeInd].getLtqsVars()
+                            # ltqs.append(nodeIndToNode[nodeInd].ltqs)
+                            # ltqsVars.append(nodeIndToNode[nodeInd].getLtqsVars())
+                        else:
+                            if geneDiffusionScaling == 'geneVariances':
+                                # This means we have to undo the rescaling that was done before
+                                node_ltqs_post = nodeIndToNode[nodeInd].ltqsAIRoot * np.sqrt(variances)
+                                node_ltqsVars_post = nodeIndToNode[nodeInd].getLtqsVars(AIRoot=True) * variances
+                            else:
+                                node_ltqs_post = nodeIndToNode[nodeInd].ltqsAIRoot * np.sqrt(geneDiffusionScaling)
+                                node_ltqsVars_post = nodeIndToNode[nodeInd].getLtqsVars(
+                                    AIRoot=True) * geneDiffusionScaling
+                            ltqs.append(node_ltqs_post)
+                            ltqsVars.append(node_ltqsVars_post)
+                        # ltqsfile.write('\t'.join(np.char.mod('%.8e', nodeIndToNode[nodeInd].ltqs)) + '\n')
+                        # varsfile.write('\t'.join(np.char.mod('%.8e', nodeIndToNode[nodeInd].getLtqsVars())) + '\n')
+                        vertIndCounter += 1
+                    vertInd = nodeIndToVertInd[nodeInd]
+                    edge[ind] = vertInd
+            del ltqs_mm
+            del ltqs_vars_mm
+            # print_memory("Wrote ltqs and ltqsVars to file")
+            # print_memory("Got all ltqs in a list")
+            # ltqs = np.vstack(ltqs)
+            # np.save(ltqs_file, ltqs, allow_pickle=False)
+            # print_memory("Stored ltqs")
+            # del ltqs
+            # print_memory("Deleted ltqs")
+            # ltqsVars = np.vstack(ltqsVars)
+            # np.save(ltqsVars_file, ltqsVars, allow_pickle=False)
+            # print_memory("Stored ltqsVars")
+            # del ltqsVars
+            # print_memory("Deleted ltqsVars")
+            mp_print("Printing to file took %.2f seconds." % (time.time() - start))
+        else:
+            for edge in edgeList:
+                for ind, nodeInd in enumerate(edge):
+                    if nodeInd not in nodeIndToVertInd:
+                        nodeIndToVertInd[nodeInd] = vertIndCounter
+                        vertInfo[vertIndCounter] = (nodeInd, nodeIndToVertId[nodeInd])
+                        vertIndCounter += 1
+                    vertInd = nodeIndToVertInd[nodeInd]
+                    edge[ind] = vertInd
+        return edgeList, distList, vertInfo
+
+    def getEdgeVertInfo(self, coords_folder=None, verbose=False, store_posterior_ltqs=False,
+                        geneDiffusionScaling=None, variances=None):
+        # print_memory("Start getEdgeVertInfo")
+        edgeList, distList, nodeIndToVertId, _, nodeIndToNode = self.compile_tree_from_scData_tree()
+        # print_memory("Got Tree")
+        if coords_folder is not None:
+            if not store_posterior_ltqs:
+                ltqs_file = os.path.join(coords_folder, 'ltqs_vertByGene.npy')
+                ltqsVars_file = os.path.join(coords_folder, 'ltqsVars_vertByGene.npy')
+            else:
+                ltqs_file = os.path.join(coords_folder, 'posterior_ltqs_vertByGene.npy')
+                ltqsVars_file = os.path.join(coords_folder, 'posterior_ltqsVars_vertByGene.npy')
+        vertInfo = {}
+        nodeIndToVertInd = {}
+        vertIndCounter = 0
+
+        if coords_folder is not None:
+            if store_posterior_ltqs:
+                self.root.getAIRootInfo(None, None)
+            start = time.time()
+            ltqs = []
+            ltqsVars = []
+            for edge in edgeList:
+                for ind, nodeInd in enumerate(edge):
+                    if nodeInd not in nodeIndToVertInd:
+                        nodeIndToVertInd[nodeInd] = vertIndCounter
+                        vertInfo[vertIndCounter] = (nodeInd, nodeIndToVertId[nodeInd])
+                        if verbose and (vertIndCounter % 1000 == 0):
+                            mp_print("Writing coords of vertex %d to file." % vertIndCounter)
+                        if not store_posterior_ltqs:
+                            ltqs.append(nodeIndToNode[nodeInd].ltqs)
+                            ltqsVars.append(nodeIndToNode[nodeInd].getLtqsVars())
+                        else:
+                            if geneDiffusionScaling == 'geneVariances':
+                                # This means we have to undo the rescaling that was done before
+                                node_ltqs_post = nodeIndToNode[nodeInd].ltqsAIRoot * np.sqrt(variances)
+                                node_ltqsVars_post = nodeIndToNode[nodeInd].getLtqsVars(AIRoot=True) * variances
+                            else:
+                                node_ltqs_post = nodeIndToNode[nodeInd].ltqsAIRoot * np.sqrt(geneDiffusionScaling)
+                                node_ltqsVars_post = nodeIndToNode[nodeInd].getLtqsVars(
+                                    AIRoot=True) * geneDiffusionScaling
+                            ltqs.append(node_ltqs_post)
+                            ltqsVars.append(node_ltqsVars_post)
+                        # ltqsfile.write('\t'.join(np.char.mod('%.8e', nodeIndToNode[nodeInd].ltqs)) + '\n')
+                        # varsfile.write('\t'.join(np.char.mod('%.8e', nodeIndToNode[nodeInd].getLtqsVars())) + '\n')
+                        vertIndCounter += 1
+                    vertInd = nodeIndToVertInd[nodeInd]
+                    edge[ind] = vertInd
+            # print_memory("Got all ltqs in a list")
+            ltqs = np.vstack(ltqs)
+            np.save(ltqs_file, ltqs, allow_pickle=False)
+            # print_memory("Stored ltqs")
+            del ltqs
+            # print_memory("Deleted ltqs")
+            ltqsVars = np.vstack(ltqsVars)
+            np.save(ltqsVars_file, ltqsVars, allow_pickle=False)
+            # print_memory("Stored ltqsVars")
+            del ltqsVars
+            # print_memory("Deleted ltqsVars")
+            mp_print("Printing to file took %.2f seconds." % (time.time() - start))
+        else:
+            for edge in edgeList:
+                for ind, nodeInd in enumerate(edge):
+                    if nodeInd not in nodeIndToVertInd:
+                        nodeIndToVertInd[nodeInd] = vertIndCounter
+                        vertInfo[vertIndCounter] = (nodeInd, nodeIndToVertId[nodeInd])
+                        vertIndCounter += 1
+                    vertInd = nodeIndToVertInd[nodeInd]
+                    edge[ind] = vertInd
+        return edgeList, distList, vertInfo
+
+    # Used
+    def getMergeList(self):
+        mergers = []  # This will become a list of tuples with (nodeInd1, nodeInd2, tdiff1, tdiff2)
+        self.root.getChildMergers(mergers)
+        return mergers
+
+    # Used
+    def calcLogLComplete(self, mem_friendly=True, loglikVarCorr=None, recalc=True):
+        # Calculate effective positions (Ltqs), error-bars (LtqVars), and prefactors for all children of the root
+        if recalc:
+            self.root.getLtqsComplete(mem_friendly=mem_friendly)
+        if loglikVarCorr is None:
+            loglik = self.root.prefactor
+        else:
+            loglik = self.root.prefactor + loglikVarCorr
+        self.loglik = loglik
+        return loglik
+
+    # Used
+    def logLGradCompleteLambda(self, logLambda, geneInd, nCells):
+        if geneInd < 0:
+            nGenes = len(logLambda)
+            loglik = -nCells * np.sum(logLambda)
+            logGrad = -nCells * np.ones(nGenes)
+            lam = np.exp(logLambda)
+            loglik, logGrad, _, _, _ = self.root.getLogLGradLambda(lam, loglik, logGrad, nGenes)
+        else:
+            logLambda = logLambda[0]
+            loglik = - nCells * logLambda
+            logGrad = -nCells
+            lam = np.exp(logLambda)
+
+            loglik, logGrad, _, _, _ = self.root.getLogLGradLambdaSingleGene(lam, geneInd, loglik, logGrad)
+
+        # print("Loglik: " + str(loglik))
+        return - loglik, - logGrad
+
+    # Used
+    def getLikelihoodGradGivenTimes(self, t, nodeInds, verbose=False, mem_friendly=False):
+        t = dict(zip(nodeInds, t))
+        self.root.assignTs(t)
+
+        # First calculate the positions (ltqs, W_g) for all nodes in the tree. This also gives us the loglik
+        self.root.getLtqsComplete(mem_friendly=mem_friendly)
+        loglik = self.root.prefactor
+
+        # Then calculate derivative w.r.t. all diff times
+        self.root.getDerivativesDownstream(self.root.ltqs, self.root.getW())
+
+        grad = self.root.getGrads({})
+        grad = np.array([grad[ind] for ind in nodeInds])
+        if verbose:
+            mp_print("Loglik = " + str(loglik), ALL_RANKS=True)
+        return loglik, grad
+
+    # Used
+    def getNegLikelihoodGradGivenLogTimesWrapper(self, logt, nodeInds, verbose=False, mem_friendly=False):
+        t = np.exp(logt)
+        loglik, grad = self.getLikelihoodGradGivenTimes(t, nodeInds, verbose=verbose, mem_friendly=mem_friendly)
+        return - loglik, - grad * t
+
+    def getNegLikelihoodGradGivenLogTimesWrapper_single_scalar(self, loglamb, logt, nodeInds, verbose=False,
+                                                               mem_friendly=False):
+        t = np.exp(loglamb + logt)
+        loglik, grad = self.getLikelihoodGradGivenTimes(t, nodeInds, verbose=verbose, mem_friendly=mem_friendly)
+        return - loglik, np.sum(- grad * t)
+
+    # Used
+    def optTimes(self, verbose=False, singleProcess=False, mem_friendly=True, maxiter=1e6, tol=1e-6):
+        """
+
+        :param verbose:
+        :param singleProcess: This boolean variable determines whether many processes work together to calculate such
+        that mergeChildrenUB can again be parallelized, or whether different processes are doing different instances
+        of this function.
+        :return:
+        """
+        if mpi_wrapper.is_first_process() or singleProcess:
+            nodeInds, times = zip(*self.root.getTs({}).items())
+            t0 = np.minimum(np.maximum(np.array(times), 1e-4), 1e4)
+            bounds = ((-15, 15),) * len(t0)  # np.log(1e-6) = -13.815510557964274
+            optRes = minimize(self.getNegLikelihoodGradGivenLogTimesWrapper, np.log(t0),
+                              args=(nodeInds, verbose, mem_friendly,), tol=tol,
+                              options={'disp': False, 'maxiter': maxiter}, jac=True, bounds=bounds)
+            optTimes = np.exp(optRes.x)
+            optTimes[optTimes < (1e-6 + 1e-6)] = 0.
+        else:
+            optTimes = None
+            nodeInds = None
+        if not singleProcess:
+            nodeInds = mpi_wrapper.bcast(nodeInds, root=0)
+            optTimes = mpi_wrapper.bcast(optTimes, root=0)
+
+        optTimes = dict(zip(nodeInds, optTimes))
+        self.root.assignTs(optTimes)
+        self.root.getLtqsComplete(mem_friendly=True)
+        return optTimes
+
+    # Used
+    def test_for_zero_times(self, verbose=False, singleProcess=False, mem_friendly=True, maxiter=1e6, tol=1e-6):
+        """
+
+        :param verbose:
+        :param singleProcess: This boolean variable determines whether many processes work together to calculate such
+        that mergeChildrenUB can again be parallelized, or whether different processes are doing different instances
+        of this function.
+        :return:
+        """
+        if mpi_wrapper.is_first_process() or singleProcess:
+            nodeInds, times = zip(*self.root.getTs({}).items())
+            times = np.array(times)
+            cutoffs = [None, 1e-6, 1e-5, 1e-4, 1e-3]
+            maxLogL = - np.inf
+            maxLogLInd = 0
+            for ind, cutoff in enumerate(cutoffs):
+                if cutoff is None:
+                    t0 = times.copy()
+                else:
+                    t0 = times.copy()
+                    t0[t0 < cutoff] = 0.
+                t = dict(zip(nodeInds, t0))
+                self.root.assignTs(t)
+                # First calculate the positions (ltqs, W_g) for all nodes in the tree. This also gives us the loglik
+                self.root.getLtqsComplete(mem_friendly=mem_friendly)
+                loglik = self.root.prefactor
+                if loglik > maxLogL:
+                    maxLogL = loglik
+                    maxLogLInd = ind
+
+            # Finally, pick the cutoff for which we got the best likelihood
+            cutoff = cutoffs[maxLogLInd]
+            if maxLogLInd != 0:
+                mp_print("Setting all branch lengths smaller than {} to zero. "
+                         "This increases the tree likelihood slightly.".format(cutoff))
+            optTimes = times
+            if cutoff is not None:
+                optTimes[optTimes < cutoff] = 0.
+        else:
+            optTimes = None
+            nodeInds = None
+        if not singleProcess:
+            nodeInds = mpi_wrapper.bcast(nodeInds, root=0)
+            optTimes = mpi_wrapper.bcast(optTimes, root=0)
+        optTimes = dict(zip(nodeInds, optTimes))
+        self.root.assignTs(optTimes)
+        self.root.getLtqsComplete(mem_friendly=True)
+        return optTimes
+
+        #     t0 = np.minimum(np.maximum(np.array(times), 1e-4), 1e4)
+        #     bounds = ((-15, 15),) * len(t0)  # np.log(1e-6) = -13.815510557964274
+        #     optRes = minimize(self.getNegLikelihoodGradGivenLogTimesWrapper, np.log(t0),
+        #                       args=(nodeInds, verbose, mem_friendly,), tol=tol,
+        #                       options={'disp': False, 'maxiter': maxiter}, jac=True, bounds=bounds)
+        #     optTimes = np.exp(optRes.x)
+        #     optTimes[optTimes < (1e-6 + 1e-6)] = 0.
+        # else:
+        #     optTimes = None
+        #     nodeInds = None
+        # if not singleProcess:
+        #     nodeInds = mpi_wrapper.bcast(nodeInds, root=0)
+        #     optTimes = mpi_wrapper.bcast(optTimes, root=0)
+        #
+        # optTimes = dict(zip(nodeInds, optTimes))
+        # self.root.assignTs(optTimes)
+        # self.root.getLtqsComplete(mem_friendly=True)
+        # return optTimes
+
+    # Used
+    def optTimes_single_scalar(self, verbose=False, singleProcess=False, mem_friendly=True, maxiter=1e6, tol=1e-6):
+        """
+
+        :param verbose:
+        :param singleProcess: This boolean variable determines whether many processes work together to calculate such
+        that mergeChildrenUB can again be parallelized, or whether different processes are doing different instances
+        of this function.
+        :return:
+        """
+        if mpi_wrapper.is_first_process() or singleProcess:
+            nodeInds, times = zip(*self.root.getTs({}).items())
+            t0 = np.minimum(np.maximum(np.array(times), 1e-4), 1e4)
+            loglamb0 = 0
+            bounds = ((-13.815510557964274, 13.815510557964274),)  # np.log(1e-6) = -13.815510557964274
+            optRes = minimize(self.getNegLikelihoodGradGivenLogTimesWrapper_single_scalar, loglamb0,
+                              args=(np.log(t0), nodeInds, verbose, mem_friendly,), tol=tol,
+                              options={'disp': False, 'maxiter': maxiter}, jac=True, bounds=bounds)
+            opt_lamb = np.exp(optRes.x)
+            optTimes = opt_lamb * t0
+            optTimes[optTimes < (1e-6 + 1e-8)] = 0.
+        else:
+            optTimes = None
+            nodeInds = None
+        if not singleProcess:
+            nodeInds = mpi_wrapper.bcast(nodeInds, root=0)
+            optTimes = mpi_wrapper.bcast(optTimes, root=0)
+
+        optTimes = dict(zip(nodeInds, optTimes))
+        self.root.assignTs(optTimes)
+        self.root.getLtqsComplete(mem_friendly=True)
+        return optTimes
+
+    # Used
+    def optGeneVars(self, geneVars, genesSimultaneously=False, verbose=False, singleProcess=False):
+        """
+
+        :param genesSimultaneously: boolean. Doing genes simultaneous is faster in this implementation, but can be a bit
+        less accurate.
+        :param verbose:
+        :param singleProcess: This boolean variable determines whether many processes work together to calculate such
+        that mergeChildrenUB can again be parallelized, or whether different processes are doing different instances
+        of this function.
+        :return:
+        """
+        if mpi_wrapper.is_first_process() or singleProcess:
+            nGenes = bs_glob.nGenes
+            logLambda0 = np.zeros(nGenes)
+
+            bounds = np.array([[-13.815510557964274, 13.815510557964274]] * nGenes) - np.log(
+                geneVars[:, None])  # np.log(1e-6) = -13.815510557964274
+            # Try all genes at the same time
+            if genesSimultaneously:
+                start = time.time()
+                optRes2 = minimize(self.logLGradCompleteLambda, x0=logLambda0, bounds=bounds,
+                                   jac=True, args=(-1, bs_glob.nCells))
+                optLambdas = np.exp(optRes2.x)
+                mp_print("Variance optimization (genes simultaneous) took: %.5f seconds." % (time.time() - start))
+            else:
+                start = time.time()
+                optLambdas = np.ones(nGenes)
+                for gene_ind in range(nGenes):
+                    bounds = np.array([[-13.815510557964274, 13.815510557964274]]) - np.log(
+                        geneVars[gene_ind])  # np.log(1e-6)
+                    optRes = minimize(self.logLGradCompleteLambda, x0=logLambda0[gene_ind], bounds=bounds,
+                                      jac=True, args=(gene_ind, bs_glob.nCells))
+                    if verbose and (gene_ind % 100 == 0):
+                        mp_print("Completed gene optimization on gene %d out of %d." % (gene_ind, nGenes),
+                                 ALL_RANKS=singleProcess)
+                    if optRes.success:
+                        optLambdas[gene_ind] = np.exp(optRes.x)
+                    else:
+                        mp_print("Optimizing variance of gene %d did not succeed. Re-setting to old value.")
+                        optLambdas[gene_ind] = 1
+                mp_print("Variance optimization (per gene) took: %.5f seconds." % (time.time() - start))
+
+            # optRes = minimize(self.getNegLoglikGivenLambdasWrapper, np.log(logLambda0), args=(verbose,),
+            #                   options={'disp': False}, jac=True, bounds=bounds)
+        else:
+            optLambdas = None
+        if not singleProcess:
+            optLambdas = mpi_wrapper.bcast(optLambdas, root=0)
+
+        self.root.assignVs(optLambdas)
+        optGeneVars = geneVars * optLambdas
+        self.root.getLtqsComplete(mem_friendly=True)
+        return optGeneVars
+
+    def processOptReconfig(self, optEdgeList, nodeIndToNode, nodesList, candidatesList, mostUSInfo,
+                           trackCloseness=True):
+        mostUSNode = nodeIndToNode[mostUSInfo['mostUSNodeInd']]
+        mostUSNode.childNodes = [child for child in mostUSNode.childNodes if
+                                 child.nodeInd in mostUSInfo['childrenNotInvolved']]
+        if trackCloseness:
+            mostUSNode.cumClosenessNNN = 2
+            mostUSNode.addClosenessNNN(dist=0, src=optEdgeList[0][1])
+        for edge in optEdgeList:
+            parentNode = nodeIndToNode[edge[0]]
+            if edge[1] not in nodeIndToNode:
+                childNode = TreeNode(nodeInd=edge[1], childNodes=[], isLeaf=False, isRoot=False, isCell=False)
+                nodesList.append(childNode)
+                nodeIndToNode[edge[1]] = childNode
+                candidatesList.append(childNode)
+                self.nNodes += 1
+                if edge[1] > bs_glob.max_node_ind:
+                    bs_glob.max_node_ind = edge[1]
+                    self.max_node_ind = bs_glob.max_node_ind
+            childNode = nodeIndToNode[edge[1]]
+            childNode.tParent = edge[2]
+            childNode.parentNode = parentNode
+            if trackCloseness:
+                childNode.cumClosenessNNN = 2
+            if not edge[3]:  # In this case, the childNode is not a leaf in the subtree and ltqs must be recomputed
+                childNode.ltqs = None
+                childNode.childNodes = []
+            else:
+                if trackCloseness:
+                    childNode.addClosenessNNN(dist=0, src=parentNode.nodeInd)
+            parentNode.childNodes.append(childNode)
+
+        # Recalculate ltqs of all ancestors in the subtree
+        # print(mostUSNode.nodeInd)
+        mostUSNode.getLtqsNoneOnly()
+        # Recalculate ltqs of everything that is upstream of subtree
+        mostUSNode.setLtqsUpstream()
+        # TODO: Do this only when zerotimechild is added or some edge is removed
+        recursionWrap(self.root.mergeZeroTimeChilds)
+        recursionWrap(self.root.renumberNodes)
+        # self.root.mergeZeroTimeChilds(verbose=verbose)
+        # self.root.renumberNodes()
+        self.nNodes = bs_glob.nNodes
+
+    def getOptEdgeList(self, dsNode, args, finalOptTimes=False, returnEdgelist=False, singleProcess=True, random=False,
+                       trackCloseness=True, mem_friendly=False):
+        """
+
+        :param dsNode:
+        :param args:
+        :param finalOptTimes:
+        :param returnEdgelist:
+        :param singleProcess: This boolean variable determines whether many processes work together to calculate such
+        that mergeChildrenUB can again be parallelized, or whether different processes are doing different instances
+        of this function.
+        :return:
+        """
+        # Pick a node (dsNode: downstreamNode) out of the list, then take its parent (usNode) and all
+        # nodes connected to these (which may also include a parent that we then call mostUSNode).
+        # With these next-nearest-neighbours, re-build the sub-tree, then check if you can improve this sub-tree.
+        # This mostUSNode will be the starting point in returning the changed sub-tree in the larger tree. Therefore,
+        # we need to store which children of the mostUSNode are being reconfigured, and which are not
+        processYN, tree, usNode, dsNodeCopy, mostUSNode, \
+        treeIndToOrigInd, mostUSInfo = self.buildTreeNNN(dsNode, returnMostUSInfo=returnEdgelist,
+                                                         mem_friendly=mem_friendly, random=random)
+        if not processYN:
+            if returnEdgelist:
+                return None, None, None
+            else:
+                return None, None
+        topology, centerLeafInd = tree.root.getTotalTopology()
+        # Calculate the original loglikelihood from this subtree
+        origLoglik = tree.calcLogLComplete()
+        # Reconfigure the tree into a star-tree
+        for child in dsNodeCopy.childNodes:
+            child.tParent += dsNodeCopy.tParent
+        tree.root.childNodes = tree.root.childNodes[1:] + tree.root.childNodes[0].childNodes
+        bs_glob.nNodes -= 1
+
+        # Do mergeChildren-routine to greedily approximate the optimal tree for this small star-tree
+        old_max_node_ind = bs_glob.max_node_ind
+        tree.optTimes(verbose=False, singleProcess=singleProcess, tol=1e-4)  # TODO: Test if you want to do this.
+        tree.root.mergeChildrenUB(tree.root.ltqs, tree.root.getW(), sequential=True,
+                                  verbose=False, singleProcess=singleProcess, random=random)
+        # Only increase max_node_ind when this re-order is truly processed
+        bs_glob.max_node_ind = old_max_node_ind
+
+        if trackCloseness:
+            dsNode.cumClosenessNNN = 0.
+
+        tree.root.mergeZeroTimeChilds()
+        # Get topology of resulting tree
+        # Get topology of the subtree, starting from the most upstream node (either usNode or its parent)
+        newTopology, centerLeafInd = tree.root.getTotalTopology(centerLeafInd=centerLeafInd)
+
+        if finalOptTimes:
+            tree.optTimes(verbose=False, singleProcess=singleProcess,
+                          tol=1e-6)  # TODO: Maybe only do this when merge is done.
+
+        newLoglik = tree.calcLogLComplete()
+        dsNode.nnnLoglik = newLoglik - origLoglik
+
+        if not returnEdgelist:
+            return dsNode.nnnLoglik, topology != newTopology
+        # tree.root.storeParent()  # This is already done in getTotalTopology
+        edgeList = mostUSNode.getEdgesComplete([], indMap=treeIndToOrigInd)
+        return dsNode.nnnLoglik, edgeList, mostUSInfo
+
+    def buildTreeNNN(self, dsNode, returnMostUSInfo=False, mem_friendly=True, random=False):
+        dsNeighbours = dsNode.childNodes
+        usNode = dsNode.parentNode
+        usNeighbours = [node for node in usNode.childNodes if node.nodeInd is not dsNode.nodeInd]
+
+        # TODO: Clean this up
+        if (not random) and ((len(dsNeighbours) + len(usNeighbours)) > 30):
+            return False, None, None, None, None, None, None
+        elif (len(dsNeighbours) + len(usNeighbours)) > 50:
+            return False, None, None, None, None, None, None
+        if mem_friendly:
+            dsNode.getAIRootUpstream()
+        dsNeighboursLtqs = np.array([child.ltqs for child in dsNeighbours]).T
+        dsNeighboursLtqsVars = np.array([child.getLtqsVars() for child in dsNeighbours]).T
+        dsTParents = [child.tParent for child in dsNeighbours]
+
+        usNeighboursLtqs = np.array([child.ltqs for child in usNeighbours]).T
+        usNeighboursLtqsVars = np.array([child.getLtqsVars() for child in usNeighbours]).T
+        usTParents = [child.tParent for child in usNeighbours]
+        mostUSInfo = None
+        if usNode.parentNode is not None:
+            parent = usNode.parentNode
+            usTParents.append(usNode.tParent)
+            usNeighbours.append(parent)
+            if returnMostUSInfo:
+                mostUSInfo = {'mostUSNodeInd': parent.nodeInd,
+                              'childrenNotInvolved': [ch.nodeInd for ch in parent.childNodes if
+                                                      not (ch.nodeInd == usNode.nodeInd)]}
+            # Get ltqs of parent where contribution of child is subtracted out
+            wbarChild_g = 1 / (usNode.tParent + usNode.getLtqsVars())
+            WWOChild = parent.getW(AIRoot=True) - wbarChild_g
+            ltqsWOChild = (parent.ltqsAIRoot * parent.getW(AIRoot=True) - wbarChild_g * usNode.ltqs) / WWOChild
+            ltqsVarsWOChild = 1 / WWOChild
+            usNeighboursLtqs = np.hstack((usNeighboursLtqs, ltqsWOChild[:, None]))
+            usNeighboursLtqsVars = np.hstack((usNeighboursLtqsVars, ltqsVarsWOChild[:, None]))
+        elif returnMostUSInfo:
+            mostUSInfo = {'mostUSNodeInd': usNode.nodeInd, 'childrenNotInvolved': []}
+
+        # Create a new tree object where the usNode is the root and the other nodes are summarizing their downstream
+        # information
+        nDSnb = len(dsNeighbours)
+        nUSnb = len(usNeighbours)
+        tree = Tree()
+        bs_glob.nNodes = 2 + nDSnb + nUSnb
+        treeIndToOrigInd = {usNode.nodeInd: usNode.nodeInd}
+        tree.root = TreeNode(nodeInd=usNode.nodeInd, childNodes=[], isLeaf=False, isRoot=True,
+                             ltqs=None, ltqsVars=None, isCell=usNode.isCell)
+        treeIndToOrigInd[bs_glob.max_node_ind + 1] = dsNode.nodeInd
+        dsNodeCopy = TreeNode(nodeInd=dsNode.nodeInd, childNodes=[], isLeaf=False, isRoot=False,
+                              ltqs=None, ltqsVars=None, isCell=False,
+                              tParent=dsNode.tParent, parentNode=tree.root)
+        tree.root.childNodes.append(dsNodeCopy)
+        for ind, nb in enumerate(usNeighbours):
+            treeIndToOrigInd[nb.nodeInd] = nb.nodeInd
+            tree.root.childNodes.append(TreeNode(nodeInd=nb.nodeInd, childNodes=[], isLeaf=True, isRoot=False,
+                                                 ltqs=usNeighboursLtqs[:, ind], ltqsVars=usNeighboursLtqsVars[:, ind],
+                                                 isCell=True, tParent=usTParents[ind]))
+        mostUSNode = tree.root.childNodes[-1] if (usNode.parentNode is not None) else tree.root
+
+        for ind, nb in enumerate(dsNeighbours):
+            treeIndToOrigInd[nb.nodeInd] = nb.nodeInd
+            dsNodeCopy.childNodes.append(TreeNode(nodeInd=nb.nodeInd, childNodes=[], isLeaf=True, isRoot=False,
+                                                  ltqs=dsNeighboursLtqs[:, ind], ltqsVars=dsNeighboursLtqsVars[:, ind],
+                                                  isCell=True, tParent=dsTParents[ind]))
+        # How many ancestors do we expect: for n leaves, we have max. n-2 ancestors. So add some nodeInds if necessary
+        for ind in range(nDSnb + nUSnb - 4):
+            treeIndToOrigInd[bs_glob.max_node_ind + 2 + ind] = bs_glob.max_node_ind + 1 + ind
+        return True, tree, usNode, dsNodeCopy, mostUSNode, treeIndToOrigInd, mostUSInfo
+
+    def get_vert_ind_to_node_DF(self, update=False):
+        if (self.vert_ind_to_node is None) or update:
+            vert_ind_to_node = {}
+            self.vert_ind_to_node = self.root.get_vert_ind_to_node_node(vert_ind_to_node)
+        return self.vert_ind_to_node
+
+    def set_midpoint_root(self):
+        # Find longest path below each internal node (discard branches to leafs)
+        # Store maximum for each node in some dictionary
+        self.root.get_longest_path_ds()
+
+        # Go to node with longest path. Find pair of nodes on path with root in-between
+        vert_ind_to_node = self.get_vert_ind_to_node_DF(update=True)
+        max_dist_node_tuple = (None, 0)
+        for _, node in vert_ind_to_node.items():
+            if node.max_summed_dist_ds > max_dist_node_tuple[1]:
+                max_dist_node_tuple = (node, node.max_summed_dist_ds)
+        max_dist_node, max_summed_dist = max_dist_node_tuple
+
+        # Add new node in-between these pairs at right position
+        the_parent, child_ind = max_dist_node.find_midpoint_pair(max_summed_dist)
+
+        # Change child-nodes structure to get this new root
+        the_child = the_parent.childNodes[child_ind]
+        delta = max_summed_dist / 2 - the_child.max_dist_ds
+        # Create new-node that is going to be in-between the_parent and the_child
+        midpoint_root_node = TreeNode(vert_ind=-1, nodeInd=-100, childNodes=[the_child], parentNode=the_parent,
+                                      isLeaf=False, isRoot=False, tParent=the_child.tParent - delta,
+                                      nodeId="midpoint_root", isCell=False)
+
+        # Delete the_child from the_parent
+        the_parent.childNodes = [parent_child for curr_ind, parent_child in enumerate(the_parent.childNodes) if
+                                 curr_ind != child_ind] + [midpoint_root_node]
+        the_child.parentNode = midpoint_root_node
+        the_child.tParent = delta
+
+        # Renumber vert_inds on tree such that they are in line with a depth-first search
+        vertIndToNode, self.nNodes = self.root.renumber_verts(vertIndToNode={}, vert_count=0, include_nodeInd=False)
+        self.vert_ind_to_node = vertIndToNode
+        self.root.storeParent()
+
+        self.reset_root(new_root_ind=midpoint_root_node.vert_ind)
+
+        vertIndToNode, self.nNodes = self.root.renumber_verts(vertIndToNode={}, vert_count=0, include_nodeInd=False)
+        self.vert_ind_to_node = vertIndToNode
+        self.root.storeParent()
+
+    def get_cluster_centers(self, cell_ids=None, n_clusters=None):
+        # Do min-pdist clustering to get branches that would be cut in the clustering procedure. As cluster-centers,
+        # we'll just take the upstream-nodes of these branches
+        nwk_str = self.to_newick(use_ids=True)
+        # mindist_edges will contain a list of tuples (downstream-node-id, upstream-node-id)
+        _, mindist_edges = get_min_pdists_clustering_from_nwk_str(tree_nwk_str=nwk_str, n_clusters=n_clusters,
+                                                                  cell_ids=cell_ids,
+                                                                  get_cell_ids_all_splits=False,
+                                                                  node_id_to_n_cells=None,
+                                                                  verbose=False)
+        cluster_center_node_ids = [md_edge[1] for md_edge in mindist_edges]
+        return cluster_center_node_ids
+
+    def set_mindist_root(self, cell_ids):
+        # Find parent-node "the_parent" and index of "the_child" that are on both ends of the branch that would be cut
+        # to minimize the sum of pairwise distances
+        nwk_str = self.to_newick(use_ids=True)
+        _, mindist_edge = get_min_pdists_clustering_from_nwk_str(tree_nwk_str=nwk_str, n_clusters=2, cell_ids=cell_ids,
+                                                                 get_cell_ids_all_splits=False, node_id_to_n_cells=None,
+                                                                 verbose=False)
+        child_node_id, parent_node_id = mindist_edge[0]
+        vertIndToNode, self.nNodes = self.root.renumber_verts(vertIndToNode={}, vert_count=0, include_nodeInd=False)
+        for vert_ind, node in vertIndToNode.items():
+            if node.nodeId == parent_node_id:
+                the_parent = node
+            elif node.nodeId == child_node_id:
+                the_child = node
+        # Check if child is indeed in childNodes of the parent
+        child_inds = [ind for ind, child in enumerate(the_parent.childNodes) if child.nodeId == child_node_id]
+        if len(child_inds) == 1:
+            child_ind = child_inds[0]
+        else:
+            child_inds = [ind for ind, child in enumerate(the_child.childNodes) if child.nodeId == parent_node_id]
+            if len(child_inds) == 1:
+                the_parent = the_child
+                child_ind = child_inds[0]
+            else:
+                # If this doesn't succeed, there was an error. We return False, signifying that setting root failed.
+                return False
+
+        # Change child-nodes structure to get this new root
+        the_child = the_parent.childNodes[child_ind]
+        delta = the_child.tParent / 2
+        # Create new-node that is going to be in-between the_parent and the_child
+        midpoint_root_node = TreeNode(vert_ind=-1, nodeInd=-100, childNodes=[the_child], parentNode=the_parent,
+                                      isLeaf=False, isRoot=False, tParent=the_child.tParent - delta,
+                                      nodeId="mindist_root", isCell=False)
+
+        # Delete the_child from the_parent
+        the_parent.childNodes = [parent_child for curr_ind, parent_child in enumerate(the_parent.childNodes) if
+                                 curr_ind != child_ind] + [midpoint_root_node]
+        the_child.parentNode = midpoint_root_node
+        the_child.tParent = delta
+
+        # Renumber vert_inds on tree such that they are in line with a depth-first search
+        vertIndToNode, self.nNodes = self.root.renumber_verts(vertIndToNode={}, vert_count=0, include_nodeInd=False)
+        self.vert_ind_to_node = vertIndToNode
+        self.root.storeParent()
+
+        self.reset_root(new_root_ind=midpoint_root_node.vert_ind)
+
+        vertIndToNode, self.nNodes = self.root.renumber_verts(vertIndToNode={}, vert_count=0, include_nodeInd=False)
+        self.vert_ind_to_node = vertIndToNode
+        self.root.storeParent()
+        return True
+
+    def reset_root(self, new_root_ind):
+        vert_ind_to_node = self.get_vert_ind_to_node_DF()
+        if list(vert_ind_to_node.values())[1].parentNode is None:
+            self.root.storeParent()
+        self.root = vert_ind_to_node[new_root_ind]
+        # self.root.isRoot = True
+        # self.root.tParent = None
+        self.root.reset_root_node(parent_ind=None, old_tParent=self.root.tParent)
+
+    def from_newick(self, nwk_str, node_id_to_vert_ind=None):
+        # nodes = []
+        # Here we will keep a dictionary from level down the tree, to lists of nodes that don't have an assigned parent
+        level_to_nodes = {0: []}
+        level = 0
+        curr_str = ''
+        nodeIdY_tParentF = True
+        curr_node = None
+        new_node = False
+        self.nNodes = 0
+        internal_node_ids_made_up = 0
+        for char in nwk_str:
+            if char == '(':
+                # We go down the tree one level
+                level += 1
+                level_to_nodes[level] = []
+                # It also means we start a new node
+                new_node = True
+            elif char == ')':
+                # We go back up to the parent level
+                level -= 1
+                # It also means we start a new node
+                new_node = True
+            elif char == ':':
+                # This indicates a time is coming
+                if curr_node is None:
+                    # This indicates no node-id is stored in the nwk-file for this node. Make one up
+                    curr_node = TreeNode(isLeaf=True)
+                    self.nNodes += 1
+                    curr_node.level = level
+                    level_to_nodes[level].append(curr_node)
+                    # nodeIdY_tParentF = True
+                    curr_str = 'internal_{}'.format(internal_node_ids_made_up)
+                    internal_node_ids_made_up += 1
+                    new_node = False
+
+                curr_node.nodeId = curr_str
+                if (node_id_to_vert_ind is not None) and (curr_node.nodeId in node_id_to_vert_ind):
+                    curr_node.vert_ind = node_id_to_vert_ind[curr_node.nodeId]
+                nodeIdY_tParentF = False
+                curr_str = ''
+            elif char == ',':
+                # This indicates the time is complete, new child coming
+                new_node = True
+            elif char == ';':
+                if curr_node is None:
+                    # This indicates no node-id is stored in the nwk-file for this node. Make one up
+                    curr_node = TreeNode(isLeaf=True)
+                    self.nNodes += 1
+                    curr_node.level = level
+                    level_to_nodes[level].append(curr_node)
+                    # nodeIdY_tParentF = True
+                    curr_str = 'internal_{}'.format(internal_node_ids_made_up)
+                    internal_node_ids_made_up += 1
+                    nodeIdY_tParentF = True
+                curr_node.isRoot = True
+                new_node = True
+            else:
+                if curr_node is None:
+                    curr_node = TreeNode(isLeaf=True)
+                    self.nNodes += 1
+                    curr_node.level = level
+                    level_to_nodes[level].append(curr_node)
+                    nodeIdY_tParentF = True
+                curr_str += char
+                new_node = False
+
+            if new_node:
+                if curr_node is not None:
+                    if nodeIdY_tParentF:
+                        curr_node.nodeId = curr_str
+                        if (node_id_to_vert_ind is not None) and (curr_node.nodeId in node_id_to_vert_ind):
+                            curr_node.vert_ind = node_id_to_vert_ind[curr_node.nodeId]
+                    else:
+                        curr_node.tParent = float(curr_str)
+                    curr_str = ''
+                    # level_to_nodes[level].append(curr_node)
+                    # Get all children and add them to this node
+                    if (curr_node.level + 1) in level_to_nodes:
+                        curr_node.childNodes = level_to_nodes[curr_node.level + 1]
+                        if len(level_to_nodes[curr_node.level + 1]) > 0:
+                            curr_node.isLeaf = False
+                            level_to_nodes[curr_node.level + 1] = []
+                    else:
+                        curr_node.childNodes = []
+                curr_node = None
+        self.root = level_to_nodes[0][0]
+        self.max_node_ind = self.root.get_max_node_ind(-np.inf)
+        bs_glob.max_node_ind = self.max_node_ind
+
+    def remove_two_child_root(self, change_node_inds=False):
+        if len(self.root.childNodes) > 2:
+            return
+        found_better_root = False
+        for child in self.root.childNodes:
+            if child.isLeaf or (len(child.childNodes) < 2):
+                continue
+            found_better_root = True
+            break
+
+        if not found_better_root:
+            node_list = self.getNodeListBF()
+            for child in node_list:
+                if child.isRoot:
+                    continue
+                if (not child.isLeaf) and (len(child.childNodes) >= 2):
+                    found_better_root = True
+                    break
+
+        # In this case, set the root to this child
+        vertIndToNode, self.nNodes = self.root.renumber_verts(vertIndToNode={}, vert_count=0, include_nodeInd=False)
+        self.vert_ind_to_node = vertIndToNode
+        self.root.storeParent()
+
+        self.reset_root(new_root_ind=child.vert_ind)
+
+        vertIndToNode, self.nNodes = self.root.renumber_verts(vertIndToNode={}, vert_count=0, include_nodeInd=False)
+        self.vert_ind_to_node = vertIndToNode
+        self.root.storeParent()
+
+        self.root.deleteParentsWithOneChild()
+        self.root.mergeZeroTimeChilds()
+        self.root.renumberNodes(change_node_inds=change_node_inds)
+        self.nNodes = bs_glob.nNodes
+
+    def do_spr_moves(self, max_moves=None, select_cand='random', select_target='random', do_local_search=True,
+                     do_postprocessing=True, min_branch_length=-1, verbose=False, freq_cutoff=None, cand_list=None,
+                     only_scan=False, mem_friendly=False, skip_prepare_tree=False):
+        """
+
+        :param max_moves: When we do random moves, this sets the number of SPR-moves
+        :param seed: Random seed
+        :param select_cand: Sets the strategy with which we pick candidate-nodes to move. For now, options are
+        "random", "long_branches_first", or "list"
+        :param select_target: Sets the strategy with which we pick the first target-place to attach the pruned subtree.
+        For now, options are "random", "root", "cluster_centers", "all".
+        :param do_local_search: Determines whether we do a greedy search around the target to find the best target.
+        :param do_postprocessing: Experimental for now. Resolves created polytomies immediately, but doesn't seem to
+        help much, and can be replaced by re-doing starry nodes after the whole SPR-procedure.
+        :param freq_cutoff: If not None, we keep track of how many successes we have per 1000 tries, and we only keep
+        going until we have more than 1000 * freq_cutoff successes
+        :param cand_list: If select_cand=='list', then this list should give node-indices that should be tested
+        :param only_scan: If True, this function should not change the tree, only detect successful candidates
+        :return:
+        """
+
+        """Initialize some values"""
+        if select_target == 'all':
+            do_local_search = False
+        if max_moves is None:
+            max_moves = bs_glob.nNodes
+        successful_moves = 0
+        unsuccessful_moves = 0
+        remain_cands = []
+        returned_moves = 0
+        as_if_root_version = 0
+        spr_target_version = 0
+
+        # Determine how often to clean the stored AIRoot-values, to free some memory
+        n_free_mem = int(bs_glob.nNodes / 10)
+
+        self.root.reset_version_numbers('_AIRoot_version')
+        self.root.reset_version_numbers('_spr_target_version')
+
+        n_moves = -1
+        dlogl_threshold = 1e-6 * bs_glob.nGenes * bs_glob.nCells if bs_glob.nCells is not None \
+            else 1e-6 * bs_glob.nGenes * bs_glob.nNodes
+
+        """Prepare the tree"""
+        # nChildren = self.root.gatherInfoDepthFirst([])
+        if not skip_prepare_tree:
+            orig_loglik = self.prepare_tree_spr_moves()
+        else:
+            orig_loglik = np.nan if (self.loglik is None) else self.loglik
+
+        # Store at every node how many nodes are downstream (including itself). Will need it for picking candidates
+        self.root.get_ds_node_counts()
+
+        # If we don't select random candidates, list them here by sorting by branch length
+        cands_list = None
+        if select_cand == 'long_branches_first':
+            nodesList = self.root.getNodeList([], returnRoot=True, returnLeafs=True)
+            # Sort them such that tParent (connecting branch length) is descending
+            sorted_time_node_tuples = [(node.tParent, node) for node in
+                                       nodesList if (not node.isRoot) and (node.tParent > min_branch_length)]
+            sorted_time_node_tuples.sort(key=lambda x: x[0], reverse=True)
+            cands_list = [time_node_tuple[1] for time_node_tuple in sorted_time_node_tuples]
+            max_moves = min(len(cands_list), max_moves)
+
+        if select_cand == 'list':
+            nodes_list = self.root.getNodeList([], returnRoot=True, returnLeafs=True)
+            node_ind_to_node = {node.nodeInd: node for node in nodes_list}
+            cands_list = [node_ind_to_node[node_ind] for node_ind in cand_list if node_ind in node_ind_to_node]
+            max_moves = min(len(cands_list), max_moves)
+
+        if select_target == 'cluster_centers':
+            n_clusters = int(np.log(bs_glob.nCells)) if bs_glob.nCells is not None else np.log(bs_glob.nCells)
+            cluster_center_node_ids = self.get_cluster_centers(cell_ids=None, n_clusters=n_clusters)
+            nodesList = self.root.getNodeList([], returnRoot=True, returnLeafs=True)
+            cluster_centers = [node for node in nodesList if node.nodeId in cluster_center_node_ids]
+        else:
+            cluster_centers = None
+
+        total_dlogl_increase = 0
+
+        n_print = int(min(100, max_moves / 10))
+
+        negdlogl_nodeind_tuples = None
+        if only_scan:
+            negdlogl_nodeind_tuples = []
+
+        last_n_successes = None
+        orig_t = None
+
+        while n_moves < max_moves - 1:
+            n_moves += 1
+            spr_target_version += 1
+
+            if n_moves == n_print:
+                mp_print("Performing SPR move {} out of {}. "
+                         "Results so far: {} successes, {} loglikelihood-change, "
+                         "current original branch length: {}".format(n_moves, max_moves,
+                                                                     successful_moves, total_dlogl_increase,
+                                                                     orig_t))
+                # TODO: Remove this memory measurement maybe
+                # print_memory("n_moves: {}".format(n_moves))
+
+                n_print *= 2
+
+            """Select child to be moved"""
+            candidate, old_parent = self.select_spr_candidate(select_cand=select_cand,
+                                                              cands_list=cands_list,
+                                                              n_moves=n_moves)
+
+            if candidate is None:
+                unsuccessful_moves += 1
+                continue
+
+            """Remove the candidate from the tree"""
+            cand_node_ind, orig_t, ltqs_cand_g, ltqsVars_cand_g = old_parent.detach_subtree(candidate)
+            # Discard all as_if_root-information by updating the version
+            as_if_root_version += 1
+
+            # Get the loglikelihood change for the old position
+            old_parent.getAIRootUpstream(as_if_root_version=as_if_root_version)
+            dlogl_orig_pos = getLoglik2LeafTree(ltqs1_g=old_parent.ltqsAIRoot,
+                                                ltqsVars1_g=old_parent.getLtqsVars(AIRoot=True),
+                                                ltqs2_g=ltqs_cand_g, ltqsVars2_g=ltqsVars_cand_g, t=orig_t)
+
+            """Select target-node to start the search for a good target"""
+            # The targets-object returned is a list, which either has 1 or multiple nodes. We run the SPR search on
+            # all these targets and select the best one
+            targets = self.select_spr_targets(select_target=select_target, old_parent=old_parent,
+                                              cluster_centers=cluster_centers)
+            opt_node = None
+            opt_dlogl = -np.inf
+            opt_t = None
+            for target in targets:
+                """Check the change in loglikelihood when adding to target"""
+                opt_node, opt_dlogl, opt_t, search_count = target.do_spr_search(ltqs_cand_g, ltqsVars_cand_g,
+                                                                                prev_dlogl=-np.inf,
+                                                                                prev_node_ind=None, opt_node=opt_node,
+                                                                                opt_t=opt_t,
+                                                                                opt_dlogl=opt_dlogl,
+                                                                                as_if_root_version=as_if_root_version,
+                                                                                spr_target_version=spr_target_version,
+                                                                                do_local_search=do_local_search,
+                                                                                search_count=0)
+
+            # If we only scan for successful moves, then just place the candidate at orig position,
+            # store the information for successful moves, and move to next round
+            if only_scan:
+                if ((dlogl_orig_pos + dlogl_threshold) < opt_dlogl) and (opt_node.nodeInd != old_parent.nodeInd):
+                    # If move is successful (increase logl + not adding cell at same parent node as before)
+                    successful_moves += 1
+                    negdlogl_nodeind_tuples.append((-(opt_dlogl - dlogl_orig_pos), candidate.nodeInd))
+
+            # Check if dlogl-improvement is gained. Otherwise, just place it back at its original position
+            found_new_parent = False
+            if ((dlogl_orig_pos + dlogl_threshold) > opt_dlogl) or only_scan:
+                if opt_node.nodeInd == old_parent.nodeInd:
+                    returned_moves += 1
+                elif not only_scan:
+                    unsuccessful_moves += 1
+                opt_node = old_parent
+                opt_t = orig_t
+                found_new_parent = False
+                if verbose:
+                    logger.info("SPR-move {} unsuccessful:, "
+                                "loglikelihood increase was {}.".format(n_moves, opt_dlogl - dlogl_orig_pos))
+            else:
+                if opt_node.nodeInd == old_parent.nodeInd:
+                    returned_moves += 1
+                    found_new_parent = False
+                    # logger.info("SPR-move {} returned: leaving node {} as child of {}. "
+                    #              "Time-optimization led to loglikelihood increase "
+                    #              "of: {}.".format(n_moves, candidate.nodeInd, opt_node.nodeInd,
+                    #                               opt_dlogl - dlogl_orig_pos))
+                else:
+                    successful_moves += 1
+                    found_new_parent = True
+                    if verbose:
+                        logger.info("SPR-move {} success: moving node {} as child of {}. "
+                                    "Loglikelihood increase: {}.".format(n_moves, candidate.nodeInd, opt_node.nodeInd,
+                                                                         opt_dlogl - dlogl_orig_pos))
+                total_dlogl_increase += (opt_dlogl - dlogl_orig_pos)
+
+            """Perform move"""
+            # Make sure to add new node if adding it downstream of a leaf
+            if opt_node.isLeaf:
+                # In this case, create a new node that is basically a copy of "opt_node", but is the parent of the original
+                # node in the tree with a zero branch length connecting them.
+                new_parent = opt_node.get_twin_parent()
+            else:
+                new_parent = opt_node
+
+            # Add the candidate node on the tree, and update the coordinates
+            new_parent.add_subtree(candidate, opt_t, ltqs_cand_g, ltqsVars_cand_g)
+            as_if_root_version += 1
+
+            if n_moves % n_free_mem == 0:
+                self.root.clear_AIRoot()
+                # print_memory("Freed memory kept by old posterior-node-coordinate values.")
+                if mem_friendly:
+                    self.root.keep_one_ltqsvars_or_W(keep_ltqsvars=True)
+                    # print_memory("Freed memory kept by double storage of variance and precision.")
+
+            if do_postprocessing and found_new_parent and len(new_parent.childNodes) > 2:
+                # if found_new_parent and len(new_parent.childNodes) > 2:
+                # Check if candidate (that is attached to node) still wants to sit on a downstream branch, i.e., if the
+                # likelihood increases when we add an ancestor for the candidate with some other child
+
+                # First get the coordinates of new_parent as if it's the root
+                new_parent.getAIRootUpstream(as_if_root_version=as_if_root_version)
+                changedSomething = new_parent.mergeChildrenUB(new_parent.ltqsAIRoot, new_parent.getW(AIRoot=True),
+                                                              sequential=False, verbose=False, random=False,
+                                                              specialChild=candidate.nodeInd,
+                                                              singleProcess=True, mergeDownstream=False)
+
+                if changedSomething:  # Now the ltqs upstream of the new_parent should be updated again
+                    new_parent.setLtqsUpstream()
+                    as_if_root_version += 1
+                    new_parent.storeParent()
+                    # Also update the n_ds_node variables upstream of the old_parent
+                    old_n_ds_nodes = new_parent.n_ds_nodes
+                    new_parent.get_ds_node_counts()
+                    added_n_ds_nodes = new_parent.n_ds_nodes - old_n_ds_nodes
+                    if added_n_ds_nodes != 0:
+                        if not new_parent.isRoot:
+                            new_parent.parentNode.add_n_nodes_upstream(added_n_ds_nodes)
+                        # for ch in new_parent.childNodes:
+                        #     if ch.parentNode is None:
+                        #         ch.parentNode = new_parent
+                        #         for gch in ch.childNodes:
+                        #             gch.parentNode = ch
+                        #     if ch.nodeId is None:
+                        #         ch.nodeId = 'internal_{}'.format(ch.nodeInd)
+
+            # If we run with a frequency cutoff and we did N_CHECK moves. Check whether we need to exit
+            N_CHECK = 1000
+            if (freq_cutoff is not None) and (n_moves % N_CHECK == 0):
+                if last_n_successes is not None:
+                    if (successful_moves - last_n_successes) < freq_cutoff * N_CHECK:
+                        max_moves = n_moves + 1
+                        if cands_list is None:
+                            mp_print("Frequency cutoff is for now only allowed with long_branches_first strategy.",
+                                     ERROR=True)
+                        else:
+                            mp_print("In the last {} tries, only {} successes were detected. "
+                                     "Therefore switching to mode in which we scan all SPR-candidates in parallel, "
+                                     "before processing them.".format(N_CHECK, successful_moves - last_n_successes))
+                            remain_cand_nodes = cands_list[n_moves + 1:]
+                            remain_cands = [cand.nodeInd for cand in remain_cand_nodes]
+                last_n_successes = successful_moves
+
+        if only_scan:
+            mp_print("Tried {} SPR-candidates, and found {} successful candidates.".format(len(cands_list),
+                                                                                           successful_moves),
+                     ALL_RANKS=True)
+            return negdlogl_nodeind_tuples
+
+        # TODO: Remove this additional likelihood calculation
+        self.nNodes = bs_glob.nNodes
+        mp_print("The {} SPR-moves led to an increase of {} "
+                 "of the tree loglikelihood.".format(n_moves + 1, total_dlogl_increase))
+        if not np.isnan(orig_loglik):
+            mp_print("Total loglikelihood should now thus be {} (not accounting for any resolved polytomies), "
+                     "and is {} according to the normal loglik "
+                     "calculation.".format(orig_loglik + total_dlogl_increase,
+                                           self.calcLogLComplete(mem_friendly=True, recalc=True)))
+        mp_print("Move statistics:\n"
+                 "Successful: {}\n"
+                 "Failed: {}\n"
+                 "Returned to initial point: {}".format(successful_moves, unsuccessful_moves, returned_moves))
+
+        return successful_moves, total_dlogl_increase, remain_cands
+
+    def prepare_tree_spr_moves(self):
+        self.remove_two_child_root()
+        self.root.deleteParentsWithOneChild()
+        self.root.mergeZeroTimeChilds()
+        self.root.renumberNodes(change_node_inds=False)
+        self.nNodes = bs_glob.nNodes
+
+        self.root.storeParent()
+        # TODO: Only do this when necessary?
+        self.root.getLtqsComplete(mem_friendly=True)
+        orig_loglik = self.calcLogLComplete(mem_friendly=True, recalc=False)
+        return orig_loglik
+
+    def do_spr_postprocessing(self, change_node_inds=False, only_time_opt=False, verbose=False, only_cleanup=False):
+        """
+        IMPORTANT: This function should be run without parallelization. Otherwise, one has to guarantee that the tree
+        topologies match on all processes, which we cannot at the moment.
+
+        This function should be run after the SPR moves. It will resolve do
+        - re-optimize all branch lengths
+        - resolve polytomies by doing the mergeChildrenUB-function on all nodes recursively
+        - re-optimize all branch lengths again
+
+        :return:
+        """
+        # Clean up the tree first
+        self.remove_two_child_root(change_node_inds=change_node_inds)
+        self.root.deleteParentsWithOneChild()
+        self.root.mergeZeroTimeChilds()
+        self.root.renumberNodes(change_node_inds=change_node_inds)
+        self.nNodes = bs_glob.nNodes
+        self.root.storeParent()
+        self.root.clear_memory()
+        self.root.reset_version_numbers('_AIRoot_version')
+
+        if only_cleanup:
+            return
+
+        # Do first re-optimization of times
+        self.optTimes(verbose=verbose, singleProcess=True, mem_friendly=True, maxiter=100, tol=1e-3)
+        # Clean up the tree before resolving polytomies
+        self.root.mergeZeroTimeChilds()
+        self.root.renumberNodes(change_node_inds=change_node_inds)  # Some nodes were merged, need to re-count the nodes
+        self.nNodes = bs_glob.nNodes
+
+        if only_time_opt:
+            return
+
+        self.root.getAIRootInfo(None, None)
+
+        self.root.mergeChildrenRecursive(self.root.ltqs, self.root.getW(), sequential=False, verbose=verbose,
+                                         ellipsoidSize=1.0, single_process=True, mergeDownstream=True, tree=self,
+                                         nChildNN=50, kNN=10)
+        self.root.renumberNodes(change_node_inds=change_node_inds)  # Some nodes were merged, need to re-count the nodes
+        self.nNodes = bs_glob.nNodes
+        self.root.storeParent()
+        self.optTimes(verbose=verbose, singleProcess=True, mem_friendly=True, maxiter=100, tol=1e-4)
+
+    def select_spr_candidate(self, select_cand='random', cands_list=None, n_moves=None,
+                             get_remainder=False):
+        if select_cand == 'random':
+            no_cand = True
+            n_candidates = self.root.n_ds_nodes
+            while no_cand:
+                cand_ind = np.random.randint(1, n_candidates)
+                candidate = self.root.select_nth_node_df(cand_ind, 0)
+                old_parent = candidate.parentNode
+                if len(old_parent.childNodes) >= 2:
+                    no_cand = False
+        elif select_cand in ['long_branches_first', 'list']:
+            candidate = cands_list[n_moves]
+            if candidate.parentNode is None:
+                return None, None
+            old_parent = candidate.parentNode
+            if len(old_parent.childNodes) < 2:
+                return None, None
+            if old_parent.isRoot and (len(old_parent.childNodes) < 3):
+                return None, None
+
+            # If we reach this point, we have found a good candidate
+        return candidate, old_parent
+
+    def select_spr_targets(self, select_target='random', old_parent=None, cluster_centers=None, all_nodes_list=None,
+                           cluster_centers_guaranteed=False):
+        if select_target == 'root':
+            return [self.root]
+        elif select_target == 'cluster_centers':
+            # Always include the old_parent as an option
+            available_cluster_centers = []
+            if old_parent is not None:
+                available_cluster_centers.append(old_parent)
+
+            if cluster_centers_guaranteed:
+                available_cluster_centers += cluster_centers
+                return available_cluster_centers
+
+            for clst_center in cluster_centers:
+                upstream_parent = clst_center
+                while upstream_parent.parentNode is not None:
+                    upstream_parent = upstream_parent.parentNode
+                if upstream_parent.isRoot:
+                    available_cluster_centers.append(clst_center)
+            return available_cluster_centers
+        elif select_target == 'all':
+            all_nodes_list = self.root.getNodeList([], returnRoot=True, returnLeafs=True)
+            return all_nodes_list
+        else:  # select_target == 'random'
+            # We take anything still remaining in the main tree, except the original parent of the candidate
+            no_cand = True
+            n_candidates = self.root.n_ds_nodes
+            counter = 0
+            while no_cand:
+                target_ind = np.random.randint(n_candidates)
+                target = self.root.select_nth_node_df(target_ind, 0)
+                if (old_parent is None) or (target.nodeInd != old_parent.nodeInd):
+                    no_cand = False
+                counter += 1
+                if counter > 1e9:
+                    logger.warning("Something went wrong. Can't find a random target for an SPR move!")
+                    target = None
+                    no_cand = False
+        return [target]
+
+    def getNodeListBF(self):
+        nodeList = [self.root]
+        queue = [self.root]
+        while len(queue):
+            node = queue.pop(0)
+            for child in node.childNodes:
+                nodeList.append(child)
+                queue.append(child)
+        return nodeList
+
+    def add_cells(self, ltqs_to_add_cg, ltqsvars_to_add_cg, cell_ids, growth_before_cleanup=.1,
+                  select_target='cluster_centers', resolve_polytomies_immediately=True, scdata=None, tmp_folder=None,
+                  tmp_tree_ind=0, search_tol=2, n_centers=None, only_count_search_moves=False):
+        """
+
+        :param ltqs_to_add_cg: Numpy array (cells x genes) with coordinates of cells that should be added to the tree
+        :param ltqsvars_to_add_cg: Numpy array (cells x genes) with corresponding uncertainties
+        :param growth_before_cleanup: Fraction of growth of number of nodes before we do a cleanup of the tree
+        (resolving polytomies + optimizing branch lengths)
+        :param spr_strategy: Determines how we search for where to add the node.
+        :return:
+        """
+        # TODO: Turn this off
+        very_verbose = False
+        # We initialize some variables, and do a first clean-up of the tree
+        growth_bf_small_cleanup = .1
+
+        as_if_root_version = 0
+        spr_target_version = 0
+        self.root.reset_version_numbers('_AIRoot_version')
+        self.root.reset_version_numbers('_spr_target_version')
+        total_dlogl_decrease = 0
+
+        """Prepare the tree"""
+        # nChildren = self.root.gatherInfoDepthFirst([])
+        self.remove_two_child_root()
+        self.root.deleteParentsWithOneChild()
+        self.root.mergeZeroTimeChilds()
+        self.root.renumberNodes(change_node_inds=False)
+        self.nNodes = bs_glob.nNodes
+
+        self.root.storeParent()
+        self.root.getLtqsComplete(mem_friendly=True)
+        orig_loglik = self.calcLogLComplete(mem_friendly=True, recalc=False)
+
+        n_to_add_total = ltqs_to_add_cg.shape[0]
+        tree_size = bs_glob.nCells if (bs_glob.nCells is not None) else self.nNodes
+        n_before_cleanup = int(np.ceil(growth_before_cleanup * tree_size))
+        n_bf_small_cleanup = int(np.ceil(growth_bf_small_cleanup * tree_size))
+
+        # If select_target is cluster_centers, we get cluster-centers here, which will be used as start-points for the
+        # tree-based search of where to put the new cells
+        if select_target == 'cluster_centers':
+            if n_centers is None:
+                n_cntrs = int(np.log(bs_glob.nNodes)) if bs_glob.nNodes is not None else np.log(bs_glob.nCells)
+            else:
+                n_cntrs = n_centers
+            cluster_center_node_ids = self.get_cluster_centers(cell_ids=None, n_clusters=n_cntrs + 1)
+            nodesList = self.root.getNodeList([], returnRoot=True, returnLeafs=True)
+            cluster_centers = [node for node in nodesList if node.nodeId in cluster_center_node_ids]
+        else:
+            cluster_centers = None
+
+        n_print = 100
+        n_added = 0
+        # counts_search_moves = []
+        total_search_moves = 0
+        start_adding = time.time()
+        for n_added in range(n_to_add_total):
+            if n_added == n_print:
+                # if True:
+                mp_print("Seconds since start: {}. "
+                         "Adding cell {} out of {}: {:.2f}%.".format(time.time() - start_adding,
+                                                                     n_added + 1, n_to_add_total,
+                                                                     100 * (n_added + 1) / n_to_add_total))
+                mp_print("Total number of searches done: {}".format(total_search_moves))
+                # mp_print("Current memory usage is ",
+                #          psutil.Process(os.getpid()).memory_info().rss / 1024 ** 2, " MB.", ALL_RANKS=True)
+                # print_memory("n_added: {}".format(n_added))
+                n_print *= 2
+
+            # Create TreeNode that can be added
+            ltqs = ltqs_to_add_cg[n_added, :]
+            ltqsvars = ltqsvars_to_add_cg[n_added, :]
+            cell_id = cell_ids[n_added]
+            cand_node_ind = bs_glob.max_node_ind + 1
+            bs_glob.max_node_ind += 1
+            self.max_node_ind += 1
+            bs_glob.nNodes += 1
+            self.nNodes += 1
+            candidate = TreeNode(nodeInd=cand_node_ind, childNodes=[], parentNode=None, isLeaf=True, isRoot=False,
+                                 ltqs=ltqs, ltqsVars=ltqsvars, tParent=None, nodeId=cell_id, isCell=True, vert_ind=None)
+
+            """Select target-node to start the search for a good target"""
+            # The targets-object returned is a list, which either has 1 or multiple nodes. We run the SPR search on
+            # all these targets and select the best one
+            targets = self.select_spr_targets(select_target=select_target, old_parent=None,
+                                              cluster_centers=cluster_centers, cluster_centers_guaranteed=True)
+
+            # Use SPR-strategy to find target for adding the node
+            opt_node = None
+            opt_dlogl = -np.inf
+            opt_t = None
+            for target in targets:
+                """Check the change in loglikelihood when adding to target"""
+                opt_node, opt_dlogl, opt_t, search_count = target.do_spr_search(ltqs, ltqsvars, prev_dlogl=-np.inf,
+                                                                                prev_node_ind=None, opt_node=opt_node,
+                                                                                opt_t=opt_t,
+                                                                                opt_dlogl=opt_dlogl,
+                                                                                as_if_root_version=as_if_root_version,
+                                                                                spr_target_version=spr_target_version,
+                                                                                do_local_search=True,
+                                                                                search_tol=search_tol,
+                                                                                search_count=0)
+                total_search_moves += search_count
+                # counts_search_moves.append(search_count)
+
+            # Add the node to the tree structure
+            # if only_count_search_moves:
+            #     as_if_root_version += 1
+            #     spr_target_version += 1
+            #     continue
+            """Perform move"""
+            # Keep track of loglikelihood decrease for a sanity check
+            total_dlogl_decrease += opt_dlogl
+
+            # Make sure to add new node if adding it downstream of a leaf
+            if opt_node.isLeaf:
+                # In this case, create a new node that is basically a copy of "opt_node", but is the parent of the original
+                # node in the tree with a zero branch length connecting them.
+                new_parent = opt_node.get_twin_parent()
+            else:
+                new_parent = opt_node
+
+            if very_verbose:
+                mp_print("Adding cell {} downstream of {} with branch length {}".format(candidate.nodeId,
+                                                                                        opt_node.nodeId, opt_t))
+
+            # Add the candidate node on the tree, and update the coordinates
+            new_parent.add_subtree(candidate, opt_t, ltqs, ltqsvars)
+            as_if_root_version += 1
+            spr_target_version += 1
+            bs_glob.nCells += 1
+            scdata.metadata.nCells += 1
+            scdata.metadata.cellIds.append(cell_id)
+            # TODO: Eventually check if I want to remove this
+            if resolve_polytomies_immediately and (len(new_parent.childNodes) > 2):
+                # Check if candidate (that is attached to node) still wants to sit on a downstream branch, i.e., if the
+                # likelihood increases when we add an ancestor for the candidate with some other child
+
+                # First get the coordinates of new_parent as if it's the root
+                new_parent.getAIRootUpstream(as_if_root_version=as_if_root_version)
+                changedSomething = new_parent.mergeChildrenUB(new_parent.ltqsAIRoot, new_parent.getW(AIRoot=True),
+                                                              sequential=False, verbose=False, random=False,
+                                                              specialChild=candidate.nodeInd,
+                                                              singleProcess=True, mergeDownstream=False)
+                if changedSomething:  # Now the ltqs upstream of the new_parent should be updated again
+                    new_parent.setLtqsUpstream()
+                    as_if_root_version += 1
+                    new_parent.storeParent()
+                    # Also update the n_ds_node variables upstream of the old_parent
+                    # old_n_ds_nodes = new_parent.n_ds_nodes
+                    # new_parent.get_ds_node_counts()
+                    # added_n_ds_nodes = new_parent.n_ds_nodes - old_n_ds_nodes
+                    # if (added_n_ds_nodes != 0) and (not new_parent.isRoot):
+                    #     new_parent.parentNode.add_n_nodes_upstream(added_n_ds_nodes)
+
+            # Increase metadata (nNodes, ...?)
+
+            if n_added in [n_before_cleanup, n_bf_small_cleanup]:
+                tree_size = bs_glob.nCells if (bs_glob.nCells is not None) else self.nNodes
+
+                if n_added != n_before_cleanup:
+                    only_cleanup = True
+                    mp_print("Performing small cleanup and calculating new cluster-centers. "
+                             "Current number of cells: {}".format(tree_size))
+                else:
+                    only_cleanup = False
+                    mp_print("Round of adding cells took {} seconds.".format(time.time() - start_adding))
+                    start_postprocessing = time.time()
+                    mp_print("Performing intermediate time-optimization and calculating new cluster-centers. "
+                             "Current number of cells: {}".format(tree_size))
+
+                if not only_cleanup:
+                    n_before_cleanup += int(np.ceil(growth_before_cleanup * tree_size))
+                    n_before_cleanup = min(n_before_cleanup, n_to_add_total - 1)
+                n_bf_small_cleanup += int(np.ceil(growth_bf_small_cleanup * tree_size))
+                n_bf_small_cleanup = min(n_bf_small_cleanup, n_to_add_total - 1)
+                self.do_spr_postprocessing(change_node_inds=False, verbose=False, only_cleanup=only_cleanup,
+                                           only_time_opt=resolve_polytomies_immediately)
+                if not only_cleanup:
+                    mp_print("Round of re-optimizing times took {} seconds.".format(time.time() - start_postprocessing))
+                    start_cluster_centers = time.time()
+
+                if select_target == 'cluster_centers':
+                    if n_centers is None:
+                        n_cntrs = int(np.log(bs_glob.nNodes)) if bs_glob.nNodes is not None else np.log(bs_glob.nCells)
+                    else:
+                        n_cntrs = n_centers
+                    cluster_center_node_ids = self.get_cluster_centers(cell_ids=None, n_clusters=n_cntrs + 1)
+                    nodesList = self.root.getNodeList([], returnRoot=True, returnLeafs=True)
+                    cluster_centers = [node for node in nodesList if node.nodeId in cluster_center_node_ids]
+
+                if not only_cleanup:
+                    mp_print("Round of getting new cluster centers took {} seconds.".format(
+                        time.time() - start_cluster_centers))
+
+                    if (scdata is not None) and (tmp_folder is not None):
+                        scdata.storeTreeInFolder(os.path.join(tmp_folder, 'added_%d' % tmp_tree_ind),
+                                                 with_coords=False, verbose=True, cleanup_tree=False)
+                        remove_tree_folders(tmp_folder, removeDir=False, notRemove=tmp_tree_ind, base='added')
+                        tmp_tree_ind += 1
+
+                start_adding = time.time()
+
+        # if only_count_search_moves:
+        #     np.savetxt(scdata.result_path('counts_search_moves.txt'), np.array(counts_search_moves), fmt='%d')
+        #     exit()
+        self.nNodes = bs_glob.nNodes
+        logger.info("The {} added cells led to a decrease of {} "
+                    "of the tree loglikelihood.".format(n_added + 1, total_dlogl_decrease))
+        logger.info("Not taking account intermediate resolving of polytomies: total loglikelihood should now be {}, "
+                    "and it is {} according to the normal loglik "
+                    "calculation.".format(orig_loglik + total_dlogl_decrease,
+                                          self.calcLogLComplete(mem_friendly=True, recalc=True)))
+
+
+def getNewUBInfo(xrAsIfRoot_g, WAsIfRoot_g, epsx, epsW, alldLogLsUB, UBInfo, allPairsUB, oldRoot, del_node_inds,
+                 nChild=None, kNN=None, pairsDoneInfo=None, ellipsoidSize=None, verbose=False, newUBObtained=None,
+                 mpiInfo=None):
+    # First add all newly computed upper bounds together
+    sortedUBs = np.zeros(0)
+    sortedPairs = np.zeros((0, 2), dtype=int)
+    for rankInd, dLogLUBs in enumerate(alldLogLsUB):
+        if len(dLogLUBs):
+            nUBs = len(sortedUBs)
+            indices = nUBs - np.searchsorted(sortedUBs, dLogLUBs, sorter=np.arange(nUBs - 1, -1, -1))
+            sortedUBs = np.insert(sortedUBs, indices, dLogLUBs)
+            sortedPairs = np.insert(sortedPairs, indices, allPairsUB[rankInd], axis=0)
+
+    indices = len(UBInfo['UBs']) - np.searchsorted(UBInfo['UBs'], sortedUBs,
+                                                   sorter=np.arange(len(UBInfo['UBs']) - 1, -1, -1))
+
+    UBInfo['UBs'] = np.insert(UBInfo['UBs'], indices, sortedUBs)
+    UBInfo['pairs'] = np.insert(UBInfo['pairs'], indices, sortedPairs, axis=0)
+
+    for node in del_node_inds:
+        toBeDeleted = np.where(UBInfo['pairs'] == node)[0]
+        UBInfo['pairs'] = np.delete(UBInfo['pairs'], toBeDeleted, axis=0)
+        UBInfo['UBs'] = np.delete(UBInfo['UBs'], toBeDeleted)
+
+    # Test if root moved out of ellipsoid, because then we need to calculate new UBs
+    getNewUB = (np.linalg.norm((oldRoot['pos'] - xrAsIfRoot_g) * np.sqrt(oldRoot['prec']),
+                               2) > epsx) or (
+                       np.linalg.norm((oldRoot['prec'] - WAsIfRoot_g) / oldRoot['prec'],
+                                      2) > epsW)
+    if not newUBObtained:
+        pairsDoneInfo['pairsDoneList'].append(pairsDoneInfo['totalPairsDone'])
+        if len(pairsDoneInfo['pairsDoneList']) > 10:
+            avgPairsDone = np.mean(pairsDoneInfo['pairsDoneList'][-10:])
+            if avgPairsDone > 0.20 * kNN * nChild / mpiInfo.size:
+                getNewUB = True
+                ellipsoidSize = ellipsoidSize / 2
+                # nChild * ellipsoidSize is the number of targeted steps before new UBs, we want this to be at least 2
+                ellipsoidSize = min(max(ellipsoidSize, 2 / nChild, 0.1), 10)
+                if verbose:
+                    mp_print("Too many pairs were calculated using UB. "
+                             "Calculating new upper bounds, and decreasing ellipsoid size. "
+                             "Ellipsoid size now %.2f" % ellipsoidSize)
+            elif getNewUB and (avgPairsDone < kNN * 5):
+                ellipsoidSize *= 2
+                # nChild * ellipsoidSize is the number of targeted steps before new UBs, we want this to be at least 2
+                ellipsoidSize = min(max(ellipsoidSize, 2 / nChild, 0.1), 10)
+                if verbose:
+                    mp_print("Very few pairs were calculated per round. "
+                             "Ellipsoid size for UB-estimation will be increased. "
+                             "Ellipsoid size now %.2f" % ellipsoidSize)
+    return UBInfo, getNewUB, ellipsoidSize
+
+
+def communicateMaxs(maxdLogL, maxdLogLZeroRoot, foundMax, task, nNewPairs, UBInfo, mpiInfo):
+    if mpiInfo.size > 1:
+        maxdLogLTuples = mpi_wrapper.world_allgather(maxdLogL)
+        maxdLogLZeroRootTuples = mpi_wrapper.world_allgather(maxdLogLZeroRoot)
+        ind1s, ind2s, maxdLogLs = zip(*maxdLogLTuples)
+        ind1sZeroRoot, ind2sZeroRoot, maxdLogLsZeroRoot = zip(*maxdLogLZeroRootTuples)
+        maxdLogL = maxdLogLTuples[np.argmax(maxdLogLs)]
+        maxdLogLZeroRoot = maxdLogLZeroRootTuples[np.argmax(maxdLogLsZeroRoot)]
+        if not foundMax:
+            foundMax = (maxdLogL[2] > UBInfo['UBs'][task - nNewPairs])
+        foundMaxs = mpi_wrapper.world_allgather(foundMax)
+        allFoundMax = min(foundMaxs)
+        return foundMax, allFoundMax, maxdLogL, maxdLogLZeroRoot
+    else:
+        return foundMax, foundMax, maxdLogL, maxdLogLZeroRoot
+
+
+def initializeTask(indTask, myTasks, pairs, nodeIndToChildInd, verbose, mpiInfo, runConfigs):
+    task = myTasks[indTask]
+    # Get indices of nodes
+    nodeInd1, nodeInd2 = pairs[task]
+    # Get corresponding indices in list self.childNodes
+    ind1 = nodeIndToChildInd[nodeInd1] if nodeInd1 in nodeIndToChildInd else None
+    ind2 = nodeIndToChildInd[nodeInd2] if nodeInd2 in nodeIndToChildInd else None
+    skip = True if ((ind1 is None) or (ind2 is None)) else False  # Happens when some node was already merged, but
+    # still appears in pairs-list. It seems faster to skip over it here than to update pairs-list
+    if (not skip) and (ind1 == ind2):
+        skip = True
+        logger.error("nodeInd1: {}, nodeInd2: {}".format(nodeInd1, nodeInd2))
+        logger.error(
+            "There's a mistake somewhere. We are trying to calculate the merging likelihood of a node with itself. "
+            "This is now skipped!")
+    if skip:
+        mp_print("A node-ind showed up in a candidate merge-pair that is no longer one of the root-children. This"
+                 "should be impossible. Candidate pairs: ({}, {})".format(nodeInd1, nodeInd2), ERROR=True)
+        return skip, task, nodeInd1, nodeInd2, ind1, ind2
+    # Print some information on progress
+    if verbose and ((indTask + 1) % 5000 == 0):
+        mp_print("Process %d: Calculating merger loglikelihoods for pair (%d,%d), "
+                 "calculation %d out of%s %.0f."
+                 % (mpiInfo.rank, ind1, ind2, indTask + 1, " (potentially)" if runConfigs['useUBNow'] else "",
+                    len(myTasks)),
+                 ALL_RANKS=True)
+    return skip, task, nodeInd1, nodeInd2, ind1, ind2
+
+
+# TODO: Check if this can be improved
+# Used
+def findOptimalTSingleCell(ltqs_g, ltqsVars_g, xr_g, t0, W_g):
+    # We here find the root of the derivative of the star-tree likelihood w.r.t. to ti. We are almost certain that this
+    # is a decreasing function in ti. We therefore first check the derivative at ti=0
+    sqDists_g = (xr_g - ltqs_g) ** 2
+    derAtZero = np.dot(1 / ltqsVars_g, sqDists_g / ltqsVars_g - 1 + 1 / (ltqsVars_g * W_g))
+    if derAtZero < 0:
+        return 0.
+    else:
+        # The derivative is positive at ti=0. Now find ti for which the derivative is negative, so that we can start
+        # the brentq-algorithm
+        tUBNotFound = True
+        tLB = 0.
+        tUB = max(t0, 0.01)
+        while tUBNotFound:
+            if derLogLikStar(tUB, ltqsVars_g, sqDists_g, W_g) < 0:
+                tUBNotFound = False
+            else:
+                tLB = tUB
+                tUB *= 10
+        tOpt = brentq(derLogLikStar, tLB, tUB, args=(ltqsVars_g, sqDists_g, W_g), xtol=1e-4, rtol=1e-4, maxiter=100,
+                      full_output=False, disp=True)
+    return tOpt
+
+
+# Used
+def derLogLikStar(t, ltqsVars_g, sqDists_g, W_g):
+    tbar_g = ltqsVars_g + t
+    wbar_g = 1 / tbar_g
+    return np.dot(wbar_g, wbar_g * sqDists_g - 1 + 1 / (tbar_g * W_g))
+
+
+# Used
+def optimiseT3LeafStar(ltqs_gi, ltqsVars_gi, t0_i, verbose=False):
+    optRes = minimize(getLogLikAndGradStarTreeWrapper, np.log(np.maximum(t0_i, 1e-4)), args=(ltqsVars_gi, ltqs_gi),
+                      bounds=((-16.1180, 10), (-16.1180, 10), (-16.1180, 10)), jac=True, tol=None)
+
+    # TODO: Decide if using Hessian, seems to not do much and may be problematic at t=0
+    # negHess = getHessStarTreeJax_jit(optRes.x, ltqsVars_gi, ltqs_gi)
+    # detNegHess = np.linalg.det(negHess)
+    # optLoglik = -optRes.fun - (np.log(detNegHess) / 2)
+    optLoglik = -optRes.fun
+    return optLoglik, np.exp(optRes.x), optRes.success
+
+
+# This may be used in the future
+# def getHessStarTreeJax(t, ltqsVars_gi, ltqs_gi):
+#     hessFun = jax.jacfwd(jax.jacrev(logLStarTreeJax))
+#     return hessFun(t, ltqsVars_gi, ltqs_gi)
+
+
+# def logLStarTreeJax(t_i, ltqsVars_gi, ltqs_gi):
+#     wbar_gi = 1 / (ltqsVars_gi + t_i)
+#     W_g = jnp.sum(wbar_gi, axis=1)
+#
+#     wOverW_gi = jnp.divide(wbar_gi, W_g[:, None])
+#     xr_g = jnp.sum(jnp.multiply(wOverW_gi, ltqs_gi), axis=1)
+#     sqdistsWbar_gi = jnp.multiply(wbar_gi, (xr_g[:, None] - ltqs_gi) ** 2)
+#     loglik = jnp.sum(jnp.sum(jnp.log(wbar_gi), axis=1) - jnp.log(W_g) - jnp.sum(sqdistsWbar_gi, axis=1))
+#     # grad = np.sum(wbar_gi * (sqdistsWbar_gi - 1 + wOverW_gi), axis=0)
+#     return -loglik
+
+
+# Used
+def optimiseT3LeafStarSequential(ltqs_gi, ltqsVars_gi, t0_i, tol=None, verbose=False):
+    # Optimise t12, total diffusion time between the two cells as if these are not connected to the root
+    # if t12Opt is None:
+    # t12Opt, converged = getOptTime2LeafTree(ltqs_gi, ltqsVars_gi, tol=tol)
+    t12Opt, converged = getOptTime2LeafTree(ltqs1_g=ltqs_gi[:, 0], ltqsVars1_g=ltqsVars_gi[:, 0], ltqs2_g=ltqs_gi[:, 1],
+                                            ltqsVars2_g=ltqsVars_gi[:, 1], tol=tol)
+    if not converged:
+        return None, None, None, False
+    # Fix t12 = t1a + t2a and optimise t1a < t12 and tar.
+    # We will optimize t1a on a linear scale, and tar on log-scale
+    # omicverse: the compiled optimiser replaces the SciPy call here -- see
+    # omicverse/external/bonsai/_fast.py for why and for the accuracy it was
+    # measured to. Same problem, same bounds, same starting point.
+    from .._fast import opt_t3, use_fast
+    x_init = (0.5 * t12Opt, np.log(max(t0_i[1], 1e-4)))
+    if use_fast(ltqs_gi.shape[0]) and ltqs_gi.shape[1] == 3:
+        fun, xa, xb = opt_t3(np.ascontiguousarray(ltqs_gi, dtype=np.float64),
+                             np.ascontiguousarray(ltqsVars_gi, dtype=np.float64),
+                             float(t12Opt), float(x_init[0]), float(x_init[1]),
+                             float(tol) if tol else 1e-5, 1e-16, 200)
+        return -fun, np.array([xa, np.exp(xb)]), t12Opt, True
+    optRes = minimize(getLogLikAndGradStarTreeSequentialWrapper, list(x_init),
+                      args=(t12Opt, ltqsVars_gi, ltqs_gi), bounds=((0, t12Opt), (-16.1180, 10)),
+                      jac=True, tol=tol)
+    optRes.x[1] = np.exp(optRes.x[1])
+    return -optRes.fun, optRes.x, t12Opt, optRes.success
+
+
+# Used
+# def optimiseT3LeafStarSequentialOld(ltqs_gi, ltqsVars_gi, t0_i, tol=None, verbose=False):
+#     # Optimise t12, total diffusion time between the two cells as if these are not connected to the root
+#     # if t12Opt is None:
+#     t12Opt, converged = getOptTime2LeafTree(ltqs_gi, ltqsVars_gi, tol=tol)
+#     if not converged:
+#         return None, None, None, False
+#     # Fix t12 = t1a + t2a and optimise t1a < t12 and tar.
+#     # We will optimize t1a on a linear scale, and tar on log-scale
+#     optRes = minimize(getLogLikAndGradStarTreeSequentialWrapper, [0.5 * t12Opt, np.log(max(t0_i[1], 1e-4))],
+#                       args=(t12Opt, ltqsVars_gi, ltqs_gi), bounds=((0, t12Opt), (np.log(1e-7), np.log(1e7))),
+#                       jac=True, tol=tol)
+#     optRes.x[1] = np.exp(optRes.x[1])
+#     return -optRes.fun, optRes.x, t12Opt, optRes.success
+
+def getLoglik2LeafTree(ltqs1_g, ltqsVars1_g, ltqs2_g, ltqsVars2_g, t):
+    totalVars_g = ltqsVars1_g + ltqsVars2_g + t
+    sqDists_g = (ltqs1_g - ltqs2_g) ** 2
+    loglik = -np.sum(np.log(totalVars_g) + sqDists_g / totalVars_g)
+    return loglik
+
+
+# Used
+def getOptTime2LeafTree(ltqs1_g, ltqsVars1_g, ltqs2_g, ltqsVars2_g, tol=1e-7):
+    summedLtqsVars_g = ltqsVars1_g + ltqsVars2_g
+    sqDists_g = (ltqs1_g - ltqs2_g) ** 2
+    lb_bracket = 0
+    ub_bracket = lb_bracket + 1
+    value_lb = der2LeafTree(lb_bracket, summedLtqsVars_g, sqDists_g)
+    if value_lb <= 0:
+        # First derivative at lower bound is negative, so lower bound is (local) optimum
+        return 0, True
+
+    value_ub = der2LeafTree(ub_bracket, summedLtqsVars_g, sqDists_g)
+    bracket_counter = 0
+    while value_ub >= 0:
+        bracket_counter += 1
+        if bracket_counter > 10:
+            mp_print("Bisection method could not find good starting bracket in first 10 trys.\n"
+                     "Lower bound is now {} (value={}), upper bound is now {} (value={})".format(lb_bracket, value_lb,
+                                                                                                 ub_bracket, value_ub),
+                     ALL_RANKS=True, ERROR=True)
+        lb_bracket = ub_bracket
+        ub_bracket *= 10
+        value_ub = der2LeafTree(ub_bracket, summedLtqsVars_g, sqDists_g)
+        if lb_bracket > 1e6:
+            return None, False
+        if value_ub > 1e9:
+            exit()
+    opt_dist, opt_sol = brentq(der2LeafTree, lb_bracket, ub_bracket,
+                               (summedLtqsVars_g, sqDists_g),
+                               rtol=tol, full_output=True)
+    return opt_sol.root, opt_sol.converged
+
+
+# Used
+def der2LeafTree(t12, summedLtqsVars_g, sqDists_g):
+    # omicverse: compiled fast path for small feature counts; identical maths.
+    from .._fast import der2_leaf_tree, use_fast
+    if use_fast(summedLtqsVars_g.shape[0]):
+        return der2_leaf_tree(float(t12), summedLtqsVars_g, sqDists_g)
+    totVar_g = t12 + summedLtqsVars_g
+    der = np.sum((-1 + sqDists_g / totVar_g) / totVar_g)
+    return der
+
+
+# Used
+def logLGradStarTreeLogT(logt_i, ltqsVars_gi, ltqs_gi):
+    t_i = np.exp(logt_i)
+    wbar_gi = 1 / (ltqsVars_gi + t_i)
+    W_g = np.sum(wbar_gi, axis=1)
+    wOverW_gi = np.divide(wbar_gi, W_g[:, None])
+    xr_g = np.sum(np.multiply(wOverW_gi, ltqs_gi), axis=1)
+    sqdists_gi = (xr_g[:, None] - ltqs_gi) ** 2
+    loglik = np.sum(np.sum(np.log(wbar_gi), axis=1) - np.log(W_g) - np.sum(np.multiply(wbar_gi, sqdists_gi), axis=1))
+    grad = np.sum(wbar_gi * (sqdists_gi * wbar_gi - 1 + wOverW_gi), axis=0)
+    # print("Loglik: " + str(loglik / bs_glob.nGenes))
+    return -loglik, - t_i * grad
+
+
+# Used
+def logLGradStarTreeLogLambda(logLambda_g, t_i, ltqs_gi, ltqsVars_gi, nCells):
+    lambda_g = np.exp(logLambda_g)
+
+    ltqsNew_gi = ltqs_gi / np.sqrt(lambda_g[:, None])
+    ltqsVarsNew_gi = ltqsVars_gi / lambda_g[:, None]
+    xr_g, W_g, wbar_gi, wOverW_gi = findNodeLtqsGivenLeafs(ltqs_gi=ltqsNew_gi, ltqsVars_gi=ltqsVarsNew_gi, t_i=t_i,
+                                                           return_wbar_gi=True, return_wOverW_gi=True)
+    sqDistsTimesWbar_gi = wbar_gi * (ltqsNew_gi - xr_g[:, None]) ** 2
+
+    loglik = np.sum(- nCells * logLambda_g - np.log(W_g) + np.sum(np.log(wbar_gi) - sqDistsTimesWbar_gi, axis=1))
+    logGrad = - nCells - np.sum(wbar_gi * (ltqsVarsNew_gi * (wOverW_gi - 1) - t_i * sqDistsTimesWbar_gi), axis=1)
+
+    # print("Loglik: " + str(loglik))
+    return - loglik, - logGrad
+
+
+# Used
+def logLGradStarTreeLogLambdaSingleGene(logLambda, t_i, ltqs_i, ltqsVars_i, nCells):
+    logLambda = logLambda[0]
+    lam = np.exp(logLambda)
+
+    ltqsNew_i = ltqs_i / np.sqrt(lam)
+    ltqsVarsNew_i = ltqsVars_i / lam
+    xr, W, wbar_i, wOverW_i = findNodeLtqsGivenLeafsSingleGene(ltqsNew_i, ltqsVarsNew_i, t_i, return_wbar_i=True,
+                                                               return_wOverW_i=True)
+    sqDistsTimesWbar_i = wbar_i * (ltqsNew_i - xr) ** 2
+
+    loglik = - nCells * logLambda - np.log(W) + np.sum(np.log(wbar_i) - sqDistsTimesWbar_i)
+    logGrad = - nCells - np.sum(wbar_i * (ltqsVarsNew_i * (wOverW_i - 1) - t_i * sqDistsTimesWbar_i))
+
+    # print("Loglik: " + str(loglik))
+    return - loglik, - logGrad
+
+
+# Used
+def optimiseTStar(ltqs_gi, ltqsVars_gi, nChilds=None, verbose=False):
+    if nChilds is None:
+        nChilds = ltqs_gi.shape[1]
+    t_i = np.ones(nChilds)
+    tnew_i = np.zeros(nChilds)
+    converged = False
+
+    # We first try to optimize the diffusion times using an EM-like scheme. If this doesn't work we use a gradient-
+    # based approach
+    max_steps = 1000
+    step_counter = 0
+    while (not converged) and (np.max(t_i) < 1e8) and (step_counter < max_steps):
+        step_counter += 1
+        xr_g, W_g = findNodeLtqsGivenLeafs(ltqs_gi=ltqs_gi, ltqsVars_gi=ltqsVars_gi, t_i=t_i)
+
+        for ind in range(nChilds):
+            tnew_i[ind] = findOptimalTSingleCell(ltqs_gi[:, ind], ltqsVars_gi[:, ind], xr_g, t_i[ind], W_g)
+        changeInT = np.max(np.abs(tnew_i - t_i))
+        if verbose:
+            mp_print("Max absolute change in ti was: " + str(changeInT))
+        if changeInT < 1e-4:
+            converged = True
+        t_i = tnew_i.copy()
+    if not converged:
+        mp_print("Iterative procedure for optimising diffusion times on star-tree diverged. "
+                 "Trying gradient-based approach.")
+        optRes = minimize(logLGradStarTreeLogT, x0=np.log(t_i), jac=True, args=(ltqsVars_gi, ltqs_gi))
+        t_i = np.exp(optRes.x)
+        if not optRes.success:
+            mp_print("Could not optimize diffusion times for star-tree. "
+                     "Maybe try including fewer noisy genes, using zscore_cutoff-argument.")
+            t_i = np.ones(nChilds)
+            xr_g, W_g = findNodeLtqsGivenLeafs(ltqs_gi=ltqs_gi, ltqsVars_gi=ltqsVars_gi, t_i=t_i)
+            return t_i, -1e9, W_g, xr_g
+
+    # Found optimum. Now getting information to print and store
+    xr_g, W_g, wbar_gi, wOverW_gi = findNodeLtqsGivenLeafs(ltqs_gi=ltqs_gi, ltqsVars_gi=ltqsVars_gi, t_i=t_i,
+                                                           return_wbar_gi=True,
+                                                           return_wOverW_gi=True)
+    loglik = getLoglikAndGradStarTree(ltqs_gi=ltqs_gi, xr_g=xr_g, wbar_gi=wbar_gi, W_g=W_g, returnGrad=False)
+    if verbose:
+        mp_print("LogL per Gene: " + str(loglik / bs_glob.nGenes))
+        # Real loglikelihood is:
+        # (loglik * 0.5) - (bs_glob.nGenes * (bs_glob.nCells - 1)/2)* np.log(2 * math.pi)
+    return t_i, loglik, W_g, xr_g
+
+
+# Used
+def optimiseLambdaStar(t_i, ltqs_gi, ltqsVars_gi, geneVars, verbose=False):
+    nGenes = bs_glob.nGenes
+    nCells = bs_glob.nCells
+    logLambda_g = np.zeros(nGenes)
+
+    # bounds = ((-13.815510557964274, 13.815510557964274),) * nGenes  # np.log(1e-6) = -13.815510557964274
+    # start = time.time()
+    # optRes = minimize(logLGradStarTreeLogLambda, x0=logLambda_g, jac=True, bounds=bounds, args=(t_i, ltqs_gi, ltqsVars_gi, nCells))
+    # lambda_g = np.exp(optRes.x)
+    # mp_print("Variance optimization took: %.5f seconds." % (time.time() - start))
+    # if not optRes.success:
+    #     mp_print("Could not optimize gene variances for star-tree. "
+    #              "Maybe try including fewer noisy genes, using zscore_cutoff-argument.")
+    #     lambda_g = np.ones(nGenes)
+    #     return lambda_g, ltqs_gi, ltqsVars_gi
+
+    start = time.time()
+    lambda_g = np.zeros(nGenes)
+    for gene_ind in range(nGenes):
+        bounds = np.array([[-13.815510557964274, 13.815510557964274]]) - np.log(geneVars[gene_ind])  # np.log(1e-6)
+        optRes = minimize(logLGradStarTreeLogLambdaSingleGene, x0=logLambda_g[gene_ind], bounds=bounds, jac=True,
+                          args=(t_i, ltqs_gi[gene_ind, :], ltqsVars_gi[gene_ind, :], nCells))
+        if optRes.success:
+            lambda_g[gene_ind] = np.exp(optRes.x)
+        else:
+            mp_print("Optimizing variance of gene %d did not succeed. Re-setting to old value.")
+            lambda_g[gene_ind] = 1
+    mp_print("Variance optimization (per gene) took: %.5f seconds." % (time.time() - start))
+    return lambda_g
+
+
+# Used
+def getLoglikAndGradStarTree(childNodes=None, ltqs_gi=None, ltqsVars_gi=None, t_i=None, xr_g=None, wbar_gi=None,
+                             W_g=None, returnGrad=False, mem_friendly=False):
+    """
+    :param childNodes: if childNodes is not None, this information about connected nodes is used
+    :param ltqs_gi: only necessary when no childNodes. List of coordinates of children.
+    :param ltqsVars_gi: only necessary when no childNodes. List of uncertainty-variances on coordinates of children
+    :param t_i: only necessary when no childNodes. List of edge-lengths to children.
+    :param xr_g: if provided, root position is not recalculated
+    :param W_g: if provided, root precision is not recalculated
+    :return:
+    """
+    if childNodes is None:
+        # omicverse: this branch is the hot one (called ~900k times per run via
+        # getLogLikAndGradStarTreeSequentialWrapper) and is pure array maths, so
+        # it gets the fused kernel when the feature count is small enough for
+        # NumPy's per-call dispatch to dominate. Same expressions, same order.
+        from .._fast import star_loglik_grad, use_fast
+        if (returnGrad and xr_g is None and ltqs_gi is not None
+                and ltqs_gi.ndim == 2 and use_fast(ltqs_gi.shape[0])):
+            return star_loglik_grad(np.ascontiguousarray(ltqs_gi, dtype=np.float64),
+                                    np.ascontiguousarray(ltqsVars_gi, dtype=np.float64),
+                                    np.ascontiguousarray(t_i, dtype=np.float64))
+        mem_friendly = False
+        wOverW_gi = None
+    if xr_g is None:
+        if mem_friendly:
+            xr_g, W_g = findNodeLtqsGivenLeafs(childNodes=childNodes, ltqs_gi=ltqs_gi, ltqsVars_gi=ltqsVars_gi, t_i=t_i,
+                                               return_wbar_gi=False, return_wOverW_gi=False)
+            wbar_gi = None
+        elif not returnGrad:
+            xr_g, W_g, wbar_gi = findNodeLtqsGivenLeafs(childNodes=childNodes, ltqs_gi=ltqs_gi, ltqsVars_gi=ltqsVars_gi,
+                                                        t_i=t_i, return_wbar_gi=True, return_wOverW_gi=False)
+        else:
+            xr_g, W_g, wbar_gi, wOverW_gi = findNodeLtqsGivenLeafs(childNodes=childNodes, ltqs_gi=ltqs_gi,
+                                                                   ltqsVars_gi=ltqsVars_gi, t_i=t_i,
+                                                                   return_wbar_gi=True, return_wOverW_gi=True)
+
+    if childNodes is None:
+        sqdists_gi = (xr_g[:, None] - ltqs_gi) ** 2
+        sqdistsWbar_gi = np.multiply(wbar_gi, sqdists_gi)
+        loglik = np.sum(np.sum(np.log(wbar_gi), axis=1) - np.log(W_g) - np.sum(sqdistsWbar_gi, axis=1))
+    else:
+        loglik = - np.sum(np.log(W_g))
+        if returnGrad:
+            grad = np.zeros(len(childNodes))
+        for cInd, child in enumerate(childNodes):
+            if wbar_gi is None:
+                wbar_g = 1 / (child.getLtqsVars() + child.tParent)
+            else:
+                wbar_g = wbar_gi[:, cInd]
+            loglik += np.sum(np.log(wbar_g))
+            sqdistsWbar_g = np.multiply(wbar_g, (xr_g - child.ltqs) ** 2)
+            loglik -= np.sum(sqdistsWbar_g)
+            if returnGrad:
+                grad[cInd] = np.sum(wbar_g * (sqdistsWbar_g - 1 + np.divide(wbar_g, W_g)))
+    if not returnGrad:
+        return loglik
+    else:
+        if childNodes is None:
+            if wOverW_gi is None:
+                wOverW_gi = np.divide(wbar_gi, W_g[:, None])
+            grad = np.sum(wbar_gi * (sqdistsWbar_gi - 1 + wOverW_gi), axis=0)
+        return loglik, grad
+
+
+def estimateDerBasedDLogLUB(rootInfo, tOpt, ltqs_gi=None, ltqsVars_gi=None, wir_gi=None, child1=None,
+                            child2=None, sequential=True):
+    """
+    Function that takes information about a pair and the root, and returns two values that are used to calculate an
+    upper bound on the dLogL under the assumption that the root stays in an ellipsoid. The size of this allowed
+    ellipsoid scales for the position x_{rg}, epsx/sqrt(n_c W(r)_g), and for the precision W(r)_g as epsW W(r)_g/n_c.
+
+    This function returns the upper bound *per epsx and epsW* so that these can be picked later. So, it returns
+    ddLogL/epsx, ddLogL/epsW
+    and the upper bound is then determined by
+    dLogL + ddLogL/epsx * epsX + ddLogL/epsW * epsW
+    """
+    xr_g, Wr_g, nChild = rootInfo['pos'], rootInfo['prec'], rootInfo['nChild']
+    if ltqs_gi is None:
+        tOld1, wbar1_g, ltqs1, ltqsVars1, nodeInd1 = child1.getInfo()
+        tOld2, wbar2_g, ltqs2, ltqsVars2, nodeInd2 = child2.getInfo()
+
+        rootMinusFirst_W_g = Wr_g - wbar1_g
+        rootMinusFirst_ltqs = xr_g * Wr_g - wbar1_g * ltqs1
+        WR_g = rootMinusFirst_W_g - wbar2_g
+        ltqsR = (rootMinusFirst_ltqs - wbar2_g * ltqs2) / WR_g
+        ltqsVarsR = 1 / WR_g
+        ltqs_gi = np.column_stack((ltqs1, ltqs2, ltqsR))
+        ltqsVars_gi = np.column_stack((ltqsVars1, ltqsVars2, ltqsVarsR))
+        wir_gi = np.column_stack((wbar1_g, wbar2_g, 1 / ltqsVarsR))
+        if sequential:
+            newLogLik, optTimes, t12Opt, converged = optimiseT3LeafStarSequential(ltqs_gi, ltqsVars_gi, tOpt,
+                                                                                  verbose=False)
+
+            if converged:
+                optTimes = [optTimes[0], t12Opt - optTimes[0], optTimes[1]]
+            else:
+                sequential = False
+                tOpt = calcTInit(tOld1, tOld2, sequential)
+        if not sequential:
+            newLogLik, tOpt, converged = optimiseT3LeafStar(ltqs_gi, ltqsVars_gi, tOpt, verbose=False)
+        if not converged:
+            # Now exiting. If this happens often, I can also just say that these pairs get very low likelihood.
+            mp_print("Times cannot be optimized for this pair.", WARNING=True)
+            newLogLik = -np.inf
+
+        wbar_gi = np.column_stack((wbar1_g, wbar2_g, 1 / ltqsVarsR))
+        loglik = getLoglikAndGradStarTree(ltqs_gi=ltqs_gi, xr_g=xr_g, wbar_gi=wbar_gi, W_g=Wr_g,
+                                          returnGrad=False)
+        dLogL = newLogLik - loglik
+    else:
+        dLogL = None
+    # Get derivative w.r.t. W(r)
+    wia_gi = 1 / (ltqsVars_gi + tOpt)
+    Wa_g = np.sum(wia_gi, axis=1)
+    wiaOverWa_gi = np.divide(wia_gi, Wa_g[:, None])
+
+    w1a_g, w2a_g, wRa_g = wia_gi.T
+    w1r_g, w2r_g, wRr_g = wir_gi.T
+    ltqs1, ltqs2, ltqsR = ltqs_gi.T
+
+    diff12_g = ltqs1 - ltqs2
+    diff1R_g = ltqs1 - ltqsR
+    diff2R_g = ltqs2 - ltqsR
+    diffrR_g = xr_g - ltqsR
+    v12_g = diff12_g ** 2
+    v1R_g = diff1R_g ** 2
+    v2R_g = diff2R_g ** 2
+
+    w1r_g = w1r_g
+    w2r_g = w2r_g
+
+    da_g = w1a_g * w2a_g * v12_g + w1a_g * wRa_g * v1R_g + w2a_g * wRa_g * v2R_g
+    dr_g = w1r_g * w2r_g * v12_g + w1r_g * wRr_g * v1R_g + w2r_g * wRr_g * v2R_g
+
+    wRaOverW_g = wiaOverWa_gi[:, 2]
+    wRrOverW_g = wRr_g / Wr_g
+
+    # Real expression:
+    dLdWr = (wRa_g * (1 - wRaOverW_g) - wRr_g * (1 - wRrOverW_g) +
+             wRaOverW_g * (w1a_g * w2a_g * v12_g - (1 - wRaOverW_g) * da_g) -
+             wRrOverW_g * (w1r_g * w2r_g * v12_g - (1 - wRrOverW_g) * dr_g)) / (wRr_g ** 2) + \
+            (2 * diffrR_g / wRr_g) * (
+                    wRaOverW_g * (w1a_g * diff1R_g + w2a_g * diff2R_g) - wRrOverW_g * (
+                    w1r_g * diff1R_g + w2r_g * diff2R_g))
+
+    # Given this derivative we calculate the maximal increase in dLogL by setting dLUB = |dLdWr * Wr| * epsW / n_c
+    ddLogLPerEpsW = np.linalg.norm(dLdWr * Wr_g, 2)
+
+    # WrUB_g = np.maximum(Wr_g + ((dLdWr * Wr_g ** 2) / np.linalg.norm(dLdWr * Wr_g)) * epsW / nChildren,
+    #                     1.2 * (wbar1_g + wbar2_g))
+
+    # Get most improving xr
+    # The real expression
+    dLdxr = 2 * (Wr_g / wRr_g) * (diff1R_g * (w1a_g * wRaOverW_g - w1r_g * wRrOverW_g)
+                                  + diff2R_g * (w2a_g * wRaOverW_g - w2r_g * wRrOverW_g))
+
+    # Given this derivative we calculate the maximal increase in dLogL by setting dLUB = |dLdxr/sqrt(Wr)| epsx / n_c
+    ddLogLPerEpsx = np.linalg.norm(dLdxr / np.sqrt(Wr_g), 2)
+    # Option 2: we calculate the maximal increase in dLogL by moving the W(r) in the best direction possible:
+    # xrUB_g = xr_g + (
+    #         (dLdxr / Wr_g) / np.linalg.norm(dLdxr / np.sqrt(Wr_g), 2)) * epsx / np.sqrt(nChildren)
+    return dLogL, ddLogLPerEpsx, ddLogLPerEpsW
+
+
+# Used
+def getLogLikAndGradStarTreeSequentialWrapper(t_i, t12, ltqsVars_gi, ltqs_gi):
+    # This wrapper allows t_i to be the first argument, where t_i has only 2 entries, t_{1a} and t_{ar}. Together with
+    # t_{12} = t_{1a} + t_{2a} this gives all times. The wrapper returns the negative of the loglik and grad.
+    # It is used in optimising the diffusion times for a merge when args.sequential = True
+    t_i = np.array([t_i[0], t12 - t_i[0], np.exp(t_i[1])])
+    loglik, grad = getLoglikAndGradStarTree(ltqs_gi=ltqs_gi, ltqsVars_gi=ltqsVars_gi, t_i=t_i, returnGrad=True)
+    grad = np.array([grad[0] - grad[1], t_i[2] * grad[2]])
+    return -loglik, -grad
+
+
+# Used
+def getLogLikAndGradStarTreeSequentialWrapperOld(t_i, t12, ltqsVars_gi, ltqs_gi):
+    # This wrapper allows t_i to be the first argument, where t_i has only 2 entries, t_{1a} and t_{ar}. Together with
+    # t_{12} = t_{1a} + t_{2a} this gives all times. The wrapper returns the negative of the loglik and grad.
+    # It is used in optimising the diffusion times for a merge when args.sequential = True
+    t_i = np.array([t_i[0], t12 - t_i[0], t_i[1]])
+    loglik, grad = getLoglikAndGradStarTree(ltqs_gi=ltqs_gi, ltqsVars_gi=ltqsVars_gi, t_i=t_i, returnGrad=True)
+    grad = np.array([grad[0] - grad[1], grad[2]])
+    return -loglik, -grad
+
+
+# Used
+def getLogLikAndGradStarTreeWrapper(t_i, ltqsVars_gi, ltqs_gi):
+    # This wrapper allows t_i to be the first argument, and returns the negative of the loglik and grad. It is used in
+    # optimising the diffusion times for a merge
+    t_i = np.exp(t_i)
+    loglik, grad = getLoglikAndGradStarTree(ltqs_gi=ltqs_gi, ltqsVars_gi=ltqsVars_gi, t_i=t_i, returnGrad=True)
+    return -loglik, - t_i * grad
+
+
+def getLogLikAndGradStarTreeWrapperOld(t_i, ltqsVars_gi, ltqs_gi):
+    # This wrapper allows t_i to be the first argument, and returns the negative of the loglik and grad. It is used in
+    # optimising the diffusion times for a merge
+    loglik, grad = getLoglikAndGradStarTree(ltqs_gi=ltqs_gi, ltqsVars_gi=ltqsVars_gi, t_i=t_i, returnGrad=True)
+    return -loglik, -grad
+
+
+# Used
+def findNodeLtqsGivenLeafs(childNodes=None, ltqs_gi=None, ltqsVars_gi=None, t_i=None, return_wbar_gi=False,
+                           return_wOverW_gi=False):
+    if childNodes is not None:
+        # In this case, no coordinates (ltqs_gi etc) are needed, because are taken from children-objects
+        W_g = np.zeros(bs_glob.nGenes)
+        xr_g = np.zeros(bs_glob.nGenes)
+        if return_wbar_gi:
+            wbar_gi = np.zeros(bs_glob.nGenes, len(childNodes))
+        for cInd, child in enumerate(childNodes):
+            wbar_g = 1 / (child.getLtqsVars(mem_friendly=True) + child.tParent)
+            if return_wbar_gi:
+                wbar_gi[:, cInd] = wbar_g
+            W_g += wbar_g
+            xr_g += child.ltqs * wbar_g
+        xr_g /= W_g
+        if return_wOverW_gi:
+            wOverW_gi = np.divide(wbar_gi, W_g[:, None])
+    else:
+        wbar_gi = 1 / (ltqsVars_gi + t_i)
+        W_g = np.sum(wbar_gi, axis=1)
+        wOverW_gi = np.divide(wbar_gi, W_g[:, None])
+        xr_g = np.sum(np.multiply(wOverW_gi, ltqs_gi), axis=1)
+    if not return_wbar_gi:
+        return xr_g, W_g
+    else:
+        if not return_wOverW_gi:
+            return xr_g, W_g, wbar_gi
+        else:
+            return xr_g, W_g, wbar_gi, wOverW_gi
+
+
+# Used
+def findNodeLtqsGivenLeafsSingleGene(ltqs_i, ltqsVars_i, t_i, return_wbar_i=False, return_wOverW_i=False):
+    wbar_i = 1 / (ltqsVars_i + t_i)
+    W = np.sum(wbar_i)
+    wOverW_i = np.divide(wbar_i, W)
+    xr = np.dot(wOverW_i, ltqs_i)
+    if not return_wbar_i:
+        return xr, W
+    else:
+        if not return_wOverW_i:
+            return xr, W, wbar_i
+        else:
+            return xr, W, wbar_i, wOverW_i
+
+
+# Used
+def getLtqsAsIfRoot(nodeLtqs_g, nodeW_g, tConn, rootLtqs_g, rootW_g):
+    # To get the ltqs and W of a node where all other node-positions have been integrated out, we can view it as
+    # the root. We can shift the root-position along an edge by first subtracting from the root's position the
+    # contribution of the node itself, then adding the remaining root-contribution to the position of the node
+    # TODO: Check if this can be done more efficiently
+    wbarNode_g = 1 / (tConn + 1 / nodeW_g)
+    rootMinusNodeW_g = rootW_g - wbarNode_g
+    # TODO: Check if this check can be done faster
+    if np.max(rootMinusNodeW_g) < 1e-12:
+        # In this case, the parent's ltqs are fully determined by the current node, so subtracting that
+        # contribution will give a uniform distribution, and adding that to the current node will have no
+        # effect. We can thus just set the AIRoot-coordinates to the same as the normal LTQs
+        return nodeLtqs_g.copy(), nodeW_g.copy()
+
+    rootMinusNodeLtqs_g = (rootLtqs_g * rootW_g - wbarNode_g * nodeLtqs_g) / rootMinusNodeW_g
+    wbarRoot_g = 1 / (tConn + 1 / rootMinusNodeW_g)
+    nodePlusRootW_g = nodeW_g + wbarRoot_g
+    nodePlusRootLtqs_g = (nodeLtqs_g * nodeW_g + wbarRoot_g * rootMinusNodeLtqs_g) / nodePlusRootW_g
+    return nodePlusRootLtqs_g, nodePlusRootW_g
+
+
+# Used
+def getLtqsAsIfRoot_vectorized(nodeLtqs_gi, nodeW_gi, tConn_i, rootLtqs_g, rootW_g):
+    # To get the ltqs and W of a node where all other node-positions have been integrated out, we can view it as
+    # the root. We can shift the root-position along an edge by first subtracting from the root's position the
+    # contribution of the node itself, then adding the remaining root-contribution to the position of the node
+    rootW_g = rootW_g[:, None]
+    rootLtqs_g = rootLtqs_g[:, None]
+    # TODO: Check if this can be done more efficiently
+    wbarNode_gi = 1 / (tConn_i + 1 / nodeW_gi)
+    rootMinusNodeW_gi = rootW_g - wbarNode_gi
+    rootMinusNodeLtqs_gi = (rootLtqs_g * rootW_g - wbarNode_gi * nodeLtqs_gi) / rootMinusNodeW_gi
+
+    wbarRoot_gi = 1 / (tConn_i + 1 / rootMinusNodeW_gi)
+    nodePlusRootW_gi = nodeW_gi + wbarRoot_gi
+    nodePlusRootLtqs_gi = (nodeLtqs_gi * nodeW_gi + wbarRoot_gi * rootMinusNodeLtqs_gi) / nodePlusRootW_gi
+    return nodePlusRootLtqs_gi, nodePlusRootW_gi
+
+
+# Used
+def getLtqsAfterChildUpdate(nodeLtqs_g, nodeW_g, tConn, oldChLtqs_g, oldChLtqsVars_g, newChLtqs_g, newChLtqsVars_g):
+    wbarOldCh_g = 1 / (tConn + oldChLtqsVars_g)
+    wbarNewCh_g = 1 / (tConn + newChLtqsVars_g)
+    newNodeW_g = nodeW_g - wbarOldCh_g + wbarNewCh_g
+    newNodeLtqs_g = (nodeLtqs_g * nodeW_g - wbarOldCh_g * oldChLtqs_g + wbarNewCh_g * newChLtqs_g) / newNodeW_g
+    return newNodeLtqs_g, newNodeW_g
+
+
+# Used
+def calcSingleDLogL(xrAsIfRoot_g, WAsIfRoot_g, ltqs1, ltqsVars1, wbar1_g, tOld1, rootMinusFirst_W_g,
+                    rootMinusFirst_ltqs, ltqs2, ltqsVars2, wbar2_g, tOld2, sequential=True, onlyTimes=False,
+                    returnAll=False, tol=None):
+    # t0_i = tInit if tInit is not None else calcTInit(tOld1, tOld2, sequential)
+    t0_i = calcTInit(tOld1, tOld2, sequential)
+
+    # Optimise three-leaf star-tree with leafs (ltqs1, topt1 + ltqsVars1) (ltqs2, topt2 + ltqsVars2)
+    # (ltqsR, toptR + 1/self.rootW_g)
+    # where ltqsR, 1/self.rootW_g are the mean and variance of the root-position when all other leafs
+    # (the leafs not in the current pair) are taken into account
+    WR_g = rootMinusFirst_W_g - wbar2_g
+    ltqsR = (rootMinusFirst_ltqs - wbar2_g * ltqs2) / WR_g
+    ltqsVarsR = 1 / WR_g
+    ltqs_gi = np.column_stack((ltqs1, ltqs2, ltqsR))
+    ltqsVars_gi = np.column_stack((ltqsVars1, ltqsVars2, ltqsVarsR))
+    # TODO: Change requested tolerance in t_i
+    if sequential:
+        newLogLik, optTimes, t12Opt, converged = optimiseT3LeafStarSequential(ltqs_gi, ltqsVars_gi, t0_i, verbose=False,
+                                                                              tol=tol)
+
+        if converged:
+            optTimes = [optTimes[0], t12Opt - optTimes[0], optTimes[1]]
+        else:
+            sequential = False
+            t0_i = calcTInit(tOld1, tOld2, sequential)
+    if not sequential:
+        newLogLik, optTimes, converged = optimiseT3LeafStar(ltqs_gi, ltqsVars_gi, t0_i, verbose=False)
+
+    if not converged:
+        # Now exiting. If this happens often, I can also just say that these pairs get very low likelihood.
+        mp_print("Times cannot be optimized for this pair.", WARNING=True)
+        newLogLik = -np.inf
+        optTimes = calcTInit(tOld1, tOld2, False)
+    if onlyTimes:
+        return optTimes
+    # Then calculate three-leaf star-tree likelihood with leafs (ltqs1, t1 + ltqsVars1) (ltqs2, t2 + ltqsVars2)
+    # (ltqsR, 1/self.rootW_g)
+    # wbar_gi = np.column_stack((wbar1_g, wbar2_g, 1 / ltqsVarsR))
+    wbar_gi = np.column_stack((wbar1_g, wbar2_g, WR_g))
+    loglik = getLoglikAndGradStarTree(ltqs_gi=ltqs_gi, xr_g=xrAsIfRoot_g, wbar_gi=wbar_gi, W_g=WAsIfRoot_g,
+                                      returnGrad=False)
+    dLogL = newLogLik - loglik
+    # Real dLogL is (0.5 * dLogL)
+    if returnAll:
+        return dLogL, optTimes, ltqs_gi, ltqsVars_gi, wbar_gi
+    else:
+        return dLogL, optTimes
+
+
+# Used
+def getOptTimesSingleDLogLWrapper(xrAsIfRoot_g, WAsIfRoot_g, optChild1, optChild2, sequential=True, verbose=False,
+                                  tol=1e-6):
+    # This wrapper is used when computation of optimal times is only done for one pair, so when there is no
+    # performance gain by pre-calculating some information on the first child in the pair. As such, this wrapper
+    # allows for a one-line call.
+    tOld1, wbar1_g, ltqs1, ltqsVars1, optNodeInd1 = optChild1.getInfo()
+    tOld2, wbar2_g, ltqs2, ltqsVars2, optNodeInd2 = optChild2.getInfo()
+
+    # We check whether for this pair of nodes we already have some reasonable diff. time guess
+    # sortedNodeInds = tuple(sorted([optNodeInd1, optNodeInd2]))
+    # tInit = getNodePairInfo(optTDict['all'], sortedNodeInds)
+    # In case we do sequential optimisation, we also check if t_12 = t_1a+t_2a is known already
+    # t12Opt = getNodePairInfo(optTDict['t12'], sortedNodeInds) if sequential else None
+
+    rootMinusFirst_W_g = WAsIfRoot_g - wbar1_g
+    rootMinusFirst_ltqs = xrAsIfRoot_g * WAsIfRoot_g - wbar1_g * ltqs1
+
+    optTimes = calcSingleDLogL(xrAsIfRoot_g, WAsIfRoot_g, ltqs1, ltqsVars1, wbar1_g, tOld1, rootMinusFirst_W_g,
+                               rootMinusFirst_ltqs, ltqs2, ltqsVars2, wbar2_g, tOld2, sequential=sequential,
+                               onlyTimes=True, tol=tol)
+    return optTimes
+
+
+# def getDistOnTree(node1, node2):
+#     """
+#     This function calculates the number of edges between two nodes. This assumes getDSInfo() was already called
+#     :param node1:
+#     :param node2:
+#     :return:
+#     """
+#     if node1.nodeInd in node2.dsInfo['dsNodeInds']:
+#         dist = node1.dsInfo['level'] - node2.dsInfo['level']
+#     elif node2.nodeInd in node1.dsInfo['dsNodeInds']:
+#         dist = node2.dsInfo['level'] - node1.dsInfo['level']
+#     elif node1.nodeInd == node2.nodeInd:
+#         dist = 0
+#     else:
+#         dist = node2.dsInfo['level'] + node1.dsInfo['level']
+#     return dist
+
+
+def updateNNInfo(runConfigs, NNInfo, del_node_inds, newAnc):
+    if runConfigs['useNN'] and (not runConfigs['getNewNN']) and (newAnc is not None):
+        NNInfo['NNcounter'] += 1
+        # for deletedInd in del_node_inds:  # Map all nb-connections of merged leafs to their ancestor
+        #     if deletedInd in NNInfo['leafToChild']:
+        #         NNInfo['leafToChild'][deletedInd] = newAnc.nodeInd
+        #     else:
+        #         downstreamLeafs = [leaf for leaf, child in NNInfo['leafToChild'].items() if
+        #                            child == deletedInd]
+        #         for leaf in downstreamLeafs:
+        #             NNInfo['leafToChild'][leaf] = newAnc.nodeInd
+        for leaf, child in NNInfo['leafToChild'].items():
+            if (leaf in del_node_inds) or (child in del_node_inds):
+                NNInfo['leafToChild'][leaf] = newAnc.nodeInd
+    return NNInfo
+
+
+def getEdgeDistVertNamesFromNode(node, edge_list, dist_list, orig_vert_names, intCounter, nodeIndToNode):
+    nodeIndToNode[node.nodeInd] = node
+    for child in node.childNodes:
+        edge_list.append([node.nodeInd, child.nodeInd])
+        dist_list.append(child.tParent)
+        if (child.nodeId is None) or child.nodeId[:9] == 'internal_':
+            orig_vert_names[child.nodeInd] = "internal_%d" % intCounter
+            child.nodeId = "internal_%d" % intCounter
+            intCounter += 1
+        else:
+            orig_vert_names[child.nodeInd] = child.nodeId
+        edge_list, dist_list, orig_vert_names, intCounter, nodeIndToNode = getEdgeDistVertNamesFromNode(child,
+                                                                                                        edge_list,
+                                                                                                        dist_list,
+                                                                                                        orig_vert_names,
+                                                                                                        intCounter,
+                                                                                                        nodeIndToNode)
+    return edge_list, dist_list, orig_vert_names, intCounter, nodeIndToNode
+
+
+def lik_to_post_coords_old(ltqs_lik, ltqsVars_lik):
+    vectorYN = False
+    if ltqs_lik.ndim == 1:
+        vectorYN = True
+        ltqs_lik = ltqs_lik[:, None]
+        ltqsVars_lik = ltqsVars_lik[:, None]
+    geneMeans = bs_glob.geneMeans
+
+    # Bonsai usually works with coordinates for the likelihood expression, but for the nearest-neighbor search
+    # we want to use maximal posterior ltqs. Therefore, we (re-)introduce a Gaussian prior. Before this, we first want
+    # to undo the shift by the gene-mean and the rescaling for the diffusion prior:
+    if bs_glob.geneDiffusionScaling != 'geneVariances':
+        # In this case, gene-variances used for diffusion rescaling and for the prior are different, since the
+        # diffusion rescaling is just a single scalar
+        diffusion_scaling = bs_glob.geneDiffusionScaling
+        ltqsVars_retransformed = ltqsVars_lik * diffusion_scaling
+        # The correct formula for undoing the transformation would be
+        # ltqs_retransformed = ltqs_lik * np.sqrt(diffusion_scaling) - geneMeans[:, None]
+        # But we want to re-do the diffusion rescaling after, so it's more efficient to do it here
+        ltqs_retransformed = ltqs_lik - geneMeans[:, None] / np.sqrt(diffusion_scaling)
+        rev_factor = (1 / (1 + (ltqsVars_retransformed / bs_glob.geneVariances[:, None])))
+        ltqs_post = ltqs_retransformed * rev_factor
+    else:
+        # In this case, both vectors of gene-variances are the same, such that some steps simplify
+        # ltqsVars_retransformed = ltqsVars_lik * diffusion_scaling
+        # The correct formula for undoing the transformation would be
+        # ltqs_retransformed = ltqs_lik * np.sqrt(diffusion_scaling) - geneMeans[:, None]
+        # But we want to re-do the diffusion rescaling after, so it's more efficient to do it here
+        gene_variances = bs_glob.geneVariances[:, None]
+        ltqs_retransformed = ltqs_lik - geneMeans[:, None] / np.sqrt(gene_variances)
+        rev_factor = (1 / (1 + ltqsVars_lik))
+        ltqs_post = ltqs_retransformed * rev_factor
+
+    if vectorYN:
+        return ltqs_post.flatten()
+    return ltqs_post
+
+
+def subtract_contrib_ltqs(parent_ltqs_g, parent_W_g, child_ltqs_g, child_wbar_g):
+    # Calculate node position without contribution of this child
+    ltqsTimesWAsIfRoot_g = parent_ltqs_g * parent_W_g
+    WWOChild = parent_W_g - child_wbar_g
+    parents_ltqs_wo_g = (ltqsTimesWAsIfRoot_g - child_wbar_g * child_ltqs_g) / WWOChild
+    parents_ltqsVars_wo_g = 1 / WWOChild
+    return parents_ltqs_wo_g, parents_ltqsVars_wo_g
+
+
+def add_contrib_ltqs(parent_ltqs_g, parent_W_g, child_ltqs_g, child_wbar_g):
+    # Calculate node position without contribution of this child
+    ltqsTimesWAsIfRoot_g = parent_ltqs_g * parent_W_g
+    WWChild = parent_W_g + child_wbar_g
+    parents_ltqs_wo_g = (ltqsTimesWAsIfRoot_g + child_wbar_g * child_ltqs_g) / WWChild
+    parents_ltqsVars_wo_g = 1 / WWChild
+    return parents_ltqs_wo_g, parents_ltqsVars_wo_g

--- a/omicverse/external/bonsai/bonsai/config_template_do_not_change/config_template.yaml
+++ b/omicverse/external/bonsai/bonsai/config_template_do_not_change/config_template.yaml
@@ -1,0 +1,113 @@
+# Run started at:
+start_time:
+
+# Bonsai run-configurations
+
+###################################### Input-output configurations ###################################################
+
+# dataset [str, required]: Identifier of dataset.
+dataset: new_dataset
+
+# data_folder [str, default='']:
+# Path (absolute or relative to "bonsai-development") to folder where input data can be found. This folder
+# should contain a file with means and standard-deviations in files "delta.txt" and "d_delta.txt" unless filenames_data
+# changes this behaviour.
+data_folder: data/new_dataset
+
+# filenames_data [str, default=features.txt,standard_deviations.txt]:
+# Filenames of input-files for means and standard deviations separated by a comma. These files
+# should have different cells as columns, and features (such as log transcription quotients) as rows.
+filenames_data: features.txt,standard_deviations.txt
+
+# results_folder [str, default='']:
+# Path (absolute or relative to "bonsai-development") to folder where results will be stored.'
+results_folder: results/new_dataset
+
+# verbose [bool, default=true]: False only shows essential print messages
+verbose: true
+
+# input_is_sanity_output [bool, default=true]:
+# The provided means and stds by Sanity are the means and stds of the posterior for the
+# feature: P(x | D), but in Bonsai we need the likelihood of the data given the feature value:
+# P(D | x). These are related through P(x | D) ~ P(D | x) P(x). So, we need to divide
+# out the prior. If the input is Sanity-output, we know how to do this because the reported
+# posterior is Gaussian and the prior was Gaussian around zero (see the SI of the
+# Bonsai-publication.
+# If your input data is not Sanity-output, set this flag to False, but make sure to provide
+# Bonsai with the required means and variances of the likelihood (P(D | x)).
+input_is_sanity_output: true
+
+
+######################################## Running parameters ######################################################
+
+# zscore_cutoff [float, default=1]:
+# Genes with a signal-to-noise ratio under this cutoff will be dropped. Negative means: keep all.
+# Due to the large number of genes dominated by noise, tree-reconstruction is usually better when we discard the most
+# noisy genes, even though we account for error-bars rigorously.
+# zscore is defined as: z_g = frac{1}{C} sum_c frac{(delta_{gc} - bar{delta_g})^2}{epsilon_{gc}^2}
+# where delta_{gc} is the feature value for gene g and cell c, epsilon_{gc} is the standard-deviation
+zscore_cutoff: 1.0
+
+# rescale_by_var [bool, default=True]:
+# This determines whether coordinates are rescaled by the inferred variance per gene (feature).
+# This is equivalent to putting the prior assumption that it is more likely to see change in a certain gene's expression
+# when the gene shows much variation over the whole dataset. We infer feature variances as described in the Bonsai-paper. 
+#
+# If you want to use your own inferred variances instead, you can rescale the data by the variances yourself. This means you just divide the input files (features and standard_deviations) by the square-root of the variances before giving it to Bonsai. In that case, set this flag to False.
+rescale_by_var: true
+
+# nnn_n_randommoves [int, default=1000]:
+# Decides how many random nearest-neighbor-interchange-moves we do before doing them greedily.
+nnn_n_randommoves: 1000
+
+# nnn_n_randomtrees [int, default=10]:
+# Decides how many random trees we create before taking the tree with the highest loglikelihood and doing nnn greedily.
+# Since we parallelized this procedure over the number of random trees, it never hurts to set nnn_n_randomtrees equal to the
+# number of cores that are anyhow reserved, since then the different random trees will be created in parallel.
+nnn_n_randomtrees: 10
+
+
+######################################## Speed-up configurations ######################################################
+
+# use_knn [int, default=10]:
+# Decides whether nearest-neighbours are used to get candidate pairs to merge. Set to -1 for consideringall pairs of
+# leafs. Values between 5 and 20 give good results. Computation time will scale approximately linear with use_knn, but
+# tree likelihood may also increase slightly with this parameter.
+use_knn: 10
+
+# UB_ellipsoid_size [float, default=1.0]:
+# This is a purely computational optimization that does not affect the final result.
+# Decides whether we calculate an upper bound (UB) for the increase in loglikelihood that
+# merging a certain pair can yield, given that a the root stays in a certain ellipsoid. Using these upper bounds, the
+# calculation can be sped up enormously. If the UB_ellipsoid_size < 0, this estimation will not be used. Otherwise,
+# it decides how large the ellipsoid is in root-position/precision space for which we estimate the UB. Larger values
+# will result in looser UB, so that more candidate pairs per merge have to be considered. However, it will also
+# result in longer validity of the UB-estimation, so that more merges can be done without re-calculating the upper
+# bounds.
+# Ellipsoid sizes below 5 are reasonable to try, we recommend to start at 1. Ellipsoid size will be updated dynamically
+# by Bonsai based on the results.
+UB_ellipsoid_size: 1.0
+
+# SPR-strategy [string, default='large_tree']
+# Move to general config-file later. This will determine what strategy we follow for the
+# spr-moves. Current options are 'large_tree', 'long_branch_sorted', 'super_sure'.
+# NOTE: Only large_tree allows for parallelization, the rest will only use 1 CPU.
+spr_strategy: large_tree
+
+
+########################### Information on starting from previous runs configurations ###############################
+
+# pickup_intermediate [bool, default=false]:
+# Decides whether we look for intermediate results from previous runs or not. These
+# intermediate results are periodically stored during any normal run, and can thus be used when a run did not finalize.
+pickup_intermediate: false
+
+
+############################################## Advanced features ######################################################
+
+# (ADVANCED) tmp_folder [str, default='']:
+# Path (absolute path or relative to "bonsai-development") pointing to a tree-folder from which
+# Bonsai reconstruction will start.
+# Relevant if one wants to start from a tree other than the usual star-tree, for example if one already created a
+# tree-object where cellstates were connected to a common ancestor.
+tmp_folder: ''

--- a/omicverse/external/bonsai/bonsai/create_config_file.py
+++ b/omicverse/external/bonsai/bonsai/create_config_file.py
@@ -1,0 +1,173 @@
+from argparse import ArgumentParser, ArgumentTypeError
+from ruamel.yaml import YAML
+import os, sys
+from pathlib import Path
+
+def str2bool(v):
+    if v.lower() in ('yes', 'true', 't', 'y', '1'):
+        return True
+    elif v.lower() in ('no', 'false', 'f', 'n', '0'):
+        return False
+    else:
+        raise ArgumentTypeError('Boolean value expected.')
+
+
+
+
+def main(args):
+    """Write the run YAML. Wrapped by omicverse; see the package docstring."""
+
+    # Warn about deprecated arguments
+    deprecated_args = ['skip_greedy_merging', 'skip_opt_times', 'skip_redo_starry', 'skip_nnn_reordering']
+    for dep_arg in deprecated_args:
+        if hasattr(args, dep_arg) and getattr(args, dep_arg):
+            print("WARNING: The arguments {} are deprecated and no longer have any effect. Use --pickup_intermediate True"
+                  " to pick up intermediate results from previous Bonsai runs.")
+
+    # omicverse: was a path relative to the repo root, which only resolved
+    # because upstream chdir'd there at import. Anchor it to this file instead,
+    # so it works from any working directory.
+    template_yaml_path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                                      'config_template_do_not_change', 'config_template.yaml')
+    if not os.path.exists(template_yaml_path):
+        print("Can't find template for YAML-file, should be at: {}".format(template_yaml_path))
+        exit()
+
+    yaml = YAML()
+    with open(template_yaml_path, 'r') as file_obj:
+        yaml_file = yaml.load(file_obj)
+
+    yaml_dict = dict(yaml_file)
+    for label in yaml_dict:
+        try:
+            args_attrib = getattr(args, label)
+            if args_attrib is not None:
+                yaml_file[label] = getattr(args, label)
+        except AttributeError:
+            pass
+
+
+    print("Storing new config-file at {}".format(args.new_yaml_path))
+    Path(os.path.dirname(args.new_yaml_path)).mkdir(parents=True, exist_ok=True)
+    with open(args.new_yaml_path, 'w') as file_obj:
+        yaml.dump(yaml_file, file_obj)
+
+
+
+def _build_parser():
+    """Upstream's ArgumentParser, lifted out of ``__main__`` so omicverse can
+    reuse it to build an args namespace without spawning a process."""
+    parser = ArgumentParser(
+        description='Infers a binary tree to approximate the distances in gene expression space between cells in single'
+                    ' cell data.')
+    parser.add_argument('--new_yaml_path', type=str, default='my_config.yaml',
+                        help='Path (absolute or relative to "bonsai-development) to where the created YAML-file with '
+                             'configuration-parameters needs to be stored.')
+    # Arguments that define where to find the data and where to store results. Also, whether data comes from Sanity or not
+    parser.add_argument('--dataset', type=str, default='new_dataset',
+                        help='Identifier of dataset.')
+    parser.add_argument('--data_folder', type=str, default='data/new_dataset',
+                        help='Path (absolute or relative to "bonsai-development") to folder where input data can be found. '
+                             'This folder should contain a file with means and standard-deviations in files "delta.txt" '
+                             'and "d_delta.txt" unless filenames_data changes this behaviour.')
+    parser.add_argument('--results_folder', type=str, default=None,
+                        help='# Path (absolute or relative to "bonsai-development") to folder where results will be '
+                             'stored.')
+    parser.add_argument('--filenames_data', type=str, default='features.txt,standard_deviations.txt',
+                        help='Filenames of input-files for means and standard deviations separated by a comma. These files '
+                             'should have different cells as columns, and features (such as log transcription quotients) '
+                             'as rows.')
+    parser.add_argument('--input_is_sanity_output', type=str2bool, default=True,
+                        help='The provided means and stds by Sanity are the means and stds of the posterior for the '
+                             'feature: P(x | D), but in Bonsai we need the likelihood of the data given the feature value: '
+                             'P(D | x). These are related through P(x | D) ~ P(D | x) P(x). So, we need to divide '
+                             'out the prior. If the input is Sanity-output we know how to do this because the reported '
+                             'posterior is Gaussian and the prior was Gaussian around zero (see the SI of the '
+                             'Bonsai-publication. '
+                             'If your input-data is not Sanity-output, set this flag to False, but make sure to provide '
+                             'Bonsai with the required means and variances of the likelihood (P(D | x)).')
+    # Arguments that determine running configurations of bonsai. How much is printed, which steps are run?
+    parser.add_argument('--verbose', type=str2bool, default=True,
+                        help='False only shows essential print messages')
+    # Arguments that decide on how data is preprocessed
+    parser.add_argument('--zscore_cutoff', type=float, default=1.0,
+                        help='# Genes with a signal-to-noise ratio under this cutoff will be dropped. '
+                             'Default=1.0, Negative means: keep all. '
+                             'Due to the large number of genes dominated by noise, tree-reconstruction is usually better '
+                             'when we discard the most noisy genes, even though we account for error-bars rigorously. '
+                             'zscore is defined as: '
+                             'z_g = frac{1}{C} sum_c frac{(delta_{gc} - bar{delta_g})^2}{epsilon_{gc}^2} '
+                             'where delta_{gc} is the feature value for gene g and cell c, '
+                             'epsilon_{gc} is the standard-deviation')
+    parser.add_argument("--rescale_by_var", type=str2bool, default=True,
+                        help="This determines whether oordinates are rescaled by the inferred variance per gene (feature). "
+                             "This is equivalent to putting the prior assumption that it is more likely to see change in a "
+                             "certain gene's expression when the gene shows much variation over the whole dataset.")
+    # Arguments determining which computational speedups are done
+    parser.add_argument("--use_knn", type=int, default=10,
+                        help="Decides whether nearest-neighbours are used to get candidate pairs to merge. Set to -1 for "
+                             "consideringall pairs of leafs. Values between 5 and 20 give good results. Computation time "
+                             "will scale approximately linear with use_knn, but tree likelihood may also increase "
+                             "slightly with this parameter.")
+    parser.add_argument("--nnn_n_randommoves", type=int, default=1000,
+                        help="Decides how many random nearest-neighbor-interchange-moves we do before doing them greedily.")
+    parser.add_argument("--nnn_n_randomtrees", type=int, default=10,
+                        help="Decides how many random trees we create before taking the tree with the highest "
+                             "loglikelihood and doing nnn greedily. Since the creation of one random tree is not "
+                             "parallelized, it never hurts to set nnn_n_randomtrees equal to the number of cores that are "
+                             "anyhow reserved, since then the different random trees will be created in parallel.")
+    parser.add_argument("--UB_ellipsoid_size", type=float, default=1.0,
+                        help="This is a purely computational optimization that does not affect the final result. Decides "
+                             "whether we calculate an upper bound (UB) for the increase in loglikelihood that merging a "
+                             "certain pair can yield, given that a the root stays in a certain ellipsoid. Using these "
+                             "upper bounds, the calculation can be sped up enormously. If the UB_ellipsoid_size < 0, "
+                             "this estimation will not be used. Otherwise, it decides how large the ellipsoid is in "
+                             "root-position/precision space for which we estimate the UB. Larger values will result in "
+                             "looser UB, so that more candidate pairs per merge have to be considered. However, it will "
+                             "also result in longer validity of the UB-estimation, so that more merges can be done "
+                             "without re-calculating the upper bounds. Ellipsoid sizes below 5 are reasonable to try, I "
+                             "recommend to start at 1. Ellipsoid size will be updated dynamically by Bonsai based on the "
+                             "results.")
+    parser.add_argument('--spr_strategy', type=str, default='large_tree',
+                        help="Move to general config-file later. This will determine what strategy we follow for the "
+                             "spr-moves. Current options are 'large_tree', 'long_branch_sorted', 'super_sure'."
+                             "NOTE: Only large_tree allows for parallelization, the rest will only use 1 CPU.")
+    """Information on starting from previous runs configurations"""
+    # If Bonsai was already ran with these configurations, but failed (e.g. because of a time limit), it can be re-started
+    # from the last completed results by setting --pickup_intermediate True.
+    # In that case, we will look for the furthest advanced result in the results-folder. Note that the results-folder thus
+    # has to be cleaned of results that you don't want to be picked up.
+    # The main Bonsai calculation takes the 5 below steps. After each step, the current tree will be stored in the results-
+    # folder. Therefore, if Bonsai fails (or runs out of time) in some step, it can be picked up from the end-result of the
+    # previous step.
+    #  - greedy_merging: greedily merging pairs starting from the star-tree
+    #  - redo_starry: detecting nodes that still have more than 2 children, and checking if more merges can be done
+    #  - opt_times: optimizing all branch length simultaneously once
+    #  - nnn_reordering: taking any edge and interchanging children of the two connected nodes
+    #  - reorder_edges: swapping the order of branches to ladderize the tree and re-setting the root
+    parser.add_argument('--pickup_intermediate', type=str2bool, default=False,
+                        help='Decides whether we look for intermediate results from previous runs or not. '
+                             'These intermediate results are periodically stored during any normal run, and can thus be '
+                             'used when a run did not finalize.')
+    # The following arguments are DEPRECATED! They won't do anything anymore.
+    # Arguments that decide how much post-optimisation is done
+    parser.add_argument('--skip_greedy_merging', type=str2bool, default=False,
+                        help='[DEPRECATED!] Used to skip tree reconstruction when this is already done and stored')
+    parser.add_argument("--skip_opt_times", type=str2bool, default=False,
+                        help="[DEPRECATED!] Decides whether all times are optimised after tree reconstruction.")
+    parser.add_argument("--skip_redo_starry", type=str2bool, default=False,
+                        help="[DEPRECATED!] Decides whether, after the first greedy merging, for nodes with more than 2 children, "
+                             "pairs of children are considered for merge.")
+    parser.add_argument("--skip_nnn_reordering", type=str2bool, default=False,
+                        help="[DEPRECATED!] Decides whether we go over edges and try to reconfigure all connected nodes (which are thus"
+                             "next-nearest-neighbours).")
+    parser.add_argument('--tmp_folder', type=str, default='',
+                        help='(ADVANCED): Path (absolute path or relative to "bonsai-development") pointing to a '
+                             'tree-folder from which Bonsai reconstruction will start. Relevant if one wants to start '
+                             'from a tree other than the usual star-tree, for example if one already created a '
+                             'tree-object where cellstates were connected to a common ancestor.')
+    return parser
+
+
+if __name__ == "__main__":
+    main(_build_parser().parse_args())

--- a/omicverse/external/bonsai/bonsai/mpi_wrapper.py
+++ b/omicverse/external/bonsai/bonsai/mpi_wrapper.py
@@ -1,0 +1,100 @@
+import sys, os
+comm = None
+from collections import namedtuple
+import numpy as np
+
+
+def mpi_init():
+    if sys.platform.startswith('win32'):
+        print("mpi4py does not work properly on Windows, so its use will be skipped.")
+        return
+    try:
+        # test = 1 / 0
+        from mpi4py import MPI
+    except ImportError:
+    # except ZeroDivisionError:
+        print("Since the mpi4py-package is not installed, parallel computation is not possible. "
+              "This package does not work properly on Windows, but can be installed on other operating systems.")
+        return
+
+    global comm
+    global MPI
+    comm = MPI.COMM_WORLD
+    os.environ['OPENBLAS_NUM_THREADS'] = '1'
+
+
+def get_mpi_info(singleProcess=False):
+    MpiInfo = namedtuple("MpiInfo", ['rank', 'size'])
+    if not singleProcess:
+        return MpiInfo(get_process_rank(), get_process_size())
+    else:
+        return MpiInfo(0, 1)
+
+
+def get_process_rank():
+    return comm.Get_rank() if comm is not None else 0
+
+
+def get_process_size():
+    return comm.Get_size() if comm is not None else 1
+
+
+def is_first_process():
+    return get_process_rank() == 0
+
+
+def world_allgather(data):
+    return comm.allgather(data) if comm is not None else [data]
+
+
+def gather(data, root=0):
+    return comm.gather(data, root) if comm is not None else [data]
+
+
+def Gather(data, root=0):
+    return comm.Gather(data, root=root) if comm is not None else [data]
+
+
+def GatherNpUnknownSize(data, root=0):
+    """
+    Gathers numpy arrays with unknown number of rows and set number of columns from all processes on root-process.
+    :param data:
+    :param root:
+    :return:
+    """
+    n_rows, n_cols = data.shape
+    mpi_info = get_mpi_info()
+
+    # Compute sizes and offsets for Allgatherv
+    sizes = np.array(comm.gather(n_rows, root=root))
+    
+    if mpi_info.rank == 0:
+        sizes_memory = (n_cols * sizes).tolist()
+        offsets = np.zeros(get_process_size(), dtype=int)
+        offsets[1:] = np.cumsum(sizes_memory)[:-1].tolist()
+
+        # Prepare buffer for Gatherv
+        data_out = np.empty((np.sum(sizes), n_cols), dtype=np.double)
+    else:
+        data_out = None
+        sizes_memory = None
+        offsets = None
+    comm.Gatherv(data, recvbuf=[data_out, sizes_memory, offsets, MPI.DOUBLE], root=root)
+
+    return data_out
+
+
+def Bcast(data, root=0, type='double'):
+    if type == 'double':
+        return comm.Bcast([data, MPI.DOUBLE], root=root) if comm is not None else None
+    elif type == 'int':
+        return comm.Bcast([data, MPI.INT], root=root) if comm is not None else None
+    return comm.Bcast(data, root) if comm is not None else data
+
+
+def bcast(data, root=0):
+    return comm.bcast(data, root) if comm is not None else data
+
+
+def barrier():
+    return comm.barrier() if comm else None

--- a/omicverse/external/bonsai/downstream_analyses/__init__.py
+++ b/omicverse/external/bonsai/downstream_analyses/__init__.py
@@ -1,0 +1,6 @@
+"""Vendored Bonsai downstream helpers (upstream v1.0.0), CC BY-NC 4.0.
+
+Only the two modules ``bonsai_treeHelpers`` imports are carried, not the whole
+upstream ``downstream_analyses/``. Imports rewritten to relative form; see
+``omicverse/external/bonsai/bonsai/__init__.py`` for why.
+"""

--- a/omicverse/external/bonsai/downstream_analyses/get_cluster_helpers.py
+++ b/omicverse/external/bonsai/downstream_analyses/get_cluster_helpers.py
@@ -1,0 +1,828 @@
+import numpy as np
+from pathlib import Path
+import os
+from ..bonsai.bonsai_helpers import set_recursion_limits
+
+
+class Cluster_Tree:
+    # This is just a slim version of the scdata_tree, to make getting 
+    # make it as fast and lean as possible.
+    root = None
+    nNodes = None
+    n_cell_nodes = None
+    vert_ind_to_node = None
+
+    # Layout information
+    coords = None
+    nodeIds = None
+
+    def __init__(self):
+        self.root = Cluster_TreeNode(vert_ind=-1, isRoot=True)
+        self.nNodes = 1
+        self.n_cell_nodes = 0
+
+    def copy(self, minimal_copy=False):
+        new_tree = Cluster_Tree()
+        if not minimal_copy:
+            new_tree.coords = self.coords.copy()
+        new_tree.nNodes = self.nNodes
+        new_tree.root = self.root.copy(minimal_copy=minimal_copy)
+        for child in new_tree.root.childNodes:
+            child.parentNode = new_tree.root
+        return new_tree
+
+    def to_newick(self, use_ids=True, results_path=None):
+        nwk_str = self.root.to_newick_node(use_ids=use_ids)
+        if results_path is not None:
+            with open(results_path, 'w') as f:
+                f.write(nwk_str)
+        return nwk_str
+
+    # Used
+    def storeTreeInFolder(self, treeFolder, nwk=True):
+        Path(treeFolder).mkdir(parents=True, exist_ok=True)
+        # TODO: Replace this with newer file, as in bonsai.bonsai_treeHelpers
+        edgeList, distList, vertInfo = self.getEdgeVertInfo(verbose=False)
+
+        with open(os.path.join(treeFolder, 'edgeInfo.txt'), "w") as file:
+            for ind, edge in enumerate(edgeList):
+                file.write('%d\t%d\t%.8e\n' % (edge[0], edge[1], distList[ind]))
+        with open(os.path.join(treeFolder, 'vertInfo.txt'), "w") as file:
+            file.write("vertInd\tnodeInd\tvertName\n")
+            for vert in vertInfo:
+                file.write('%d\t%d\t%s\n' % (vert, vertInfo[vert][0], vertInfo[vert][1]))
+
+        if nwk:
+            self.to_newick(use_ids=True, results_path=os.path.join(treeFolder, 'tree_test.nwk'))
+
+    def from_newick_string(self, nwk_str, node_id_to_vert_ind=None):
+        self.from_newick(nwk_str=nwk_str, node_id_to_vert_ind=node_id_to_vert_ind)
+
+        # Renumber vert_inds on tree such that they are in line with a depth-first search
+        set_recursion_limits(int(self.nNodes))
+        vertIndToNode, self.nNodes = self.root.renumber_verts(vertIndToNode={}, vert_count=0)
+        self.vert_ind_to_node = vertIndToNode
+        self.root.storeParent()
+
+    def from_newick_file(self, nwk_file, node_id_to_vert_ind=None):
+
+        with open(nwk_file, "r") as f:
+            nwk_str = f.readline()
+
+        self.from_newick(nwk_str=nwk_str, node_id_to_vert_ind=node_id_to_vert_ind)
+
+        # Renumber vert_inds on tree such that they are in line with a depth-first search
+        vertIndToNode, self.nNodes = self.root.renumber_verts(vertIndToNode={}, vert_count=0)
+        self.vert_ind_to_node = vertIndToNode
+        self.root.storeParent()
+
+    def from_newick(self, nwk_str, node_id_to_vert_ind=None):
+        # nodes = []
+        # Here we will keep a dictionary from level down the tree, to lists of nodes that don't have an assigned parent
+        level_to_nodes = {0: []}
+        level = 0
+        curr_str = ''
+        nodeIdY_tParentF = True
+        curr_node = None
+        new_node = False
+        self.nNodes = 0
+        internal_node_ids_made_up = 0
+        for char in nwk_str:
+            if char == '(':
+                # We go down the tree one level
+                level += 1
+                level_to_nodes[level] = []
+                # It also means we start a new node
+                new_node = True
+            elif char == ')':
+                # We go back up to the parent level
+                level -= 1
+                # It also means we start a new node
+                new_node = True
+            elif char == ':':
+                # This indicates a time is coming
+                if curr_node is None:
+                    # This indicates no node-id is stored in the nwk-file for this node. Make one up
+                    curr_node = Cluster_TreeNode(isLeaf=True)
+                    self.nNodes += 1
+                    curr_node.level = level
+                    level_to_nodes[level].append(curr_node)
+                    # nodeIdY_tParentF = True
+                    curr_str = 'internal_{}'.format(internal_node_ids_made_up)
+                    internal_node_ids_made_up += 1
+                    new_node = False
+
+                curr_node.nodeId = curr_str
+                if (node_id_to_vert_ind is not None) and (curr_node.nodeId in node_id_to_vert_ind):
+                    curr_node.vert_ind = node_id_to_vert_ind[curr_node.nodeId]
+                nodeIdY_tParentF = False
+                curr_str = ''
+            elif char == ',':
+                # This indicates the time is complete, new child coming
+                new_node = True
+            elif char == ';':
+                if curr_node is None:
+                    # This indicates no node-id is stored in the nwk-file for this node. Make one up
+                    curr_node = Cluster_TreeNode(isLeaf=True)
+                    self.nNodes += 1
+                    curr_node.level = level
+                    level_to_nodes[level].append(curr_node)
+                    # nodeIdY_tParentF = True
+                    curr_str = 'internal_{}'.format(internal_node_ids_made_up)
+                    internal_node_ids_made_up += 1
+                    nodeIdY_tParentF = True
+                curr_node.isRoot = True
+                new_node = True
+            else:
+                if curr_node is None:
+                    curr_node = Cluster_TreeNode(isLeaf=True)
+                    self.nNodes += 1
+                    curr_node.level = level
+                    level_to_nodes[level].append(curr_node)
+                    nodeIdY_tParentF = True
+                curr_str += char
+                new_node = False
+
+            if new_node:
+                if curr_node is not None:
+                    if nodeIdY_tParentF:
+                        curr_node.nodeId = curr_str
+                        if (node_id_to_vert_ind is not None) and (curr_node.nodeId in node_id_to_vert_ind):
+                            curr_node.vert_ind = node_id_to_vert_ind[curr_node.nodeId]
+                    else:
+                        curr_node.tParent = float(curr_str)
+                    curr_str = ''
+                    # level_to_nodes[level].append(curr_node)
+                    # Get all children and add them to this node
+                    if (curr_node.level + 1) in level_to_nodes:
+                        curr_node.childNodes = level_to_nodes[curr_node.level + 1]
+                        if len(level_to_nodes[curr_node.level + 1]) > 0:
+                            curr_node.isLeaf = False
+                            level_to_nodes[curr_node.level + 1] = []
+                    else:
+                        curr_node.childNodes = []
+                curr_node = None
+        self.root = level_to_nodes[0][0]
+
+    def set_coords_at_node(self):
+        node_list = self.get_vert_ind_to_node_DF()
+        for vert_ind, node in node_list.items():
+            node.coords = self.coords[vert_ind, :]
+
+    def get_vert_ind_to_node_DF(self, update=False):
+        if (self.vert_ind_to_node is None) or update:
+            vert_ind_to_node = {}
+            self.vert_ind_to_node = self.root.get_vert_ind_to_node_node(vert_ind_to_node)
+        return self.vert_ind_to_node
+
+    def reset_root(self, new_root_ind):
+        vert_ind_to_node = self.get_vert_ind_to_node_DF()
+        if list(vert_ind_to_node.values())[1].parentNode is None:
+            self.root.storeParent()
+        self.root = vert_ind_to_node[new_root_ind]
+        # self.root.isRoot = True
+        # self.root.tParent = None
+        self.root.reset_root_node(parent_ind=None, old_tParent=self.root.tParent)
+
+    def set_midpoint_root(self):
+        # Find longest path below each internal node (discard branches to leafs)
+        # Store maximum for each node in some dictionary
+        self.root.get_longest_path_ds()
+
+        # Go to node with longest path. Find pair of nodes on path with root in-between
+        vert_ind_to_node = self.get_vert_ind_to_node_DF()
+        max_dist_node_tuple = (None, 0)
+        for _, node in vert_ind_to_node.items():
+            if node.max_summed_dist_ds > max_dist_node_tuple[1]:
+                max_dist_node_tuple = (node, node.max_summed_dist_ds)
+        max_dist_node, max_summed_dist = max_dist_node_tuple
+
+        # Add new node in-between these pairs at right position
+        the_parent, child_ind = max_dist_node.find_midpoint_pair(max_summed_dist)
+
+        # Change child-nodes structure to get this new root
+        the_child = the_parent.childNodes[child_ind]
+        delta = max_summed_dist / 2 - the_child.max_dist_ds
+        # Create new-node that is going to be in-between the_parent and the_child
+        midpoint_root_node = Cluster_TreeNode(vert_ind=-1, childNodes=[the_child], parentNode=the_parent, isLeaf=False,
+                                              isRoot=False, tParent=the_child.tParent - delta, nodeId="midpoint_root")
+        # Delete the_child from the_parent
+        the_parent.childNodes = [parent_child for curr_ind, parent_child in enumerate(the_parent.childNodes) if curr_ind != child_ind] + [midpoint_root_node]
+        the_child.parentNode = midpoint_root_node
+        the_child.tParent = delta
+
+        # Renumber vert_inds on tree such that they are in line with a depth-first search
+        vertIndToNode, self.nNodes = self.root.renumber_verts(vertIndToNode={}, vert_count=0)
+        self.vert_ind_to_node = vertIndToNode
+        self.root.storeParent()
+
+        self.reset_root(new_root_ind=midpoint_root_node.vert_ind)
+
+        vertIndToNode, self.nNodes = self.root.renumber_verts(vertIndToNode={}, vert_count=0)
+        self.vert_ind_to_node = vertIndToNode
+        self.root.storeParent()
+
+    def getEdgeVertInfo(self, verbose=False):
+        edgeList, distList, nodeIndToVertId, _, nodeIndToNode = self.compile_tree_from_scData_tree()
+        vertInfo = {}
+        nodeIndToVertInd = {}
+        vertIndCounter = 0
+
+        for edge in edgeList:
+            for ind, nodeInd in enumerate(edge):
+                if nodeInd not in nodeIndToVertInd:
+                    nodeIndToVertInd[nodeInd] = vertIndCounter
+                    vertInfo[vertIndCounter] = (nodeInd, nodeIndToVertId[nodeInd])
+                    vertIndCounter += 1
+                vertInd = nodeIndToVertInd[nodeInd]
+                edge[ind] = vertInd
+        return edgeList, distList, vertInfo
+
+    # Used
+    def compile_tree_from_scData_tree(self):
+        edge_list = []
+        dist_list = []
+        if self.root.nodeId is None:
+            self.root.nodeId = 'root'
+        rootId = self.root.nodeId
+        orig_vert_names = {self.root.vert_ind: rootId}
+        intCounter = 0
+        starryYN = len(self.root.childNodes) > 3
+        nodeIndToNode = {}
+        edge_list, dist_list, orig_vert_names, intCounter, nodeIndToNode = getEdgeDistVertNamesFromNode(self.root,
+                                                                                                        edge_list,
+                                                                                                        dist_list,
+                                                                                                        orig_vert_names,
+                                                                                                        intCounter,
+                                                                                                        nodeIndToNode)
+        return edge_list, dist_list, orig_vert_names, starryYN, nodeIndToNode
+
+    def assign_cluster_id_to_all_downstream_nodes(self, start_node, cluster_index):
+        """
+        get all downstream nodes in depth first (DF) order, store them and for each of the downstream nodes the cluster index
+        """
+
+        # so far, every nodes knows its downstream nodes
+        # maybe want to change this, due to potential memory issues?? maybe not..
+        _, ds_nodes_idxs = start_node.getDsLeafs_DForder()
+
+        for ds_node_idx in ds_nodes_idxs: # TODO check that start node is here included, but I think this is the case
+            ds_node = self.vert_ind_to_node[ds_node_idx]
+            if ds_node.cluster_idx == 0:
+                ds_node.cluster_idx = cluster_index
+
+    def print_all_nodes_info(self):
+        for n_idx in range(len(self.vert_ind_to_node)):
+            n = self.vert_ind_to_node[n_idx]
+            print("vert_idx: {} - nodeId: {} - edge_length: {} - parent node idx : {} - isLeaf {} -cluster_idx: {}".format(n_idx, n.nodeId, n.tParent,
+                                                                                                      n.parentNode.vert_ind if n.parentNode else None,
+                                                                                                      n.isLeaf,
+                                                                                                      n.cluster_idx))
+
+    def print_all_leafs_info(self):
+        for n_idx in range(len(self.vert_ind_to_node)):
+
+            n = self.vert_ind_to_node[n_idx]
+            if n.isLeaf:
+                print("n_idx: {} - edge_length: {} - parent node: {} - isLeaf {} -cluster_idx: {}".format(n_idx, n.tParent,
+                                                                                                      n.parentNode.vert_ind if n.parentNode else None,
+                                                                                                      n.isLeaf,
+                                                                                                      n.cluster_idx))
+
+    # def get_downstream_leafs(self, root_node):
+    def cut(self, subtree_root, cell_ids=None):
+
+        # from subtree_root, traverse whole subtree and return leafs
+        # and set all traversed nodes to deleted
+        _, ds_nodes_idxs = subtree_root.getDsLeafs_DForder()
+
+        downstream_leafs = []
+        for ds_node_idx in ds_nodes_idxs:  # TODO check that start node is here included, but I think this is the case
+            ds_node = self.vert_ind_to_node[ds_node_idx]
+
+            if cell_ids is None:
+                if ds_node.isLeaf and not ds_node.is_deleted:
+                    # downstream_leafs.append(ds_node)
+                    downstream_leafs.append(ds_node.nodeId)
+            else:
+                if (ds_node.nodeId in cell_ids) and not ds_node.is_deleted:
+                    # downstream_leafs.append(ds_node)
+                    downstream_leafs.append(ds_node.nodeId)
+            ds_node.is_deleted = True
+
+        return downstream_leafs
+
+    def get_min_pdists_info(self):
+        self.n_leafs, self.root.ds_dists, self.n_cell_nodes = self.root.get_ds_and_parent_info_plus_dists()
+        self.root.us_dists = 0
+        self.root.store_us_dists(total_leafs=self.n_leafs)
+        return self.n_leafs
+
+    def get_ent_changes(self):
+        if self.vert_ind_to_node is None:
+            self.vert_ind_to_node, self.nNodes = self.root.renumber_verts(vertIndToNode={}, vert_count=0)
+
+        clade_ent_root = self.root.clade_ent_contrib_ds
+        annot_ent_root = self.root.annot_ent_contrib_ds
+        for vert_ind, node in self.vert_ind_to_node.items():
+            if node.include_as_cand:
+                node.clade_ent_change = clade_ent_root - node.clade_ent_contrib_ds - node.clade_ent_contrib_us
+                node.annot_ent_change = annot_ent_root - node.annot_ent_contrib_ds - node.annot_ent_contrib_us
+
+
+class Cluster_TreeNode:
+    # TODO remove all the stuff that is not used...
+    vert_ind = None  # identifier index for the node
+    nodeId = None
+    tParent = None  # diffusion time to parent along tree
+    childNodes = None  # list with pointers to child TreeNode objects
+    parentNode = None
+    isLeaf = None
+    isRoot = None
+    ds_leafs = None
+
+    # Variables necessary for the annotation-based clustering
+    own_annot_counts = None
+    ds_annot_counts = None
+    own_n_annots = None
+    ds_n_annots = None
+    clade_ent_contrib_ds = None
+    annot_ent_contrib_ds = None
+    clade_ent_contrib_us = None
+    annot_ent_contrib_us = None
+    clade_ent_change = None
+    annot_ent_change = None
+    old_parent_node = None
+    belongs_to_tree = None
+    revert_clade_ent_change = None
+    revert_annot_ent_change = None
+    include_as_cand = True
+
+    # Variables necessary for the min-dist clustering
+    ds_leafs_weighted = None # not used so far
+    dsNodes = None # not used
+    usNodes = None # not used
+    level = None # not used
+    max_dist_ds = None
+    max_summed_dist_ds = None
+
+    # Clustering information
+    cluster_idx = 0 # per default all cells correspond to the same cluster at the beginning
+    edge_length_rank = None # is this used?
+    len_to_most_distant_leaf = 0 # For a cut set C of the tree, we define B(C,u) = the length of the path from u to the most distance connected leaf in U. U is the tree rooted at u
+    edge_to_parent = True # set to false when we cut the tree
+    is_deleted = False # check if it has already been processed
+
+    # Coordinate information
+    coords = None
+    angle = None
+    opt_angle = None
+    thetaParent = None
+
+    def __init__(self, vert_ind=None, childNodes=None, parentNode=None, isLeaf=False, isRoot=False, tParent=None,
+                 nodeId=None):
+        self.vert_ind = vert_ind
+        self.childNodes = [] if (childNodes is None) else childNodes
+        self.nodeId = nodeId
+        self.tParent = tParent
+        self.parentNode = parentNode
+        self.isLeaf = isLeaf  # isLeaf
+        self.isRoot = isRoot
+        self.n_cells = None
+        # self.opt_angle = opt_angle
+
+    def to_newick_node(self, use_ids=True):
+        nwk_children = []
+        for child in self.childNodes:
+            nwk_children.append(child.to_newick_node())
+        if len(nwk_children) > 0:
+            nwk = ','.join(nwk_children)
+            nwk = '(' + nwk + ')'
+        else:
+            nwk = ''
+        if self.isRoot:
+            own_nwk = self.nodeId if use_ids else 'N' + str(self.nodeInd)
+        else:
+            own_nwk = self.nodeId + ':' + str(self.tParent) if use_ids else 'N' + str(self.nodeInd) + ':' + str(
+                self.tParent)
+        nwk = nwk + own_nwk
+        if self.isRoot:
+            return nwk + ';'
+        else:
+            return nwk
+
+    def copy(self, minimal_copy=False):
+        new_node = Cluster_TreeNode(vert_ind=self.vert_ind, nodeId=self.nodeId, tParent=self.tParent, isLeaf=self.isLeaf,
+                                   isRoot=self.isRoot)
+        if not minimal_copy:
+            new_node.ds_leafs = self.ds_leafs
+            new_node.ds_leafs_weighted = self.ds_leafs_weighted
+            new_node.dsNodes = self.dsNodes.copy()
+            new_node.usNodes = self.usNodes.copy()
+
+            # Coordinate information
+            new_node.coords = self.coords.copy()
+            new_node.angle = self.angle
+            new_node.opt_angle = self.opt_angle
+            new_node.thetaParent = self.thetaParent
+            new_node.vert_ind = self.vert_ind
+
+        new_node.childNodes = [child.copy(minimal_copy=minimal_copy) for child in self.childNodes]
+        for child in new_node.childNodes:
+            child.parentNode = new_node
+        return new_node
+
+    def renumber_verts(self, vertIndToNode, vert_count):
+        self.vert_ind = vert_count
+        vertIndToNode[self.vert_ind] = self
+        vert_count += 1
+        for child in self.childNodes:
+            vertIndToNode, vert_count = child.renumber_verts(vertIndToNode, vert_count)
+        return vertIndToNode, vert_count
+
+    def add_info_to_nodes(self, node_id_to_info=None, info_key=None, const_val=None):
+        if node_id_to_info is not None:
+            if self.nodeId in node_id_to_info:
+                setattr(self, info_key, node_id_to_info[self.nodeId])
+            else:
+                setattr(self, info_key, None)
+        elif const_val is not None:
+            setattr(self, info_key, const_val)
+        else:
+            print("WARNING: Don't know what information to add in 'add_info_to_nodes()'")
+            return
+        for child in self.childNodes:
+            child.add_info_to_nodes(node_id_to_info=node_id_to_info, info_key=info_key, const_val=const_val)
+
+    def getDsLeafs_DForder(self):
+        """
+        TODO: store only at the node where this is invoked
+        get downstream leafs of the current node in depth first (DF) order
+        """
+
+        dsNodes = [self.vert_ind]
+
+        if self.isLeaf:
+            self.ds_leafs = 1
+        else:
+            self.ds_leafs = 0
+            for child in self.childNodes:
+                ds_leafsCh, dsNodesCh = child.getDsLeafs_DForder()
+                # ds_leafsCh = child.getDsLeafs_DForder()
+
+                self.ds_leafs += ds_leafsCh
+                # dsNodes += dsNodesChild
+                # dsNodes += child.dsNodes
+
+
+                dsNodes += dsNodesCh
+        # self.dsNodes = dsNodes
+
+        return self.ds_leafs, dsNodes
+
+    def getDsLeafs_and_UsLeafs_DForder(self, nNodes):
+        """
+        get down stream nodes list and upstreames nodes list
+        """
+        dsNodes = [self.vert_ind]
+
+        if self.isLeaf:
+            self.ds_leafs = 1
+        else:
+            self.ds_leafs = 0
+            for child in self.childNodes:
+                ds_leafsCh, dsNodesCh, _ = child.getDsLeafs_and_UsLeafs_DForder(nNodes)
+                # ds_leafsCh = child.getDsLeafs_DForder()
+
+                self.ds_leafs += ds_leafsCh
+                # dsNodes += dsNodesChild
+                # dsNodes += child.dsNodes
+
+
+                dsNodes += dsNodesCh
+
+        usNodes = np.setdiff1d(range(nNodes), np.array(dsNodes + [self.vert_ind]))
+        # self.dsNodes = np.array(dsNodes)
+        # self.usNodes = np.setdiff1d(range(nNodes), np.array(dsNodes + [self.vert_ind]))
+
+        # self.dsNodes = dsNodes
+
+        return self.ds_leafs, dsNodes, usNodes
+
+    def getPostOrder(self):
+        """
+        get list of nodes in post order (left, right, root) #depth first tree
+        In the postorder traversal, first, we traverse the left child or left subtree of the current node and
+        then we traverse the right child or right subtree of the current node. At last, we traverse the current node.
+        """
+        post_order_nodes = []
+
+        if self.isLeaf:
+            # print("my vert ind: {}".format(self.vert_ind))
+            post_order_nodes.append(self.vert_ind)
+            return post_order_nodes
+
+        # define the left child to be the one with the lower vert ind
+        left_child_index = np.argmin([self.childNodes[0].vert_ind, self.childNodes[1].vert_ind])
+        left_child = self.childNodes[left_child_index]
+        right_child = self.childNodes[set([0,1]).difference(set([left_child_index])).pop()]
+
+
+        verts_left = left_child.getPostOrder()
+        verts_right = right_child.getPostOrder()
+
+        post_order_nodes = post_order_nodes + verts_left + verts_right + [self.vert_ind]
+
+        return  post_order_nodes
+
+    def getPostOrder_v2(self):
+        """
+        get list of nodes in post order (left, right, root) #depth first tree
+        In the postorder traversal, first, we traverse the left child or left subtree of the current node and
+        then we traverse the right child or right subtree of the current node. At last, we traverse the current node.
+
+        I think this is more robust!! i.e. looks at all the children if there are more than two... (should not, but who know)
+        """
+        post_order_nodes = []
+
+        if self.isLeaf:
+            # print("my vert ind: {}".format(self.vert_ind))
+            post_order_nodes.append(self.vert_ind)
+            return post_order_nodes
+
+        # define the left child to be the one with the lower vert ind
+        # BUT i have see that the "root" has 3 children I think in tamaras tree...
+        # Then the below definition does not work...
+        for child_node in self.childNodes:
+            grandchildren = child_node.getPostOrder_v2()
+            post_order_nodes = post_order_nodes + grandchildren
+
+        post_order_nodes = post_order_nodes + [self.vert_ind]
+
+        return  post_order_nodes
+
+    def getPostOrder_only_internalNodes(self):
+        """
+        get list of nodes in post order (left, right, root) #depth first tree
+        In the postorder traversal, first, we traverse the left child or left subtree of the current node and
+        then we traverse the right child or right subtree of the current node. At last, we traverse the current node.
+
+        I think this is more robust!! i.e. looks at all the children if there are more than two... (should not, but who know)
+        """
+        post_order_nodes = []
+
+        if self.isLeaf:
+            return post_order_nodes
+
+        # define the left child to be the one with the lower vert ind
+        # BUT i have see that the "root" has 3 children I think in tamaras tree...
+        # Then the below definition does not work...
+        for child_node in self.childNodes:
+            grandchildren = child_node.getPostOrder_only_internalNodes()
+            post_order_nodes = post_order_nodes + grandchildren
+
+        post_order_nodes = post_order_nodes + [self.vert_ind]
+
+        return  post_order_nodes
+
+    def find_longest_path_between_two_leafs(self):
+
+        if self.isLeaf:
+            return 0, 0
+
+        long_dists = []
+        short_dists = []
+        for child in self.childNodes:
+            long_to_ch, short_to_ch = child.find_longest_path_between_two_leafs()
+            long_dists.append(long_to_ch + child.tParent)
+            short_dists.append(short_to_ch + child.tParent)
+
+        return np.max(long_dists), np.min(short_dists)
+
+    def get_longest_path_ds(self, ignore_leaf_edge=True):
+        if self.isLeaf:
+            self.max_dist_ds = 0
+            self.max_summed_dist_ds = 0
+            return
+
+        max_dists = []
+        for child in self.childNodes:
+            child.get_longest_path_ds()
+            if child.isLeaf and ignore_leaf_edge:
+                max_dists.append(0)
+            else:
+                max_dists.append(child.tParent + child.max_dist_ds)
+
+        max_dists = np.array(max_dists)
+        node_idxs_partition = np.argpartition(a=-max_dists, kth=1)  # all entries left of the kth element are smaller than the kth element, but not sorted
+        nodes_with_top_edgelength = node_idxs_partition[:2]
+        top_edge_lengths = max_dists[nodes_with_top_edgelength]
+        self.max_summed_dist_ds = np.sum(top_edge_lengths)
+        self.max_dist_ds = np.max(top_edge_lengths)
+
+    def find_midpoint_pair(self, max_summed_dist):
+        # First find child with maximum downstream path
+        for child_ind, child in enumerate(self.childNodes):
+            if abs(child.max_dist_ds + child.tParent - self.max_dist_ds) < 1e-9:
+                break
+        # Check if midpoint is between this node and child
+        if child.max_dist_ds < max_summed_dist / 2:
+            # If so, return this node and the index of the child
+            return self, child_ind
+        else:
+            # Go down to child and repeat
+            max_dist_node, child_ind = child.find_midpoint_pair(max_summed_dist)
+            return max_dist_node, child_ind
+
+    def get_vert_ind_to_node_node(self, vert_ind_to_node):
+        vert_ind_to_node[self.vert_ind] = self
+        for child in self.childNodes:
+            vert_ind_to_node = child.get_vert_ind_to_node_node(vert_ind_to_node)
+        return vert_ind_to_node
+
+    def storeParent(self):
+        for child in self.childNodes:
+            child.parentNode = self
+            if not child.isLeaf:
+                child.storeParent()
+
+    def reset_root_node(self, parent_ind=None, old_tParent=None):
+        # Get all connecting nodes
+        new_children = []
+        new_parent = None
+        old_tParents = []
+        for node in self.childNodes:
+            if node.vert_ind == parent_ind:
+                new_parent = node
+            else:
+                new_children.append(node)
+                old_tParents.append(node.tParent)
+        if self.parentNode is not None:
+            if self.parentNode.vert_ind == parent_ind:
+                new_parent = self.parentNode
+            else:
+                old_tParents.append(self.parentNode.tParent)
+                self.parentNode.tParent = old_tParent
+                new_children.append(self.parentNode)
+        if new_parent is not None:
+            self.parentNode = new_parent
+        else:
+            self.parentNode = None
+            self.tParent = None
+            self.isRoot = True
+        if len(new_children) == 0:
+            # self.isLeaf = True
+            self.childNodes = []
+        else:
+            self.isLeaf = False
+            self.childNodes = new_children
+        for ind, child in enumerate(self.childNodes):
+            child.reset_root_node(parent_ind=self.vert_ind, old_tParent=old_tParents[ind])
+
+    def get_ds_and_parent_info(self):
+        if self.isLeaf:
+            self.ds_leafs = 1
+        else:
+            self.ds_leafs = 0
+
+        for child in self.childNodes:
+            child.parentNode = self
+            ds_leafs_ch = child.get_ds_and_parent_info()
+            self.ds_leafs += ds_leafs_ch
+        return self.ds_leafs
+
+    def get_ds_and_parent_info_plus_dists(self):
+        self.ds_dists = 0
+        if self.n_cells is not None:
+            self.ds_leafs = self.n_cells
+            n_cell_nodes = min(self.n_cells, 1)
+        elif self.isLeaf:
+            self.ds_leafs = 1
+            n_cell_nodes = 1
+        else:
+            self.ds_leafs = 0
+            n_cell_nodes = 0
+
+        for child in self.childNodes:
+            child.parentNode = self
+            ds_leafs_ch, ds_dists_ch, ds_n_cell_nodes = child.get_ds_and_parent_info_plus_dists()
+            self.ds_dists += ds_dists_ch + child.tParent * child.ds_leafs
+            self.ds_leafs += ds_leafs_ch
+            n_cell_nodes += ds_n_cell_nodes
+        return self.ds_leafs, self.ds_dists, n_cell_nodes
+
+    def store_us_dists(self, total_leafs):
+        # We first calculate the distance from each leaf to the current node from all sides, i.e., upstream and
+        # downstream
+        total_dists = self.us_dists + self.ds_dists
+        for child in self.childNodes:
+            # For each child, we take the total dists and subtract the contribution of the leaf-paths downstream of that
+            # child
+            total_dists_excl = total_dists - child.ds_dists
+            # We then change the contribution of the edge from child to current node. This was traveled child.ds_leafs
+            # times, but now is traveled total_leafs - child.ds_leafs
+            child.us_dists = total_dists_excl - child.tParent * (child.ds_leafs - (total_leafs - child.ds_leafs))
+            child.store_us_dists(total_leafs)
+
+    def get_ds_annot_info(self):
+        self.ds_annot_counts = self.own_annot_counts.copy()
+        self.ds_n_annots = self.own_n_annots
+
+        for child in self.childNodes:
+            child.get_ds_annot_info()
+            self.ds_annot_counts += child.ds_annot_counts
+            self.ds_n_annots += child.ds_n_annots
+
+    def set_include_as_cand(self, total_n_annots, total_annot_counts, clst_size_lb, clst_cat_capture_lbs,
+                            clst_cat_capture_ubs):
+        smallest_clst = min(total_n_annots - self.ds_n_annots, self.ds_n_annots)
+        smallest_clst_counts = np.minimum(total_annot_counts - self.ds_annot_counts, self.ds_annot_counts)
+        if smallest_clst < clst_size_lb:
+            self.include_as_cand = False
+        # elif np.all(smallest_clst_counts < clst_cat_capture_lbs):
+        #     self.include_as_cand = False
+        if np.any(smallest_clst_counts > clst_cat_capture_ubs):
+            self.include_as_cand = True
+
+        for child in self.childNodes:
+            child.set_include_as_cand(total_n_annots, total_annot_counts, clst_size_lb, clst_cat_capture_lbs,
+                                      clst_cat_capture_ubs)
+
+    def subtract_or_add_ds_info_us(self, ds_node, add=False):
+        if not add:
+            self.ds_annot_counts -= ds_node.ds_annot_counts
+            self.ds_n_annots -= ds_node.ds_n_annots
+        else:
+            self.ds_annot_counts += ds_node.ds_annot_counts
+            self.ds_n_annots += ds_node.ds_n_annots
+        if self.parentNode is not None:
+            self.parentNode.subtract_or_add_ds_info_us(ds_node, add=add)
+
+    def get_ent_contribs(self, total_n, total_annot_counts, num_annots=None):
+        if self.include_as_cand or (self.parentNode is None):
+            if num_annots is None:
+                num_annots = len(total_annot_counts)
+            # Store the contribution to the clade- and annotation-entropy given by the subtree downstream
+            # This has the form n_c log n_c (for the clade ent.), where n_c is the total number of labeled cells downstream
+            # or sum_r n_r log n_r (for the annot ent.) where n_r is the number of labeled cells of annotation r
+            self.clade_ent_contrib_ds = - entropy_non_norm(self.ds_n_annots, num_annots=1)
+            self.clade_ent_contrib_us = - entropy_non_norm(total_n - self.ds_n_annots, num_annots=1)
+            self.annot_ent_contrib_ds = - entropy_non_norm(self.ds_annot_counts, num_annots=num_annots)
+            self.annot_ent_contrib_us = - entropy_non_norm(total_annot_counts - self.ds_annot_counts, num_annots=num_annots)
+
+        for child in self.childNodes:
+            child.get_ent_contribs(total_n=total_n, total_annot_counts=total_annot_counts, num_annots=num_annots)
+
+    def __repr__(self):
+        return "vert_ind: {}\nnodeId: {}\ncluster idx: {}\nedge length: {}\nlen_to_most_distant_leaf: {}\nis_deleted: {}".format(self.vert_ind, self.nodeId, self.cluster_idx, self.tParent, self.len_to_most_distant_leaf, self.is_deleted)
+
+
+def entropy_non_norm(n, num_annots=None):
+    """
+    Compute the Shannon entropy: - ∑_r n_r log(n_r) for a vector.
+    *NOTE THAT THIS FUNCTION DOES NOT NORMALIZE THE VALUES TO SUM TO 1*
+    :param n: int/float or numpy.ndarray of int/float
+        A single non-negative integer or an array of non-negative integers
+        representing counts n_r.
+    :param num_annots: int
+        Should indicate the array-length of n
+    """
+    if num_annots is None:
+        num_annots = len(n)
+    if num_annots == 1:
+        return - n * np.log(n) if n > 0 else 0.0
+
+    tmp = np.zeros(num_annots)
+    np.log(n, out=tmp, where=n > 0)
+    return - np.sum(n * tmp)
+
+
+def entropy(n, num_annots=None):
+    """
+    Calculates the Shannon entropy for a vector n. *Does NOT normalize when n doesn't sum up to 1*.
+
+    :param n: float or numpy.ndarray of float
+        A single non-negative integer or an array of non-negative integers
+        representing counts n_r.
+    :param num_annots: int
+        Should indicate the array-length of n
+    """
+
+def getEdgeDistVertNamesFromNode(node, edge_list, dist_list, orig_vert_names, intCounter, nodeIndToNode):
+    nodeIndToNode[node.vert_ind] = node
+    for child in node.childNodes:
+        edge_list.append([node.vert_ind, child.vert_ind])
+        dist_list.append(child.tParent)
+        if (child.nodeId is None) or child.nodeId[:9] == 'internal_':
+            orig_vert_names[child.vert_ind] = "internal_%d" % intCounter
+            child.nodeId = "internal_%d" % intCounter
+            intCounter += 1
+        else:
+            orig_vert_names[child.vert_ind] = child.nodeId
+        edge_list, dist_list, orig_vert_names, intCounter, nodeIndToNode = getEdgeDistVertNamesFromNode(child,
+                                                                                                        edge_list,
+                                                                                                        dist_list,
+                                                                                                        orig_vert_names,
+                                                                                                        intCounter,
+                                                                                                        nodeIndToNode)
+    return edge_list, dist_list, orig_vert_names, intCounter, nodeIndToNode

--- a/omicverse/external/bonsai/downstream_analyses/get_clusters_max_diameter.py
+++ b/omicverse/external/bonsai/downstream_analyses/get_clusters_max_diameter.py
@@ -1,0 +1,1196 @@
+from argparse import ArgumentParser
+import os
+import numpy as np
+import pandas as pd
+import sys
+from .get_cluster_helpers import Cluster_Tree, entropy_non_norm
+from ..bonsai.bonsai_helpers import mp_print
+from itertools import combinations
+import random
+from collections import defaultdict
+import csv
+import time
+from scipy.stats import entropy
+
+
+# parent_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+# # Add the parent directory to sys.path
+# sys.path.append(parent_dir)
+# os.chdir(parent_dir)
+# sys.path.append(os.path.join(parent_dir, 'tree_layout'))
+
+# def get_cluster_assignments(clusters_list, assign_singlets_together=False):
+#     cluster_idx = 0
+#     cluster_assigment = []
+#     cell_names = []
+#     for cluster in clusters_list:
+#         # if singleton, assign -1
+#         if assign_singlets_together and (len(cluster) == 1):
+#             cluster_assigment.append("cl_{}".format(-1))
+#             cell_names.append(cluster[0])
+#             # fout.write("{}\t{}\n".format(cluster[0], -1))
+#         else:
+#             for leaf in cluster:
+#                 # fout.write("{}\t{}\n".format(leaf, cluster_idx))
+#                 cluster_assigment.append("cl_{}".format(cluster_idx))
+#                 cell_names.append(leaf)
+#             cluster_idx += 1
+#
+#     # make dict:
+#
+#     cl_dict = dict(zip(cell_names, cluster_assigment))
+#     return cl_dict
+
+
+def get_cluster_assignments(all_clusterings, node_ids_multiple_cs_ids=None):
+    if node_ids_multiple_cs_ids is None:
+        node_ids_multiple_cs_ids = {}
+    cluster_assignments = {}
+    # Create dictionary with dictionaries for each cs-ID, containing for each clustering in which cluster it falls
+    for label, clusters in all_clusterings.items():
+        for cluster_index, ids in enumerate(clusters):
+            for id_ in ids:
+                if id_ in node_ids_multiple_cs_ids:
+                    for cs_id in node_ids_multiple_cs_ids[id_]:
+                        cluster_assignments.setdefault(cs_id, {})[label] = f"cl_{cluster_index}"
+                else:
+                    cluster_assignments.setdefault(id_, {})[label] = f"cl_{cluster_index}"
+
+    df = pd.DataFrame.from_dict(cluster_assignments, orient="index")
+    df = df.sort_index()
+    return df
+
+
+def get_footfall_clustering_from_nwk_str_deprecated(tree_nwk_str, n_clusters, cell_ids=None,
+                                                    get_cell_ids_all_splits=False):
+    print("\nInit footfall clustering-tree")
+    cluster_tree = Cluster_Tree()
+    cluster_tree.from_newick_string(nwk_str=tree_nwk_str)  # Works
+    if get_cell_ids_all_splits:
+        clusters, footfall_edges, ids_splits = get_footfall_clustering(cluster_tree, n_clusters, cell_ids=cell_ids,
+                                                                       get_cell_ids_all_splits=get_cell_ids_all_splits)
+        return clusters, footfall_edges, ids_splits
+    else:
+        clusters, footfall_edges = get_footfall_clustering(cluster_tree, n_clusters, cell_ids=cell_ids)
+    return clusters, footfall_edges
+
+
+def get_annotation_based_clustering_from_nwk_str(tree_nwk_str, annotation_dict, cell_id_to_node_id=None,
+                                                 verbose=True, node_ids_to_clst=None, random_sampling=False,
+                                                 tracking_path=None, max_moves=1e6, cutting_tol=1e-4,
+                                                 prohibit_small_clsts=False):
+    """
+
+    :param tree_nwk_str: String read from a .nwk-file
+    :param annotation_dict: Dictionary having key-value pairs with cell-ID to annotation
+    :param cell_id_to_node_id: (Optional) Annotation is given for each cell, but multiple cells may have been mapped to
+    the same node. This optional dictionary allows the user to give the mapping. If left to None, we assume that
+    annotated IDs coincide with node-IDs.
+    :param node_ids_to_clst: Node Ids of nodes that should be in reported clustering (otherwise leaf-nodes are returned)
+    then we assume that we should cluster the leaves of the given newick string
+    :param random_sampling: Boolean, default=False. If False, then we do a pure greedy hierarchical clustering that
+    maximizes the Normalized Mutual Information at each clustering step. If True, we randomly sample clustering-steps
+    weighted by their NMI. In addition, we allow for reverting a cut.
+    :param tracking_path: Just for debugging purposes, we can give a folder where we will store some stats.
+    :param verbose:
+    :return:
+    """
+    cluster_tree = Cluster_Tree()
+    cluster_tree.from_newick_string(nwk_str=tree_nwk_str)
+    clusters, cut_edges, mut_info = get_annotation_based_clustering_random(cluster_tree,
+                                                                           cell_id_to_node_id=cell_id_to_node_id,
+                                                                           annotation_dict=annotation_dict,
+                                                                           verbose=verbose,
+                                                                           node_ids_to_clst=node_ids_to_clst,
+                                                                           random_sampling=random_sampling,
+                                                                           tracking_path=tracking_path,
+                                                                           max_moves=max_moves,
+                                                                           cutting_tol=cutting_tol,
+                                                                           prohibit_small_clsts=prohibit_small_clsts)
+    return clusters, cut_edges, mut_info
+
+
+def get_min_pdists_clustering_from_nwk_str(tree_nwk_str, n_clusters, cell_ids=None, get_cell_ids_all_splits=False,
+                                           node_id_to_n_cells=None, verbose=True, footfall=False):
+    if verbose:
+        mp_print("\nInit min-dist clustering-tree")
+    cluster_tree = Cluster_Tree()
+    cluster_tree.from_newick_string(nwk_str=tree_nwk_str)  # Works
+    if node_id_to_n_cells is not None:
+        cluster_tree.root.add_info_to_nodes(node_id_to_info=node_id_to_n_cells, info_key='n_cells')
+
+    all_clusterings, footfall_edges = get_min_pdists_clustering(cluster_tree, n_clusters, cell_ids=cell_ids,
+                                                                verbose=verbose, footfall=footfall)
+    return all_clusterings, footfall_edges
+
+
+def get_min_pdists_clustering_from_nwk_str_deprecated(tree_nwk_str, n_clusters, cell_ids=None,
+                                                      get_cell_ids_all_splits=False,
+                                                      node_id_to_n_cells=None, verbose=True):
+    if verbose:
+        print("\nInit min-dist clustering-tree")
+    cluster_tree = Cluster_Tree()
+    cluster_tree.from_newick_string(nwk_str=tree_nwk_str)  # Works
+    if node_id_to_n_cells is not None:
+        cluster_tree.root.add_info_to_nodes(node_id_to_info=node_id_to_n_cells, info_key='n_cells')
+    if get_cell_ids_all_splits:
+        clusters, footfall_edges, ids_splits = get_min_pdists_clustering_deprecated(cluster_tree, n_clusters,
+                                                                                    cell_ids=cell_ids,
+                                                                                    get_cell_ids_all_splits=get_cell_ids_all_splits)
+        return clusters, footfall_edges, ids_splits
+    else:
+        clusters, footfall_edges = get_min_pdists_clustering_deprecated(cluster_tree, n_clusters, cell_ids=cell_ids,
+                                                                        verbose=verbose)
+    return clusters, footfall_edges
+
+
+def get_max_diam_clustering_from_nwk_str(tree_nwk_str, max_diam_threshold, cell_ids=None):
+    print("\nInit max diameter clustering-tree")
+    cluster_tree = Cluster_Tree()
+    cluster_tree.from_newick_string(nwk_str=tree_nwk_str)  # Works
+
+    clusters = get_max_diam_clustering(cluster_tree, max_diam_threshold, cell_ids=cell_ids)
+
+    return clusters
+
+
+def get_footfall_clustering(cluster_tree, n_clusters, cell_ids=None, get_cell_ids_all_splits=False):
+    if cell_ids is not None:
+        cell_id_set = set(cell_ids)
+    if get_cell_ids_all_splits:
+        cell_ids_splits = {}
+
+    tree_ensmbl = [cluster_tree]
+    # Make sure each node knows how many ds leafs it has
+    cluster_tree.n_leafs = cluster_tree.root.get_ds_and_parent_info()
+    footfall_edges = []
+
+    while len(tree_ensmbl) < n_clusters:
+        # Loop over all edges to find max footfall one
+        max_footfall_tree_ind = None
+        max_footfall_node = None
+        max_footfall_score = -1e9
+        for ind_tree, tree in enumerate(tree_ensmbl):
+            for vert_ind, node in tree.vert_ind_to_node.items():
+                if node.parentNode is not None:
+                    footfall_score = node.ds_leafs * (tree.n_leafs - node.ds_leafs) * node.tParent
+                    if footfall_score > max_footfall_score:
+                        max_footfall_tree_ind = ind_tree
+                        max_footfall_node = node
+                        max_footfall_score = footfall_score
+
+        # Cut the tree into two pieces at the max footfall edge
+        ds_node = max_footfall_node
+        us_node = max_footfall_node.parentNode
+        footfall_edges.append((ds_node.nodeId, us_node.nodeId))
+
+        # Make one new tree:
+        max_tree = tree_ensmbl[max_footfall_tree_ind]
+        new_tree = Cluster_Tree()
+
+        # Remove ds node from original tree
+        us_node.childNodes = [child for child in us_node.childNodes if child.vert_ind != ds_node.vert_ind]
+
+        # Make ds-node the root of the new tree
+        new_tree.root = ds_node
+        ds_node.parentNode = None
+
+        # tree_1 = max_footfall_tree.copy(minimal_copy=True)
+        # tree_2 = max_footfall_tree.copy(minimal_copy=True)
+        # Reset the roots of these trees to the connecting nodes
+        # tree_1.reset_root(new_root_ind=ds_node_vert_ind)
+        # tree_2.reset_root(new_root_ind=us_node_vert_ind)
+        # Cut off the redundant parts of the trees
+        # tree_1.root.childNodes = [child for child in tree_1.root.childNodes if child.vert_ind != us_node_vert_ind]
+        # tree_2.root.childNodes = [child for child in tree_2.root.childNodes if child.vert_ind != ds_node_vert_ind]
+        # Update vert_ind_to_node
+        max_tree.vert_ind_to_node, max_tree.nNodes = max_tree.root.renumber_verts(vertIndToNode={}, vert_count=0)
+        new_tree.vert_ind_to_node, new_tree.nNodes = new_tree.root.renumber_verts(vertIndToNode={}, vert_count=0)
+        max_tree.n_leafs = max_tree.root.get_ds_and_parent_info()
+        new_tree.n_leafs = new_tree.root.get_ds_and_parent_info()
+
+        tree_ensmbl.append(new_tree)
+        if get_cell_ids_all_splits:
+            cell_ids_splits[(ds_node.nodeId, us_node.nodeId)] = []
+            for tree in [max_tree, new_tree]:
+                leaf_ids_tree = []
+                for vert_ind, node in tree.vert_ind_to_node.items():
+                    if cell_ids is None:
+                        if node.isLeaf:
+                            leaf_ids_tree.append(node.nodeId)
+                    else:
+                        if node.nodeId in cell_id_set:
+                            leaf_ids_tree.append(node.nodeId)
+                cell_ids_splits[(ds_node.nodeId, us_node.nodeId)].append(leaf_ids_tree)
+
+    clusters = []
+    for ind_tree, tree in enumerate(tree_ensmbl):
+        leaf_ids_tree = []
+        for vert_ind, node in tree.vert_ind_to_node.items():
+            if cell_ids is None:
+                if node.isLeaf:
+                    leaf_ids_tree.append(node.nodeId)
+            else:
+                if node.nodeId in cell_id_set:
+                    leaf_ids_tree.append(node.nodeId)
+        clusters.append(leaf_ids_tree)
+    # Should produce a list of lists with the node-IDs of the various clusterings
+    print("Clustering done")
+    if get_cell_ids_all_splits:
+        return clusters, footfall_edges, cell_ids_splits
+    return clusters, footfall_edges
+
+
+def get_min_pdists_clustering_deprecated(cluster_tree, n_clusters, cell_ids=None, get_cell_ids_all_splits=False,
+                                         verbose=True):
+    if cell_ids is not None:
+        cell_id_set = set(cell_ids)
+    if get_cell_ids_all_splits:
+        cell_ids_splits = {}
+
+    tree_ensmbl = [cluster_tree]
+    # Make sure each node knows how many ds leafs it has
+    cluster_tree.n_leafs = cluster_tree.get_min_pdists_info()
+    # cluster_tree.n_leafs, cluster_tree.root.ds_dists = cluster_tree.root.get_ds_and_parent_info_plus_dists()
+    # cluster_tree.root.us_dists = 0
+    # cluster_tree.root.store_us_dists(total_leafs=cluster_tree.n_leafs)
+    footfall_edges = []
+
+    while len(tree_ensmbl) < n_clusters:
+        # Loop over all edges to find max footfall one
+        max_footfall_tree_ind = None
+        max_footfall_node = None
+        max_footfall_score = -1e9
+        for ind_tree, tree in enumerate(tree_ensmbl):
+            for vert_ind, node in tree.vert_ind_to_node.items():
+                if node.parentNode is not None:
+                    footfall_score = node.ds_leafs * (tree.n_leafs - node.ds_leafs) * node.tParent
+                    footfall_score += node.ds_dists * (tree.n_leafs - node.ds_leafs)
+                    footfall_score += node.us_dists * node.ds_leafs
+                    if footfall_score > max_footfall_score:
+                        max_footfall_tree_ind = ind_tree
+                        max_footfall_node = node
+                        max_footfall_score = footfall_score
+
+        # Cut the tree into two pieces at the max footfall edge
+        ds_node = max_footfall_node
+        us_node = max_footfall_node.parentNode
+        footfall_edges.append((ds_node.nodeId, us_node.nodeId))
+
+        # Make one new tree:
+        max_tree = tree_ensmbl[max_footfall_tree_ind]
+        new_tree = Cluster_Tree()
+
+        # Remove ds node from original tree
+        us_node.childNodes = [child for child in us_node.childNodes if child.vert_ind != ds_node.vert_ind]
+
+        # Make ds-node the root of the new tree
+        new_tree.root = ds_node
+        ds_node.parentNode = None
+
+        # tree_1 = max_footfall_tree.copy(minimal_copy=True)
+        # tree_2 = max_footfall_tree.copy(minimal_copy=True)
+        # Reset the roots of these trees to the connecting nodes
+        # tree_1.reset_root(new_root_ind=ds_node_vert_ind)
+        # tree_2.reset_root(new_root_ind=us_node_vert_ind)
+        # Cut off the redundant parts of the trees
+        # tree_1.root.childNodes = [child for child in tree_1.root.childNodes if child.vert_ind != us_node_vert_ind]
+        # tree_2.root.childNodes = [child for child in tree_2.root.childNodes if child.vert_ind != ds_node_vert_ind]
+        # Update vert_ind_to_node
+        max_tree.vert_ind_to_node, max_tree.nNodes = max_tree.root.renumber_verts(vertIndToNode={}, vert_count=0)
+        new_tree.vert_ind_to_node, new_tree.nNodes = new_tree.root.renumber_verts(vertIndToNode={}, vert_count=0)
+        max_tree.n_leafs = max_tree.get_min_pdists_info()
+        new_tree.n_leafs = new_tree.get_min_pdists_info()
+
+        tree_ensmbl.append(new_tree)
+        if get_cell_ids_all_splits:
+            cell_ids_splits[(ds_node.nodeId, us_node.nodeId)] = []
+            for tree in [max_tree, new_tree]:
+                leaf_ids_tree = []
+                for vert_ind, node in tree.vert_ind_to_node.items():
+                    if cell_ids is None:
+                        if node.isLeaf:
+                            leaf_ids_tree.append(node.nodeId)
+                    else:
+                        if node.nodeId in cell_id_set:
+                            leaf_ids_tree.append(node.nodeId)
+                cell_ids_splits[(ds_node.nodeId, us_node.nodeId)].append(leaf_ids_tree)
+    # Should produce a list of lists with the node-IDs of the various clusterings
+    clusters = []
+    for ind_tree, tree in enumerate(tree_ensmbl):
+        leaf_ids_tree = []
+        for vert_ind, node in tree.vert_ind_to_node.items():
+            if cell_ids is None:
+                if node.isLeaf:
+                    leaf_ids_tree.append(node.nodeId)
+            else:
+                if node.nodeId in cell_id_set:
+                    leaf_ids_tree.append(node.nodeId)
+        clusters.append(leaf_ids_tree)
+    if verbose:
+        print("Clustering done")
+
+    if get_cell_ids_all_splits:
+        return clusters, footfall_edges, cell_ids_splits
+    return clusters, footfall_edges
+
+
+def get_ent_change_merge_move(node, n_labels=None):
+    """
+    This assumes that node is the root of a subtree that was already split off from an original tree.
+    :param node:
+    :param n_labels:
+    :return:
+    """
+    old_parent = node.old_parent_node
+    # Find out which tree the old-parent currently belongs to
+    old_tree_root = old_parent.belongs_to_tree.root
+    # Find out the total counts in this old tree
+    if n_labels is None:
+        n_labels = len(node.ds_annot_counts)
+    comb_clade_ent_cont = - entropy_non_norm(node.ds_n_annots + old_tree_root.ds_n_annots, num_annots=1)
+    comb_annot_ent_cont = - entropy_non_norm(node.ds_annot_counts + old_tree_root.ds_annot_counts, num_annots=n_labels)
+    node.revert_clade_ent_change = node.clade_ent_contrib_ds + old_tree_root.clade_ent_contrib_ds - comb_clade_ent_cont
+    node.revert_annot_ent_change = node.annot_ent_contrib_ds + old_tree_root.annot_ent_contrib_ds - comb_annot_ent_cont
+
+
+def get_new_mut_info(orig_ent_diff, annot_entropy, clade_entropy, clade_ent_change, annot_ent_change):
+    new_ent_diff = (orig_ent_diff + clade_ent_change - annot_ent_change)
+    new_normalization_sq = annot_entropy * (clade_entropy + clade_ent_change)
+    if new_normalization_sq > 0.:
+        new_mut_info = new_ent_diff / np.sqrt(new_normalization_sq)
+    else:
+        new_mut_info = 0.0
+    return new_mut_info
+
+
+def test_move_acceptance(sampling_beta, orig_mut_info, new_mut_info):
+    sampling_prob = np.exp(-sampling_beta * (1 - new_mut_info / orig_mut_info))
+    accepted = sampling_prob > random.random()
+    return accepted
+
+
+def get_annotation_based_clustering_random(cluster_tree, annotation_dict, cell_id_to_node_id=None, verbose=True,
+                                           node_ids_to_clst=None, random_sampling=False, seed=1231,
+                                           tracking_path=None, max_moves=1e6, cutting_tol=1e-4,
+                                           prohibit_small_clsts=False):
+    """
+    Greedily cuts tree into clades such that mutual information with some annotation is maximized.
+    *NOTE:* We allow for partial annotation, such that some cells have an annotation, while others do not. The use case
+    for this is that people may have partial annotation-information, and want to use the tree to annotate the rest. In
+    that case, these un-annotated cells will not be counted in the mutual annotation score, but they will still be
+    clustered in the final clustering.
+    :param cluster_tree: Cluster_tree object
+    :param node_ids_to_clst: Node Ids of nodes that should be in reported clustering (otherwise leaf-nodes are reurned)
+    :param annotation_dict: Dictionary having key-value pairs with cell-ID to annotation.
+    :param cell_id_to_node_id: (Optional) Annotation is given for each cell, but multiple cells may have been mapped to
+    the same node. This optional dictionary allows the user to give the mapping. If left to None, we assume that
+    annotated IDs coincide with node-IDs.
+    :param random_sampling: Boolean, default=False. If False, then we do a pure greedy hierarchical clustering that
+    maximizes the Normalized Mutual Information at each clustering step. If True, we randomly sample clustering-steps
+    weighted by their NMI. In addition, we allow for reverting a cut.
+    :param verbose:
+    :param tracking_folder: Just a path where I can store some stats for performance tracking.
+    :return:
+    """
+    very_verbose = False
+
+    if tracking_path is not None:
+        # tracking_path, _ = os.path.splitext(tracking_path)
+        # tracking_path += '_random.tsv' if random_sampling else '.tsv'
+        stats = []
+    np.random.seed(seed)
+    random.seed(np.random.randint(1e6))
+    n_moves = -1
+    if node_ids_to_clst is not None:
+        node_ids_to_clst_set = set(node_ids_to_clst)
+    else:
+        node_ids_to_clst_set = None
+
+    if cluster_tree.vert_ind_to_node is None:
+        cluster_tree.vert_ind_to_node, cluster_tree.nNodes = cluster_tree.root.renumber_verts(vertIndToNode={},
+                                                                                              vert_count=0)
+
+    if random_sampling:
+        # We will do random-sampling at each step, such that an option that is a factor <optimality_decrease> below the
+        # best option is picked with <prob_decrease> lower probability than the maximal option
+        # We start with optimality_decrease = .95, and may lower it when we move on.
+        # I think we can keep prob_decrease fixed at .5
+        prob_decrease = .5
+        optimality_decrease = .95
+        # We want a formula like exp(-beta * (1 - (NMI/NMI_max)^2)), so we want
+        # exp(-beta * (1 - optimality_decrease^2)) = prob_decrease
+        # beta = -log(prob_decrease) / (1 - optimality_decrease ^ 2)
+        # So, if we set:
+        sampling_beta = - np.log(prob_decrease) / (1 - optimality_decrease)
+        # n_annealing = 100
+        n_annealing = int(min(max(10, cluster_tree.nNodes / 1000), 200))
+        optimality_decrease_lb = .999
+        annealing_factor = 5
+        # Then the function for the (unnormalized) probability becomes
+        # prob(NMI) = exp(-beta * (1 - (NMI/NMI_max) * optimality_decrease))
+
+        # Add these random moves to the max_moves. With the current settings these are 3 annealing phases
+        max_moves += 3 * n_annealing
+
+        # We first do a burn-in phase though, where we just pick greedily
+        greedy = True
+
+    # First, put the annotation-labels on the tree
+    # cluster_tree.root.add_info_to_nodes(node_id_to_info=annotation_dict, info_key='annotation')
+    # Get some statistics on the annotation-labels
+    annot_labels = np.unique(list(annotation_dict.values()))
+    n_labels = len(annot_labels)
+    if n_labels in [1, len(annotation_dict)]:
+        if n_labels == 1:
+            mp_print("Only one annotation-label, nothing to cluster.")
+        elif n_labels == len(annotation_dict):
+            mp_print("All annotation-labels are different, no point in trying to match this with clustering.")
+        tree_ensmbl = [cluster_tree]
+        clusters = get_clustering_lists(tree_ensmbl, node_ids_to_clst_set)
+        return clusters, [], 1.0
+
+    label_to_ind = {annot: ind for ind, annot in enumerate(annot_labels)}
+
+    # Store the downstream annotation-counts on each node
+    node_id_to_node = {}
+    for _, node in cluster_tree.vert_ind_to_node.items():
+        node_id_to_node[node.nodeId] = node
+        node.own_annot_counts = np.zeros(n_labels, dtype=int)
+        node.own_n_annots = 0
+
+    # Store on each node to which tree it belongs
+    cluster_tree.root.add_info_to_nodes(info_key='belongs_to_tree', const_val=cluster_tree)
+    label_counts = np.zeros(n_labels, dtype=int)
+
+    # TODO: Remove when sklearn test is no longer necessary
+    # labels_true = np.zeros(len(annotation_dict), dtype=int)
+    # labels_pred = np.zeros(len(annotation_dict), dtype=int)
+    # node_id_to_cell_ids = defaultdict(list)
+    # cell_id_to_ind = {cell_id: ind for ind, cell_id in enumerate(annotation_dict)}
+    # for cell_id, node_id in cell_id_to_node_id.items():
+    #     node_id_to_cell_ids[node_id].append(cell_id)
+
+    for cell_id, annot in annotation_dict.items():
+        if cell_id_to_node_id is not None:
+            node_id = cell_id_to_node_id[cell_id]
+        else:
+            node_id = cell_id
+        if node_id not in node_id_to_node:
+            mp_print("WARNING: Node_id {} is not present in the tree. "
+                     "Cannot take its annotation into account in clustering.".format(node_id), WARNING=True)
+            continue
+        else:
+            node = node_id_to_node[node_id]
+
+        node.own_annot_counts[label_to_ind[annot]] += 1
+        node.own_n_annots += 1
+        label_counts[label_to_ind[annot]] += 1
+
+    n_cells = np.sum(label_counts)
+
+    if prohibit_small_clsts:
+        # Here, we calculate based on the label-counts some cutoffs for how small clusters can be before we cut them
+        # Ad-hoc rule: Clusters should be at least .1 of the average category, or at least .01 of the entire dataset.
+        avg_cat = n_cells / n_labels
+        clst_size_lb = min(avg_cat / 10, n_cells / 200)
+        # Clusters cannot be cut if they contain only very small fractions of all categories.
+        clst_cat_capture_lb_factor = .025
+        clst_cat_capture_lbs = label_counts * clst_cat_capture_lb_factor
+        # However, clusters can always be cut if they contain a certain fraction of all cells of a certain category.
+        clst_cat_capture_ub_factor = .3
+        clst_cat_capture_ubs = label_counts * clst_cat_capture_ub_factor
+
+    # Here, we can already calculate the entropy in the annotation. This is independent of the clustering
+    annot_entropy = entropy_non_norm(label_counts / n_cells)
+    # Initial clade entropy is 0, everyone is in the same cluster
+    clade_entropy = 0
+    # Initial joint entropy is the same as the annot_entropy, since all cells are in same cluster
+    joint_entropy = annot_entropy
+
+    # Multiply these three entropies by total number of annotations. This makes calculations easier later
+    annot_entropy *= n_cells
+    clade_entropy *= n_cells
+    joint_entropy *= n_cells
+
+    # Initialize the necessary information on the nodes of the full tree
+    cluster_tree.root.get_ds_annot_info()
+    if prohibit_small_clsts:
+        cluster_tree.root.set_include_as_cand(total_n_annots=cluster_tree.root.ds_n_annots,
+                                              total_annot_counts=cluster_tree.root.ds_annot_counts,
+                                              clst_size_lb=clst_size_lb,
+                                              clst_cat_capture_lbs=clst_cat_capture_lbs,
+                                              clst_cat_capture_ubs=clst_cat_capture_ubs)
+    # Store on each node their contribution to the clade and annot-entropy
+    cluster_tree.root.get_ent_contribs(total_n=cluster_tree.root.ds_n_annots,
+                                       total_annot_counts=cluster_tree.root.ds_annot_counts,
+                                       num_annots=n_labels)
+    # Store on each node how clade- and joint-entropy would change when edge to this node was cut
+    cluster_tree.get_ent_changes()
+    tree_ensmbl = [cluster_tree]
+
+    # TODO: Maybe remove
+    # Per tree that we create (i.e., cluster) we keep track of the total number of cells for each label
+    # total_annot_counts = [label_counts]
+
+    # TODO: Check if, for each tree, we can keep track of the maximal mutual information increase,
+    #  and which node we'd have to cut off for that maximal score
+    # max_scores = [None]
+    # max_nodes = [None]
+    # clusters = [None]
+    cut_edges = []
+
+    # Can't cut more branches between cells than there are annotated nodes
+    n_clusters = n_cells
+
+    print_i = 2
+    n_random_moves = 0
+    while (len(tree_ensmbl) < n_clusters) and (n_moves < max_moves):
+        n_moves += 1
+        n_trees = len(tree_ensmbl)
+        if verbose and (n_moves == print_i):
+            mp_print("Annotation-based clustering has done {} moves, "
+                     "currently {} clusters, "
+                     "and Normalized Mutual Information of {}.".format(n_moves, n_trees, max_new_mut_info))
+            print_i *= 2
+        # Loop over all edges to find which increases mutual information most
+        orig_ent_diff = annot_entropy + clade_entropy - joint_entropy
+        orig_normalization = np.sqrt(annot_entropy * clade_entropy)
+        if orig_normalization == 0:
+            orig_mut_info = 0.
+        else:
+            orig_mut_info = orig_ent_diff / orig_normalization
+        # max_tree_ind = None
+        max_node = None
+        max_new_mut_info = -1e9
+        if random_sampling and (not greedy):
+            if (n_random_moves % n_annealing == 0) and n_random_moves != 0:
+                optimality_decrease = 1 - ((1 - optimality_decrease) / annealing_factor)
+                sampling_beta = - np.log(prob_decrease) / (1 - optimality_decrease)
+                if optimality_decrease > optimality_decrease_lb:
+                    random_sampling = False
+                    continue
+            n_random_moves += 1
+            node_list_split = []
+            node_list_merge = []
+            sampling_probs_split = []
+            sampling_probs_merge = []
+            for ind_tree, tree in enumerate(tree_ensmbl):
+                for vert_ind, node in tree.vert_ind_to_node.items():
+                    # We set the sampling prob. of a node equal to how much it changes the clade-entropy.
+                    # We make sure to never sample a pure-cluster-split (i.e. that do not change clade-annot-ent)
+                    if node.parentNode is None:
+                        if node.old_parent_node is None:
+                            continue
+                        else:
+                            # In this case, this is a "merge"-move
+                            get_ent_change_merge_move(node, n_labels=n_labels)
+                            node_list_merge.append(node)
+                            sampling_probs_merge.append(node.revert_clade_ent_change)
+                    else:
+                        # In this case, this is a "split"-move
+                        if not node.include_as_cand:
+                            # We can skip this one because the created clusters would be too small
+                            continue
+                        if node.annot_ent_change == 0:
+                            # We can skip this node because it splits up all annotated labels from a cluster.
+                            continue
+                        node_list_split.append(node)
+                        sampling_probs_split.append(node.clade_ent_change)
+            # Now sample nodes prop. to  sampling_probs until we find a successful one
+            sampling_probs_split = np.abs(np.array(sampling_probs_split))
+            sampling_probs_merge = np.abs(np.array(sampling_probs_merge))
+            n_probs_split = len(sampling_probs_split)
+            n_probs_merge = len(sampling_probs_merge)
+            n_probs_total = n_probs_merge + n_probs_split
+            sampling_probs_split /= sampling_probs_split.sum()
+            sampling_probs_merge /= sampling_probs_merge.sum()
+            n_counter = 0
+            while (max_node is None) and (n_counter < 2 * n_probs_total):
+                n_counter += 1
+                # First decide whether you pick a merge or a split
+                pick_split = random.random() > 0.5
+                if (pick_split and (n_probs_split > 0)) or (n_probs_merge == 0):
+                    sampled_ind = np.random.choice(n_probs_split, p=sampling_probs_split)
+                    node = node_list_split[sampled_ind]
+                else:  # pick_merge
+                    sampled_ind = np.random.choice(n_probs_merge, p=sampling_probs_merge)
+                    node = node_list_merge[sampled_ind]
+
+                if node.parentNode is None:
+                    new_mut_info = get_new_mut_info(orig_ent_diff, annot_entropy, clade_entropy,
+                                                    node.revert_clade_ent_change,
+                                                    node.revert_annot_ent_change)
+                else:
+                    new_mut_info = get_new_mut_info(orig_ent_diff, annot_entropy, clade_entropy,
+                                                    node.clade_ent_change,
+                                                    node.annot_ent_change)
+                if (new_mut_info > orig_mut_info) or test_move_acceptance(sampling_beta, orig_mut_info, new_mut_info):
+                    max_node = node
+                    max_tree = node.belongs_to_tree
+                    max_new_mut_info = new_mut_info
+            if max_node is None:
+                # Wasn't able to find any successful move. Stopping random_sampling and going for a greedy finish
+                random_sampling = False
+                continue
+
+        else:
+            for ind_tree, tree in enumerate(tree_ensmbl):
+                for vert_ind, node in tree.vert_ind_to_node.items():
+                    if node.parentNode is None:
+                        if node.old_parent_node is None:
+                            continue  # This is the root of original tree. Can't merge nor split
+                        else:
+                            # This is a sub-tree root, ask it if wants to go back to its daddy
+                            # This function stores revert_clade_ent_change and revert_annot_ent_change on the node
+                            get_ent_change_merge_move(node, n_labels=n_labels)
+                            new_mut_info = get_new_mut_info(orig_ent_diff, annot_entropy, clade_entropy,
+                                                            node.revert_clade_ent_change,
+                                                            node.revert_annot_ent_change)
+                    else:
+                        if not node.include_as_cand:
+                            # We can skip this one because the created clusters would be too small
+                            continue
+                        if node.annot_ent_change == 0:
+                            # if (node.ds_n_annots == 0) or (tree.root.ds_n_annots == node.ds_n_annots):
+                            # This node, we can skip because it splits up all annotated labels from a cluster.
+                            continue
+                        new_mut_info = get_new_mut_info(orig_ent_diff, annot_entropy, clade_entropy,
+                                                        node.clade_ent_change,
+                                                        node.annot_ent_change)
+                    # if we're grouping clusters, we always accept moves that improve the NMI, if we're cutting
+                    # we only accept if they're improving to a reasonable extent
+                    tol = -1e-5 if (node.parentNode is None) else cutting_tol
+                    if new_mut_info > max(max_new_mut_info, orig_mut_info + tol):
+                        max_node = node
+                        max_tree = tree
+                        max_new_mut_info = new_mut_info
+
+        # Determine which tree has the maximum score
+        if not random_sampling:
+            # if we're grouping clusters, we always accept moves that improve the NMI, if we're cutting we only accept
+            # if they're improving to a reasonable extent
+            quitting = False
+            if max_node is None:
+                quitting = True
+            else:
+                tol = -1e-5 if (max_node.parentNode is None) else cutting_tol
+                if max_new_mut_info < orig_mut_info + tol:
+                    quitting = True
+            if quitting:
+                mp_print("\nAfter making {} clusters, norm. mutual information doesn't significantly increase. "
+                         "Stopping here.".format(n_trees))
+                break
+
+        if random_sampling and greedy:
+            if (max_new_mut_info / (orig_mut_info + 1e-9)) < 1.01:
+                mp_print("Progress is stalling, stopping the greedy burn-in phase, starting the random phase")
+                greedy = False
+                continue
+
+        # Cut the tree into two pieces at the edge that maximizes the norm. mut. info.
+        ds_node = max_node
+        if max_node.parentNode is None:
+            if max_node.old_parent_node is None:
+                mp_print("Something went terribly wrong. Node doesn't have parent, and no former parent, "
+                         "and was still selected in clustering. Check this.", ERROR=True)
+                exit()
+
+            # In this case, we do not create a new tree, but rather merge two trees
+            us_node = max_node.old_parent_node
+            cut_edges = [edge for edge in cut_edges if edge != (ds_node.nodeId, us_node.nodeId)]
+            # Update current entropies
+            clade_entropy += max_node.revert_clade_ent_change
+            joint_entropy += max_node.revert_annot_ent_change
+
+            # Delete the tree
+            tree_ensmbl = [tree_inst for tree_inst in tree_ensmbl if tree_inst.root.nodeId != max_tree.root.nodeId]
+            # del tree_ensmbl[max_tree_ind]
+
+            # Add node to original tree
+            us_node.childNodes.append(ds_node)
+            # ds-node should no longer be the root
+            ds_node.parentNode = us_node
+            ds_node.old_parent_node = None
+            ds_node.isRoot = False
+
+            # Update vert_ind_to_node for the now merged tree
+            new_tree = us_node.belongs_to_tree
+            new_tree.vert_ind_to_node, new_tree.nNodes = new_tree.root.renumber_verts(vertIndToNode={}, vert_count=0)
+
+            # Initialize the necessary information on the nodes of the full tree
+            # We don't have to do: new_tree.root.get_ds_annot_info(), because new_tree still has correct ds-info
+            # For cluster_tree, we just subtract the ds_info for everything upstream of new root
+            us_node.subtract_or_add_ds_info_us(ds_node, add=True)
+            if prohibit_small_clsts:
+                new_tree.root.set_include_as_cand(total_n_annots=new_tree.root.ds_n_annots,
+                                                  total_annot_counts=new_tree.root.ds_annot_counts,
+                                                  clst_size_lb=clst_size_lb,
+                                                  clst_cat_capture_lbs=clst_cat_capture_lbs,
+                                                  clst_cat_capture_ubs=clst_cat_capture_ubs)
+            # Store on each node their contribution to the clade and annot-entropy.
+            new_tree.root.get_ent_contribs(total_n=new_tree.root.ds_n_annots,
+                                           total_annot_counts=new_tree.root.ds_annot_counts, num_annots=n_labels)
+            # Store on each node how clade- and joint-entropy would change when edge to this node was cut
+            new_tree.get_ent_changes()
+            # Add for all downstream nodes to which tree it belongs
+            ds_node.add_info_to_nodes(info_key='belongs_to_tree', const_val=new_tree)
+
+            if very_verbose:
+                mp_print("\nMerging two clusters with {} and {} labeled-cells. "
+                         "Norm. mut. info. now: {}".format(new_tree.root.ds_n_annots - ds_node.ds_n_annots,
+                                                           ds_node.ds_n_annots,
+                                                           max_new_mut_info),
+                         DEBUG=True)
+                mp_print("Cluster 1, annot_counts: {}".format(','.join(map(str,
+                                                                           new_tree.root.ds_annot_counts - ds_node.ds_annot_counts))),
+                         DEBUG=True)
+                mp_print("Cluster 2, annot_counts: {}".format(','.join(map(str, ds_node.ds_annot_counts))),
+                         DEBUG=True)
+        else:
+            us_node = max_node.parentNode
+            cut_edges.append((ds_node.nodeId, us_node.nodeId))
+
+            # Update current entropies
+            clade_entropy += max_node.clade_ent_change
+            joint_entropy += max_node.annot_ent_change
+
+            # Make one new tree:
+            # max_tree = tree_ensmbl[max_tree_ind]
+            new_tree = Cluster_Tree()
+
+            # Remove ds node from original tree
+            us_node.childNodes = [child for child in us_node.childNodes if child.vert_ind != ds_node.vert_ind]
+
+            # Make ds-node the root of the new tree
+            new_tree.root = ds_node
+            ds_node.parentNode = None
+            ds_node.old_parent_node = us_node
+
+            # Update vert_ind_to_node
+            # TODO: Check at some point whether this can be done efficient by re-using information
+            max_tree.vert_ind_to_node, max_tree.nNodes = max_tree.root.renumber_verts(vertIndToNode={}, vert_count=0)
+            new_tree.vert_ind_to_node, new_tree.nNodes = new_tree.root.renumber_verts(vertIndToNode={}, vert_count=0)
+            # Initialize the necessary information on the nodes of the full tree
+            # We don't have to do: new_tree.root.get_ds_annot_info(), because new_tree still has correct ds-info
+            # For cluster_tree, we just subtract the ds_info for everything upstream of new root
+            us_node.subtract_or_add_ds_info_us(ds_node, add=False)
+
+            if prohibit_small_clsts:
+                max_tree.root.set_include_as_cand(total_n_annots=max_tree.root.ds_n_annots,
+                                                  total_annot_counts=max_tree.root.ds_annot_counts,
+                                                  clst_size_lb=clst_size_lb,
+                                                  clst_cat_capture_lbs=clst_cat_capture_lbs,
+                                                  clst_cat_capture_ubs=clst_cat_capture_ubs)
+                new_tree.root.set_include_as_cand(total_n_annots=new_tree.root.ds_n_annots,
+                                                  total_annot_counts=new_tree.root.ds_annot_counts,
+                                                  clst_size_lb=clst_size_lb,
+                                                  clst_cat_capture_lbs=clst_cat_capture_lbs,
+                                                  clst_cat_capture_ubs=clst_cat_capture_ubs)
+
+            # Store on each node their contribution to the clade and annot-entropy.
+            # Ideally, this is done only for us-ent-contribs for nodes downstream of change, and for ds-ent-contribs for
+            # nodes upstream of change. But it's a bit of work for little gain (only a factor 2, I think)
+            max_tree.root.get_ent_contribs(total_n=max_tree.root.ds_n_annots,
+                                           total_annot_counts=max_tree.root.ds_annot_counts, num_annots=n_labels)
+            new_tree.root.get_ent_contribs(total_n=new_tree.root.ds_n_annots,
+                                           total_annot_counts=new_tree.root.ds_annot_counts, num_annots=n_labels)
+
+            # Store on each node how clade- and joint-entropy would change when edge to this node was cut
+            max_tree.get_ent_changes()
+            new_tree.get_ent_changes()
+
+            new_tree.root.add_info_to_nodes(info_key='belongs_to_tree', const_val=new_tree)
+
+            # Add tree to ensemble, and make space for the new tree in the lists
+            tree_ensmbl.append(new_tree)
+
+            if very_verbose:
+                mp_print("\nCreating two clusters with {} and {} labeled-cells. "
+                         "Norm. mut. info. now: {}".format(max_tree.root.ds_n_annots, new_tree.root.ds_n_annots,
+                                                           max_new_mut_info),
+                         DEBUG=True)
+                mp_print("Cluster 1, annot_counts: {}".format(','.join(map(str, max_tree.root.ds_annot_counts))),
+                         DEBUG=True)
+                mp_print("Cluster 2, annot_counts: {}".format(','.join(map(str, new_tree.root.ds_annot_counts))),
+                         DEBUG=True)
+
+        if tracking_path is not None:
+            if not random_sampling:
+                greedy = optimality_decrease = None
+            stats.append({
+                "n_moves": n_moves,
+                "norm_mut_info": max_new_mut_info,
+                "n_clusters": len(tree_ensmbl),
+                "random_sampling": random_sampling,
+                "greedy": greedy,
+                "optimality_decrease": optimality_decrease
+            })
+
+        # TODO: Write independent norm. mut. info. check and eventually comment that out.
+        DO_TEST = False
+        if DO_TEST:
+            contingency = np.zeros((n_labels, len(tree_ensmbl)), dtype=int)
+            for ind_tree, tree in enumerate(tree_ensmbl):
+                contingency[:, ind_tree] = tree.root.ds_annot_counts
+
+            labels_true = []
+            labels_pred = []
+            for i, row in enumerate(contingency):
+                for j, count in enumerate(row):
+                    labels_true.extend([i] * count)
+                    labels_pred.extend([j] * count)
+            from sklearn.metrics import adjusted_mutual_info_score, normalized_mutual_info_score, rand_score, \
+                adjusted_rand_score
+
+            nmi_test = normalized_mutual_info_score(np.array(labels_true), np.array(labels_pred),
+                                                    average_method='geometric')
+            adjusted_mut_info = adjusted_mutual_info_score(np.array(labels_true), np.array(labels_pred),
+                                                           average_method='geometric')
+            rand_index = rand_score(np.array(labels_true), np.array(labels_pred))
+            adjusted_rand_index = adjusted_rand_score(np.array(labels_true), np.array(labels_pred))
+            print(nmi_test, max_new_mut_info)
+            if abs(max_new_mut_info - nmi_test) > 1e-9:
+                mp_print("Predicted mutual information deviates from independently calculated mut.info."
+                         "Check this!", ERROR=True)
+                exit()
+
+            if tracking_path is not None:
+                stats[-1].update({"adjusted_mut_info": adjusted_mut_info,
+                                  "rand_index": rand_index,
+                                  "adjusted_rand_index": adjusted_rand_index})
+
+        # if DO_TEST:
+        #     joint_entropy_test = 0.0
+        #     clade_sizes_test = []
+        #     joint_counts = []
+        #     annot_counts_test = np.zeros(n_labels)
+        #     for ind_tree, tree in enumerate(tree_ensmbl):
+        #         clade_sizes_test.append(tree.root.ds_n_annots)
+        #         joint_entropy_test += entropy_non_norm(tree.root.ds_annot_counts / n_cells)
+        #         joint_counts.append(tree.root.ds_annot_counts)
+        #         annot_counts_test += tree.root.ds_annot_counts
+        #
+        #     joint_counts = np.hstack(joint_counts)
+        #     # joint_entropy_test2 = entropy_non_norm(joint_counts / n_cells)
+        #     clade_entropy_test = entropy_non_norm(np.array(clade_sizes_test) / n_cells)
+        #     annot_entropy_test = entropy_non_norm(annot_counts_test / n_cells)
+        #
+        #     norm_mut_inf_test = (clade_entropy_test + annot_entropy_test - joint_entropy_test) / np.sqrt(
+        #         clade_entropy_test * annot_entropy_test)
+        #     # print("label_counts is equal to annot_counts_test: {}".format(annot_counts_test == label_counts))
+        #     # print("n_cells is equal to sum(clade_sizes_test): {}".format(n_cells == np.sum(clade_sizes_test)))
+        #
+        #     mp_print("Predicted mutual information is {}, and independent test gives {}".format(max_new_mut_info,
+        #                                                                                         norm_mut_inf_test))
+        #     if abs(max_new_mut_info - norm_mut_inf_test) > 1e-9:
+        #         mp_print("Predicted mutual information deviates from independently calculated mut.info."
+        #                  "Check this!", ERROR=True)
+        #         exit()
+
+    mp_print("Final annotation-based clustering did {} moves, "
+             "created {} clusters, "
+             "with a Normalized Mutual Information of {}.".format(n_moves + 1, n_trees, orig_mut_info))
+
+    clusters = get_clustering_lists(tree_ensmbl, node_ids_to_clst_set)
+
+    if tracking_path is not None:
+        df = pd.DataFrame(stats)
+        df.to_csv(tracking_path, index=False, sep='\t')
+
+    # Store current clustering in dictionary of clusterings
+    if verbose:
+        mp_print("Clustering done")
+    return clusters, cut_edges, orig_mut_info
+
+
+def get_clustering_lists(tree_ensmbl, node_ids_to_clst_set):
+    # Should produce a list of lists with the node-IDs of the various clusters
+    clusters = [None] * len(tree_ensmbl)
+    for ind_tree, tree in enumerate(tree_ensmbl):
+        if clusters[ind_tree] is not None:
+            continue
+        leaf_ids_tree = []
+        for vert_ind, node in tree.vert_ind_to_node.items():
+            if node_ids_to_clst_set is None:
+                if node.isLeaf:
+                    leaf_ids_tree.append(node.nodeId)
+            else:
+                if node.nodeId in node_ids_to_clst_set:
+                    leaf_ids_tree.append(node.nodeId)
+        clusters[ind_tree] = leaf_ids_tree
+    return clusters
+
+
+def get_min_pdists_clustering(cluster_tree, n_clusters, cell_ids=None, get_cell_ids_all_splits=False, verbose=True,
+                              footfall=False):
+    # if get_cell_ids_all_splits:
+    #     cell_ids_splits = {}
+    if cell_ids is not None:
+        cell_ids_set = set(cell_ids)
+    if cluster_tree.vert_ind_to_node is None:
+        cluster_tree.vert_ind_to_node, cluster_tree.nNodes = cluster_tree.root.renumber_verts(vertIndToNode={},
+                                                                                              vert_count=0)
+
+    all_clusterings = {}
+    tree_ensmbl = [cluster_tree]
+    # Make sure each node knows how many ds leafs it has
+    cluster_tree.n_leafs = cluster_tree.get_min_pdists_info()
+    max_scores = [None]
+    max_nodes = [None]
+    clusters = [None]
+    footfall_edges = []
+
+    # Can't cut more branches between cells than there are cell-associated nodes
+    n_clusters = min(n_clusters, cluster_tree.n_cell_nodes)
+
+    print_i = 2
+    while len(tree_ensmbl) < n_clusters:
+        n_trees = len(tree_ensmbl)
+        if verbose and (n_trees == print_i):
+            mp_print(
+                "Clustering has created {} subtrees, {} branches still to cut.".format(n_trees, n_clusters - n_trees))
+            print_i *= 2
+        # Loop over all edges to find max footfall one
+        for ind_tree, tree in enumerate(tree_ensmbl):
+            if max_scores[ind_tree] is not None:
+                continue
+            if tree.n_cell_nodes == 1:
+                max_scores[ind_tree] = 0.0
+                continue
+            max_footfall_node = None
+            max_footfall_score = -1e9
+            for vert_ind, node in tree.vert_ind_to_node.items():
+                if node.parentNode is not None:
+                    footfall_score = node.ds_leafs * (tree.n_leafs - node.ds_leafs) * node.tParent
+                    if not footfall:
+                        footfall_score += node.ds_dists * (tree.n_leafs - node.ds_leafs)
+                        footfall_score += node.us_dists * node.ds_leafs
+                    if footfall_score > max_footfall_score:
+                        max_footfall_node = node
+                        max_footfall_score = footfall_score
+            max_scores[ind_tree] = max_footfall_score
+            max_nodes[ind_tree] = max_footfall_node
+
+        # Determine which tree has the maximum score
+        max_tree_ind = np.argmax(max_scores)
+        if max_scores[max_tree_ind] < 1e-9:
+            # This should never happen
+            print("Cannot find more than {} clusters. Cannot find edge that reduces the pairwise distances.")
+            break
+
+        max_node = max_nodes[max_tree_ind]
+
+        # Cut the tree into two pieces at the max footfall edge
+        ds_node = max_node
+        us_node = max_node.parentNode
+        footfall_edges.append((ds_node.nodeId, us_node.nodeId))
+
+        # Make one new tree:
+        max_tree = tree_ensmbl[max_tree_ind]
+        new_tree = Cluster_Tree()
+
+        # Remove ds node from original tree
+        us_node.childNodes = [child for child in us_node.childNodes if child.vert_ind != ds_node.vert_ind]
+
+        # Make ds-node the root of the new tree
+        new_tree.root = ds_node
+        ds_node.parentNode = None
+
+        # Update vert_ind_to_node
+        # TODO: Check at some point whether this can be done efficient by re-using information
+        max_tree.vert_ind_to_node, max_tree.nNodes = max_tree.root.renumber_verts(vertIndToNode={}, vert_count=0)
+        new_tree.vert_ind_to_node, new_tree.nNodes = new_tree.root.renumber_verts(vertIndToNode={}, vert_count=0)
+        max_tree.n_leafs = max_tree.get_min_pdists_info()
+        new_tree.n_leafs = new_tree.get_min_pdists_info()
+
+        # Add tree to ensemble, and make space for the new tree in the lists
+        tree_ensmbl.append(new_tree)
+        max_scores[max_tree_ind] = None  # This will make sure the score is recalculated
+        max_nodes[max_tree_ind] = None
+        clusters[max_tree_ind] = None
+        max_scores.append(None)  # This will give a place for the new tree to store
+        max_nodes.append(None)
+        clusters.append(None)
+
+        # Should produce a list of lists with the node-IDs of the various clusters
+        for ind_tree, tree in enumerate(tree_ensmbl):
+            if clusters[ind_tree] is not None:
+                continue
+            leaf_ids_tree = []
+            for vert_ind, node in tree.vert_ind_to_node.items():
+                if cell_ids is None:
+                    if node.isLeaf:
+                        leaf_ids_tree.append(node.nodeId)
+                else:
+                    if node.nodeId in cell_ids_set:
+                        leaf_ids_tree.append(node.nodeId)
+            clusters[ind_tree] = leaf_ids_tree
+        # Store current clustering in dictionary of clusterings
+        clustering_name = 'annot_bnsi_cluster_n{}'.format(len(tree_ensmbl))
+        all_clusterings[clustering_name] = clusters.copy()
+
+    if verbose:
+        print("Clustering done")
+    return all_clusterings, footfall_edges
+
+
+def get_max_diam_clustering(cluster_tree, max_diam_threshold, cell_ids=None):
+    # print("\nInit tree")
+    # cluster_tree = Cluster_Tree()
+    # cluster_tree.from_newick_file(nwk_file=tree_nwk_file)  # Works
+
+    # get post traversal order
+    vert_ind_in_postOrder_v3 = cluster_tree.root.getPostOrder_only_internalNodes()
+
+    print("Do clustering with maxdiam: {}".format(max_diam_threshold))
+    clusters = []
+    # traverse tree in post_order_traversal
+    for vert_ind in vert_ind_in_postOrder_v3:
+        # print("traversing node: {}".format(vert_ind))
+        node = cluster_tree.vert_ind_to_node[vert_ind]
+
+        # if for some reason the node has already been visited...
+        if node.is_deleted:
+            # print("node {} is deleted".format(node.vert_ind))
+            continue
+
+        # Check constraint
+        # For that calculate first all pairwise max distances to leaf through parent (node)
+        # print("number of children: {}".format(len(node.childNodes)))
+        # print("find all combinations of children")
+
+        comb = combinations(range(len(node.childNodes)), 2)
+        max_pairwise_distances = {}
+        # print("calc max pairwise distances of children")
+        for i1, i2 in list(comb):  # store in dict (i1,i2) : dist
+            u1 = node.childNodes[i1]
+            u2 = node.childNodes[i2]
+            if not u1.is_deleted and not u2.is_deleted:
+                # TODO : store only if  node is not deleted: done
+                dist = u1.len_to_most_distant_leaf + u1.tParent + u2.len_to_most_distant_leaf + u2.tParent
+                max_pairwise_distances[(i1, i2)] = dist
+        # print("sort max pairwise distances of children")
+        # sort distances:
+        pair_wise_comb = list(max_pairwise_distances.keys())
+        distances = np.array(list(max_pairwise_distances.values()))
+        distances_sortidx = np.argsort(-distances)  # largest will be at first position
+
+        # check if all max pairwise distances fullfill the constraint
+        # for that I can check if the largest max pairwise distance fullfills the constraint
+        # print("len(pair_wise_comb): {}".format(len(pair_wise_comb)))
+        # print("start while loop")
+        while len(pair_wise_comb) > 0:
+            # print("len(pair_wise_comb): {}".format(len(pair_wise_comb)))
+            # print("check if contraint is met for the largest distances between two leafs")
+            if distances[distances_sortidx][0] < max_diam_threshold:
+                # print("contraint is met, we can continue")
+                longest_distances_to_leafs_from_node = [x.len_to_most_distant_leaf + x.tParent for x in node.childNodes
+                                                        if not x.is_deleted]
+                node.len_to_most_distant_leaf = np.max(longest_distances_to_leafs_from_node)
+                break
+            else:
+                # print("contraint is NOT met, we have to cut the longest branch")
+                # cut longest branch
+
+                i1, i2 = np.array(pair_wise_comb)[distances_sortidx][0]
+                u1 = node.childNodes[i1]
+                u2 = node.childNodes[i2]
+                # cut longest branch and get cluster
+                if u1.len_to_most_distant_leaf + u1.tParent >= u2.len_to_most_distant_leaf + u2.tParent:
+                    # print("longest branch corresponds to child: {}".format(i1))
+                    cluster = cluster_tree.cut(subtree_root=u1, cell_ids=cell_ids)
+                    # todo set u1 to deleted
+                    deleted_node_idx = i1
+                    clusters.append(cluster)
+                    node.len_to_most_distant_leaf = u2.len_to_most_distant_leaf + u2.tParent
+                else:
+                    # print("longest branch corresponds to child: {}".format(i2))
+                    cluster = cluster_tree.cut(subtree_root=u2, cell_ids=cell_ids)
+                    deleted_node_idx = i2
+                    clusters.append(cluster)
+                    node.len_to_most_distant_leaf = u1.len_to_most_distant_leaf + u1.tParent
+
+                # print("Now remove all that corresponds to that longest branch and redo while loop")
+                # then delete the node and subtree of the longest branch, and check again for the distances
+
+                valid_pairs = [True if x[0] != deleted_node_idx and x[1] != deleted_node_idx else False for x in
+                               pair_wise_comb]
+
+                pair_wise_comb = [b for a, b in zip(valid_pairs, pair_wise_comb) if a]
+                distances = distances[valid_pairs]
+                distances_sortidx = np.argsort(
+                    -distances)  # i think i have to sort new TODO check if this is right, make more efficient
+
+    # at the end get the rest of the cluster
+    cluster = cluster_tree.cut(subtree_root=node, cell_ids=cell_ids)
+    clusters.append(cluster)
+    print("Clustering done")
+    return clusters
+
+
+if __name__ == "__main__":
+
+    parser = ArgumentParser(
+        description='Starts from a reconstructed tree output by Bonsai and creates a data-object necessary for further '
+                    'visualization and usage in the Bonsai-Shiny app.')
+
+    parser.add_argument('--dataset', type=str, default='test_sarah',
+                        help='Name of dataset. This will determine name of results-folder where information is stored.')
+    # Arguments that define where to find the data and where to store results. Also, whether data comes from Sanity or not
+    # parser.add_argument('--results_folder', type=str, default="/Users/sarahmorillo/bz_mnt/software/waddington-code-github/python_waddington_code/downstream_analyses/test_res",
+    #                     help='path to folder where results will be stored.')
+    parser.add_argument('--tree_folder', type=str,
+                        # default='/Users/sarahmorillo/bz_mnt/software/waddington-code-github/python_waddington_code/downstream_analyses/test_data/tamara_ecoli_isolates/mergers_zscore1.0_ellipsoidsize1.0_smallerrorbars_redoStarry_optTimes_nnnReorder_reorderedEdges',
+                        default='/Users/sarahmorillo/bz_mnt/software/waddington-code-github/downstream_analyses/test/test_data/',
+                        help='Path to folder that determines tree topology. Should contain edgeInfo and vertInfo and tree.nwk')
+    parser.add_argument('--output_file', type=str,
+                        default="/Users/sarahmorillo/bz_mnt/software/waddington-code-github/downstream_analyses/test/test_res/test_binary_tree_8_leafs",
+                        help="output file name")
+    parser.add_argument('--t', type=float, default=5, dest='max_diam_threshold', help="max diam threshold")
+    # Arguments that determine running configurations of MLTree. How much is printed, which steps are run?
+    # parser.add_argument('--verbose', type=str2bool, default=True,
+    #                     help='--verbose False only shows essential print messages (default: True)')
+
+    args = parser.parse_args()
+    print(args)
+
+    """Test max footfall and min pdists clustering on some test case"""
+    nwk_file = '/Users/Daan/Documents/postdoc/bonsai-development/results/simulated_datasets/simulated_binary_6_gens_samplingnoise_seed_1231/final_bonsai_zscore1.0/tree.nwk'
+    with open(nwk_file, "r") as f:
+        nwk_str = f.readline()
+    clusters_list, cut_edges_main = get_footfall_clustering_from_nwk_str(tree_nwk_str=nwk_str,
+                                                                         n_clusters=8)
+    clusters_list_min_pd, cut_edges_min_pd = get_min_pdists_clustering_from_nwk_str(tree_nwk_str=nwk_str,
+                                                                                    n_clusters=8)
+
+    """In the following lines the tree is read in from the output generated by Bonsai"""
+
+    clusters_md = get_max_diam_clustering_from_nwk_file(
+        tree_nwk_file=os.path.join(args.tree_folder, 'test_binary_tree_8_leafs.nwk'),
+        max_diam_threshold=args.max_diam_threshold)
+
+    cl_dict = get_cluster_assignments(clusters_list=clusters_md)
+
+    # print output:
+    print("number of clusters found: {}".format(len(clusters_md)))
+    # write to file:
+    with open(args.output_file + "-max_diam_{}.cluster".format(args.max_diam_threshold), "w") as fout:
+        cluster_idx = 0
+        for cluster in clusters_md:
+            # if singleton, assign -1
+            if len(cluster) == 1:
+                fout.write("{}\t{}\n".format(cluster[0], -1))
+            else:
+                for leaf in cluster:
+                    fout.write("{}\t{}\n".format(leaf, cluster_idx))
+
+                cluster_idx += 1
+
+    print("done")
+
+    # try out to get longest path from root to a leaf
+    cluster_tree_md = Cluster_Tree()
+    cluster_tree_md.from_newick_file(
+        nwk_file=os.path.join(args.tree_folder, 'test_binary_tree_8_leafs-longest_path_to_leaf_11.5.nwk'))  # Works
+    longest_path_from_root_to_leaf, _ = cluster_tree_md.root.find_longest_path_between_two_leafs()

--- a/omicverse/external/bonsai/scout/__init__.py
+++ b/omicverse/external/bonsai/scout/__init__.py
@@ -1,0 +1,22 @@
+"""Vendored Bonsai-scout tree layout (upstream v1.0.0), CC BY-NC 4.0.
+
+Only ``my_tree_layout`` is carried, not the Dash application around it. The file
+is self-contained upstream (stdlib + numpy/pandas, no Bonsai imports);
+:func:`omicverse.external.bonsai.scout_layout` builds its ``Layout_Tree``
+straight from an edge list, so no ``SCData`` object is needed.
+
+Two upstream defects are fixed here. Both need a tree whose subtrees differ in
+depth, which is why upstream's own balanced-binary example never trips them and
+a 400-cell PBMC tree trips both:
+
+* ``equalDaylightAll`` reverts to ``old_tree`` when a step overshoots into
+  negative daylight, but only assigns it after a *successful* step -- so a run
+  that overshoots on step zero raised ``UnboundLocalError``. It is now seeded
+  with the incoming equal-angle tree, which is what reverting means there.
+* ``get_ed_angles`` computes ``child.opt_angle`` only on the branch that has
+  shade to balance; the other branch left it ``None`` and the loop below it did
+  ``opt_angle - angle`` -> ``TypeError``. With no shade to balance there is
+  nothing to correct, so the optimal angle is set to the current one.
+
+Both edits carry an ``omicverse:`` comment at the site. Nothing else is touched.
+"""

--- a/omicverse/external/bonsai/scout/my_tree_layout.py
+++ b/omicverse/external/bonsai/scout/my_tree_layout.py
@@ -1,0 +1,1054 @@
+import os
+import csv
+import numpy as np
+import time
+import pandas as pd
+import itertools
+from numpy import ndarray
+from random import shuffle
+
+import logging
+FORMAT = '%(asctime)s %(funcName)s %(levelname)s %(message)s'
+log_level = logging.WARNING
+log_level = logging.DEBUG
+logging.basicConfig(format=FORMAT,
+                    datefmt='%m-%d %H:%M:%S',
+                    level=logging.WARNING)   # silence all libraries
+
+# Create your app logger
+logger = logging.getLogger("myapp")
+logger.setLevel(log_level)
+
+class Layout_Tree:
+    # This is just a slim version of the scdata_tree, to make getting the equal-angle layout independent of bonsai and
+    # make it as fast and lean as possible.
+    root = None
+    nNodes = None
+    vert_ind_to_node_df = None
+    vert_ind_to_node = None
+
+    # Layout information
+    coords = None
+    nodeIds = None
+
+    def __init__(self):
+        self.root = Layout_TreeNode(vert_ind=-1, isRoot=True, opt_angle=360)
+        self.nNodes = 1
+
+    def copy(self, minimal_copy=False):
+        new_tree = Layout_Tree()
+        if not minimal_copy:
+            new_tree.coords = self.coords.copy()
+        new_tree.nNodes = self.nNodes
+        new_tree.root = self.root.copy(minimal_copy=minimal_copy)
+        for child in new_tree.root.childNodes:
+            child.parentNode = new_tree.root
+        return new_tree
+
+    def from_newick(self, nwk_str, node_id_to_vert_ind=None):
+        # nodes = []
+        # Here we will keep a dictionary from level down the tree, to lists of nodes that don't have an assigned parent
+        level_to_nodes = {0: []}
+        level = 0
+        curr_str = ''
+        nodeIdY_tParentF = True
+        curr_node = None
+        new_node = False
+        self.nNodes = 0
+        for char in nwk_str:
+            if char == '(':
+                # We go down the tree one level
+                level += 1
+                level_to_nodes[level] = []
+                # It also means we start a new node
+                new_node = True
+            elif char == ')':
+                # We go back up to the parent level
+                level -= 1
+                # It also means we start a new node
+                new_node = True
+            elif char == ':':
+                # This indicates a time is coming
+                curr_node.nodeId = curr_str
+                if (node_id_to_vert_ind is not None) and (curr_node.nodeId in node_id_to_vert_ind):
+                    curr_node.vert_ind = node_id_to_vert_ind[curr_node.nodeId]
+                nodeIdY_tParentF = False
+                curr_str = ''
+            elif char == ',':
+                # This indicates the time is complete, new child coming
+                new_node = True
+            elif char == ';':
+                curr_node.isRoot = True
+                new_node = True
+            else:
+                if curr_node is None:
+                    curr_node = Layout_TreeNode(isLeaf=True)
+                    self.nNodes += 1
+                    curr_node.level = level
+                    level_to_nodes[level].append(curr_node)
+                    nodeIdY_tParentF = True
+                curr_str += char
+                new_node = False
+
+            if new_node:
+                if curr_node is not None:
+                    if nodeIdY_tParentF:
+                        curr_node.nodeId = curr_str
+                        if (node_id_to_vert_ind is not None) and (curr_node.nodeId in node_id_to_vert_ind):
+                            curr_node.vert_ind = node_id_to_vert_ind[curr_node.nodeId]
+                    else:
+                        curr_node.tParent = float(curr_str)
+                    curr_str = ''
+                    # level_to_nodes[level].append(curr_node)
+                    # Get all children and add them to this node
+                    if (curr_node.level + 1) in level_to_nodes:
+                        curr_node.childNodes = level_to_nodes[curr_node.level + 1]
+                        if len(level_to_nodes[curr_node.level + 1]) > 0:
+                            curr_node.isLeaf = False
+                            level_to_nodes[curr_node.level + 1] = []
+                    else:
+                        curr_node.childNodes = []
+                curr_node = None
+        self.root = level_to_nodes[0][0]
+
+    def set_coords_at_node(self):
+        node_list = self.get_vert_ind_to_node_DF()
+        for vert_ind, node in node_list.items():
+            node.coords = self.coords[vert_ind, :]
+
+    def get_angles_from_coords(self):
+        self.root.storeParent()
+        self.root.angle = 360
+        vert_ind_to_node = self.get_vert_ind_to_node_DF()
+        node_list_wo_leafs = [node for vert_ind, node in vert_ind_to_node.items() if not node.isLeaf]
+        for node in node_list_wo_leafs:
+            # Get neighbouring coords
+            coords = np.zeros((len(node.childNodes), 2)) if node.isRoot else np.zeros((len(node.childNodes) + 1, 2))
+            for ind, child in enumerate(node.childNodes):
+                coords[ind, :] = child.coords
+            if not node.isRoot:
+                coords[-1, :] = node.parentNode.coords
+            # Use these coords to get angles as viewed from node
+            rel_coords = coords - node.coords
+            degs = np.degrees(np.arctan2(rel_coords[:, 1], rel_coords[:, 0])) % 360
+            if node.isRoot:
+                degs = np.append(degs, 180)
+            # The angle that is stored in the treenode-object is this angle relative to the angle to the parent:
+            angles = (degs[:-1] - degs[-1]) % 360
+
+            # # Given these angles (theta), determine what part of the circle (s) is covered by each child. For this we
+            # # solve the equations: s1/2 + s2/2 = theta2 - theta1
+            # coeff_s = np.eye(len(degs)) / 2
+            # for ind in range(len(degs) - 1):
+            #     coeff_s[ind, ind + 1] = .5
+            # coeff_s[-1, :] = 1
+            #
+            # angle_diffs = np.zeros(len(degs))
+            # angle_diffs[:-1] = np.diff(degs) % 360
+            # angle_diffs[-1] = 360
+            # logger.debug(node.nodeId)
+            # shades = np.linalg.solve(coeff_s, angle_diffs)
+            for ind, child in enumerate(node.childNodes):
+                child.angle = angles[ind]
+
+    def equalAngle(self, get_nodelist=True, verbose=False):
+        coords = np.zeros((self.nNodes, 2))
+        _, _, _ = self.root.getDsLeafs(self.nNodes, verbose=verbose, get_nodelist=get_nodelist)
+        if verbose:
+            logger.debug("Obtained all downstream information.")
+        self.root.coords = np.array([0., 0.])
+        self.root.thetaParent = 180
+
+        coords[self.root.vert_ind, :] = self.root.coords
+        self.root.set_eq_angles(my_shade=360, use_weights=False)
+        self.coords = self.root.positionChildren(coords, verbose=verbose)
+
+    def get_dendrogram(self, verbose=False, xlims=(-.95, .95), ylims=(-.95, .95), ladderized=False, flipped_node_ids=[]):
+        # get list of leafs, set y-coords
+        if not ladderized:
+            vert_ind_to_node = self.get_vert_ind_to_node_DF(update=True)
+        else:
+            if self.root.dsLeafs is None:
+                self.root.getDsLeafs(get_nodelist=False)
+            vert_ind_to_node = self.root.get_vert_ind_to_node_ladderized(vert_ind_to_node={}, flipped_node_ids=flipped_node_ids)
+        leafs = [node for vert_ind, node in vert_ind_to_node.items() if node.isLeaf]
+        n_leafs = len(leafs)
+        leaf_y_coords = np.linspace(ylims[0], ylims[1], n_leafs)
+        coords = np.zeros((self.nNodes, 2))
+        for leaf_ind, leaf in enumerate(leafs):
+            coords[leaf.vert_ind, 1] = leaf_y_coords[leaf_ind]
+        coords[self.root.vert_ind, 0] = 0
+        self.coords, _ = self.root.set_dendrogram_coords(coords, verbose=verbose)
+        self.coords[:, 0] = self.coords[:, 0] / (np.max(self.coords[:, 0]) / (xlims[1] - xlims[0])) + xlims[0]
+
+    def reset_root(self, new_root_ind):
+        vert_ind_to_node = self.get_vert_ind_to_node_DF()
+        if list(vert_ind_to_node.values())[1].parentNode is None:
+            self.root.storeParent()
+        self.root = vert_ind_to_node[new_root_ind]
+        # self.root.isRoot = True
+        # self.root.tParent = None
+        self.root.reset_root_node(parent_ind=None, old_tParent=self.root.tParent)
+
+    def get_edge_dict(self, nodeIdToVertInd=None):
+        if nodeIdToVertInd is None:
+            edge_dict = {'source': [], 'target': [], 'dist': []}
+        else:
+            edge_dict = {'source': [], 'source_ind': [], 'target': [], 'target_ind': [], 'dist': []}
+        edge_dict = self.root.get_edge_dict_node(edge_dict, nodeIdToVertInd=nodeIdToVertInd)
+        return edge_dict
+
+    # def equalDaylight(self, ind, allowNegDaylight=False, verbose=False):
+    #     nodeList = self.getNodeListBF()
+    #     counter = 0
+    #     for nodeId, node in nodeList.items():
+    #         if (ind > 0) and (counter > 0):
+    #             return
+    #         if verbose and (counter % 1000 == 0):
+    #             logger.debug("Setting equal-daylight angle for vertex %d" % counter)
+    #         if not node.isLeaf:
+    #             node.setequalDaylightAngles(self.coords, allowNegDaylight=allowNegDaylight)
+    #             self.coords = node.positionChildren(self.coords, set_eq_angle=False)
+    #         counter += 1
+
+    def equalDaylightAll(self, verbose=False, print_dev=False, max_stepsize_changes=20, max_steps=100):
+        nodeList = self.getNodeListBFVertInd()
+        if print_dev:
+            int_inds = np.array([vert_ind for vert_ind, node in nodeList.items() if not node.isLeaf])
+            dev = np.zeros(self.nNodes)
+        max_dev = 360
+        step_counter = 0
+        # First get for all nodes the current angles and equal-daylight angles
+        stepsize = 0.10
+        stepsize_changed = 0
+        daylight_left = True
+        new_angles = np.zeros(self.nNodes)
+        new_angles[self.root.vert_ind] = 360
+        reuse_calc = False
+        # omicverse: old_tree is only assigned after a successful step, so a run
+        # whose very first daylight pass already overshoots into negative daylight
+        # hits UnboundLocalError below. Seeding it with the incoming (equal-angle)
+        # tree is what the revert means on step zero.
+        old_tree = self.copy()
+        while daylight_left and (step_counter < max_steps) and (max_dev > 10) and (
+                stepsize_changed < max_stepsize_changes) and (stepsize > 1e-3):
+            max_dev = 0
+            node_counter = 0
+            for vert_ind, node in nodeList.items():
+                if verbose and (node_counter % 1000 == 0):
+                    logger.debug("Calculating equal-daylight angle for vertex %d" % node_counter)
+                if not node.isLeaf:
+                    # In the following function new angles are calculated (but not yet implemented) for the whole tree
+                    # These new angles are based on the current position of the nodes
+                    new_angles, dl_left, dev_curr = node.get_ed_angles(self.coords, new_angles, stepsize=stepsize,
+                                                                       get_dev=True, reuse_calc=reuse_calc,
+                                                                       set_angles=False, break_at_branch_overlap=True)
+                    max_dev = dev_curr if dev_curr > max_dev else max_dev
+                    if print_dev:
+                        dev[vert_ind] = dev_curr
+                    # We check after each node whether we already have negative daylight, in which case we revert to
+                    # last tree for which each node had daylight
+                    if dl_left < 0:
+                        daylight_left = False
+                        break
+                node_counter += 1
+            if daylight_left:
+                if print_dev:
+                    dev_int = dev[int_inds]
+                    max_dev = np.max(dev_int)
+                    # If daylight left, previous change can be processed. Current new_angles are tested in next round
+                    logger.debug("Testing new angles equal daylight step {:d}. Stepsize {:.5f}, "
+                          "total deviation {:.5f}, max deviation {:.5f}, "
+                          "min deviation {:.5f}.".format(step_counter, stepsize, np.sum(dev_int),
+                                                         max_dev, np.min(dev_int)))
+                else:
+                    logger.debug("Performed step {:d} of equal daylight. Still daylight left on all nodes.\n"
+                          "Maximum deviation from equal-daylight across nodes is {:.2f}".format(step_counter, max_dev))
+            # If min daylight < 0, go to last stored tree
+            if not daylight_left:
+                reuse_calc = True
+                self = old_tree
+                daylight_left = True
+                stepsize_changed += 1
+                stepsize /= 2
+                nodeList = self.getNodeListBFVertInd()
+                logger.debug("Last equal-daylight step was too large. Trying again with stepsize {}.".format(stepsize))
+            else:
+                step_counter += 1
+                reuse_calc = False
+                # Copy current tree before making changes, so that we can go back if too much daylight was removed
+                old_tree = self.copy()
+                for vert_ind, node in nodeList.items():
+                    node.angle = new_angles[vert_ind]
+                self.coords = self.root.positionChildren(self.coords, verbose=verbose)
+
+        # Perform a last test if there is daylight on this tree
+        for vert_ind, node in nodeList.items():
+            if not node.isLeaf:
+                # In the following function new angles are calculated (but not yet implemented) for the whole tree
+                # These new angles are based on the current position of the nodes
+                new_angles, dl_left, dev_curr = node.get_ed_angles(self.coords, new_angles, stepsize=stepsize,
+                                                                   get_dev=True, reuse_calc=reuse_calc,
+                                                                   set_angles=False, break_at_branch_overlap=True)
+                # We check after each node whether we already have negative daylight, in which case we revert to
+                # last tree for which each node had daylight
+                if dl_left < 0:
+                    daylight_left = False
+                    break
+
+        # If min daylight < 0, go to last stored tree
+        if not daylight_left:
+            self = old_tree
+            logger.debug("Last equal-daylight step was too large. Trying again with stepsize {}.".format(stepsize))
+
+        return self
+
+    def equalDaylightSome(self, vert_inds=None, stepsize=1):
+        if vert_inds is None:
+            vert_inds = []
+        vert_ind_to_node = self.get_vert_ind_to_node_DF()
+        new_angles = np.zeros(self.nNodes)
+        for vert_ind in vert_inds:
+            node = vert_ind_to_node[vert_ind]
+            node.get_ed_angles(self.coords, new_angles, stepsize=stepsize,
+                               get_dev=False, reuse_calc=False,
+                               set_angles=True)
+            self.coords = node.positionChildren(self.coords)
+
+    def increaseEqualAngle(self, vert_inds, multip_angle, origin):
+        ancestor_ind = vert_inds[-2]
+        ancestor = self.get_vert_ind_to_node_DF()[ancestor_ind]
+        orig_coords_anc_rel_origin = ancestor.coords - origin
+        ds_ind = vert_inds[-1]
+        # Get indices of nodes in chosen subtree. Should be dsNodes that contains ds_ind
+        to_be_changed = None
+        for child in ancestor.childNodes:
+            if ds_ind in child.dsNodes:
+                to_be_changed = child.dsNodes
+                break
+        if to_be_changed is None:
+            to_be_changed = ancestor.usNodes
+
+        for vert_ind in to_be_changed:
+            node = self.get_vert_ind_to_node_DF()[vert_ind]
+            if node.isLeaf:
+                node.dsLeafs_weighted *= multip_angle
+        self.root.getDsLeafs(self.nNodes, verbose=False, get_nodelist=False)
+        self.root.set_eq_angles(my_shade=360, use_weights=True)
+        self.coords = self.root.positionChildren(self.coords)
+
+        # Pick new origin such that ancestor node remains at same spot
+        new_origin = ancestor.coords - orig_coords_anc_rel_origin
+        return new_origin
+
+    def resetEqualAngle(self):
+        for vert_ind, node in self.get_vert_ind_to_node_DF().items():
+            if node.isLeaf:
+                node.dsLeafs_weighted = 1
+        self.root.set_eq_angles(my_shade=360, use_weights=True)
+        self.coords = self.root.positionChildren(self.coords)
+
+    def getNodeListBF(self):
+        nodeList = {self.root.nodeId: self.root}
+        queue = [self.root]
+        while len(queue):
+            node = queue.pop(0)
+            for child in node.childNodes:
+                nodeList[child.nodeId] = child
+                queue.append(child)
+        return nodeList
+
+    def getNodeListBFVertInd(self):
+        nodeList = {self.root.vert_ind: self.root}
+        queue = [self.root]
+        while len(queue):
+            node = queue.pop(0)
+            for child in node.childNodes:
+                nodeList[child.vert_ind] = child
+                queue.append(child)
+        return nodeList
+
+    def get_vert_ind_to_node_DF(self, update=False):
+        if (self.vert_ind_to_node_df is None) or update:
+            vert_ind_to_node = {}
+            self.vert_ind_to_node_df = self.root.get_vert_ind_to_node_node(vert_ind_to_node)
+        return self.vert_ind_to_node_df
+
+
+class Layout_TreeNode:
+    vert_ind = None  # identifier index for the node
+    nodeId = None
+    tParent = None  # diffusion time to parent along tree
+    childNodes = None  # list with pointers to child TreeNode objects
+    parentNode = None
+    isLeaf = None
+    isRoot = None
+    dsLeafs = None
+    dsLeafs_weighted = None
+    dsNodes = None
+    usNodes = None
+    level = None
+
+    # Coordinate information
+    coords = None
+    angle = None
+    opt_angle = None
+    thetaParent = None
+
+    def __init__(self, vert_ind=None, childNodes=None, parentNode=None, isLeaf=False, isRoot=False, tParent=None,
+                 nodeId=None, opt_angle=None):
+        self.vert_ind = vert_ind
+        self.childNodes = [] if (childNodes is None) else childNodes
+        self.nodeId = nodeId
+        self.tParent = tParent
+        self.parentNode = parentNode
+        self.isLeaf = isLeaf  # isLeaf
+        self.isRoot = isRoot
+        self.opt_angle = opt_angle
+
+    def copy(self, minimal_copy=False):
+        new_node = Layout_TreeNode(vert_ind=self.vert_ind, nodeId=self.nodeId, tParent=self.tParent, isLeaf=self.isLeaf,
+                                   isRoot=self.isRoot)
+        if not minimal_copy:
+            new_node.dsLeafs = self.dsLeafs
+            new_node.dsLeafs_weighted = self.dsLeafs_weighted
+            new_node.dsNodes = self.dsNodes.copy()
+            new_node.usNodes = self.usNodes.copy()
+
+            # Coordinate information
+            new_node.coords = self.coords.copy()
+            new_node.angle = self.angle
+            new_node.opt_angle = self.opt_angle
+            new_node.thetaParent = self.thetaParent
+            new_node.vert_ind = self.vert_ind
+
+        new_node.childNodes = [child.copy() for child in self.childNodes]
+        for child in new_node.childNodes:
+            child.parentNode = new_node
+        return new_node
+
+    def renumber_verts(self, vertIndToNode, vert_count):
+        self.vert_ind = vert_count
+        vertIndToNode[self.vert_ind] = self
+        vert_count += 1
+        for child in self.childNodes:
+            vertIndToNode, vert_count = child.renumber_verts(vertIndToNode, vert_count)
+        return vertIndToNode, vert_count
+
+    def get_vert_ind_to_node_node(self, vert_ind_to_node):
+        vert_ind_to_node[self.vert_ind] = self
+        for child in self.childNodes:
+            vert_ind_to_node = child.get_vert_ind_to_node_node(vert_ind_to_node)
+        return vert_ind_to_node
+
+    def get_vert_ind_to_node_ladderized(self, vert_ind_to_node, flipped_node_ids=[]):
+        vert_ind_to_node[self.vert_ind] = self
+        ds_leafs_ch = np.zeros(len(self.childNodes), dtype=int)
+        for ind, child in enumerate(self.childNodes):
+            ds_leafs_ch[ind] = child.dsLeafs
+        if self.nodeId in flipped_node_ids:
+            count = flipped_node_ids.count(self.nodeId)
+            sorted_ch_inds_ladder = np.argsort(ds_leafs_ch)
+
+            if len(sorted_ch_inds_ladder) <= 4:
+                diff_orderings = list(itertools.permutations(sorted_ch_inds_ladder))
+                sorted_ch_inds_ladder = list(diff_orderings[count % len(diff_orderings)])
+            else:
+                if count != 0:
+                    shuffle(sorted_ch_inds_ladder)
+            logger.info("The {} branches downstream of {} flipped {} times.".format(len(sorted_ch_inds_ladder),
+                                                                                     self.nodeId, count))
+        else:
+            sorted_ch_inds_ladder = np.argsort(ds_leafs_ch)
+        for ind in sorted_ch_inds_ladder:
+            vert_ind_to_node = self.childNodes[ind].get_vert_ind_to_node_ladderized(vert_ind_to_node, flipped_node_ids=flipped_node_ids)
+        return vert_ind_to_node
+
+    def storeParent(self):
+        for child in self.childNodes:
+            child.parentNode = self
+            if not child.isLeaf:
+                child.storeParent()
+
+    def is_vert_downstream(self, vert_ind):
+        if self.vert_ind == vert_ind:
+            return True
+        for child in self.childNodes:
+            if child.is_vert_downstream(vert_ind):
+                return True
+        # If we reach this point, apparently the vert_ind was not downstream
+        return False
+
+    def reset_root_node(self, parent_ind=None, old_tParent=None):
+        # Get all connecting nodes
+        new_children = []
+        new_parent = None
+        old_tParents = []
+        for node in self.childNodes:
+            if node.vert_ind == parent_ind:
+                new_parent = node
+            else:
+                new_children.append(node)
+                old_tParents.append(node.tParent)
+        if self.parentNode is not None:
+            if self.parentNode.vert_ind == parent_ind:
+                new_parent = self.parentNode
+            else:
+                old_tParents.append(self.parentNode.tParent)
+                self.parentNode.tParent = old_tParent
+                new_children.append(self.parentNode)
+        if new_parent is not None:
+            self.parentNode = new_parent
+        else:
+            self.parentNode = None
+            self.tParent = None
+            self.isRoot = True
+        if len(new_children) == 0:
+            self.isLeaf = True
+            self.childNodes = new_children
+        else:
+            self.isLeaf = False
+            self.childNodes = new_children
+        for ind, child in enumerate(self.childNodes):
+            child.reset_root_node(parent_ind=self.vert_ind, old_tParent=old_tParents[ind])
+
+    def get_edge_dict_node(self, edge_dict, nodeIdToVertInd=None):
+        for child in self.childNodes:
+            if nodeIdToVertInd is None:
+                edge_dict['source'].append(self.nodeId)
+                edge_dict['target'].append(child.nodeId)
+                edge_dict['dist'].append(child.tParent)
+                # new_row = {'source': self.nodeId, 'target': child.nodeId, 'dist': child.tParent}
+            else:
+                edge_dict['source'].append(self.nodeId)
+                edge_dict['target'].append(child.nodeId)
+                edge_dict['source_ind'].append(nodeIdToVertInd[self.nodeId])
+                edge_dict['target_ind'].append(nodeIdToVertInd[child.nodeId])
+                edge_dict['dist'].append(child.tParent)
+                # new_row = {'source': self.nodeId, 'source_ind': nodeIdToVertInd[self.nodeId], 'target': child.nodeId,
+                #            'target_ind': nodeIdToVertInd[child.nodeId], 'dist': child.tParent}
+            # edge_df = edge_df.append(new_row, ignore_index=True)
+            if not child.isLeaf:
+                edge_dict = child.get_edge_dict_node(edge_dict, nodeIdToVertInd=nodeIdToVertInd)
+        return edge_dict
+
+    def setequalDaylightAngles(self, allCoords, allowNegDaylight=False):
+        # Calculate angles from this node with all other coordinates
+        relCoords = allCoords - self.coords
+        degs = np.degrees(np.arctan2(relCoords[:, 1], relCoords[:, 0])) % 360
+        # Find the ranks of the size of the angle from all nodes to the current one
+        argSortDegs = np.argsort(degs)
+        ranks = np.empty_like(argSortDegs)
+        ranks[argSortDegs] = np.arange(len(degs))
+        # degsMinus = np.degrees(np.arctan2(-relCoords[:,1], -relCoords[:,0])) % 360
+        # Loop over all children and make list of all ds-nodes grouped by child
+        connectingNodes = [child.dsNodes for child in self.childNodes]
+        if not self.isRoot:
+            connectingNodes += [self.usNodes]
+        # nShades = len(self.childNodes) if self.isRoot else (len(self.childNodes) + 1)
+        nShades = len(connectingNodes)
+        shades = np.zeros(nShades)
+        findingDaylight = True
+        while findingDaylight:
+            for ind, dsNodes in enumerate(connectingNodes):
+                childDegs = degs[dsNodes]
+                childRanks = ranks[dsNodes]
+                # Given the ranks of the nodes on this child, find where the biggest gap is. That's where you find the
+                # max and min angle
+                argSortRanks = np.argsort(childRanks)
+                sortedRanks = childRanks[argSortRanks]
+                # Get the jumps in ranks. A large jump indicates that in-between there are other branches
+                # The additional - 1 is to compensate for the node itself always having rank 0
+                rankJumps = np.append(np.diff(sortedRanks), sortedRanks[0] - sortedRanks[-1] - 1) % len(degs)
+                maxJump = np.argmax(rankJumps)
+                maxAngleInd, minAngleInd = argSortRanks[maxJump], argSortRanks[(maxJump + 1) % len(argSortRanks)]
+                shades[ind] = (childDegs[maxAngleInd] - childDegs[minAngleInd]) % 360
+            daylight = (360 - np.sum(shades)) / nShades
+            if True:  # (daylight > 0) or allowNegDaylight:
+                findingDaylight = False
+            else:
+                self.adjustShades(np.sum(shades))
+                exit("Found negative daylight! Work on this!")
+        angles = shades + daylight
+        for ind, child in enumerate(self.childNodes):
+            child.angle = angles[ind]
+        # if not self.isRoot:
+        #     self.angle = 360 - angles[-1]
+
+    def get_ed_angles(self, allCoords, new_angles, stepsize=0.1, get_dev=False, reuse_calc=False, set_angles=False,
+                      break_at_branch_overlap=False):
+        if not reuse_calc:
+            # Calculate angles from this node with all other coordinates
+            relCoords = allCoords - self.coords
+            degs = np.degrees(np.arctan2(relCoords[:, 1], relCoords[:, 0])) % 360
+            # # Get only the degrees of nodes other than the current node itself
+            # degs = degs[np.setdiff1d(np.arange(len(degs)), self.vert_ind)]
+            # Find the ranks of the size of the angle from all nodes to the current one
+            argSortDegs = np.argsort(degs)
+            ranks = np.empty_like(argSortDegs)
+            ranks[argSortDegs] = np.arange(len(degs))
+            if ranks[self.vert_ind]:
+                # In this case, some (or several) other node also has a degree of zero and they were ordered first. Fix
+                # this by giving the node itself rank 0, and increasing the ranks that are below its current rank by 1
+                ranks[ranks < ranks[self.vert_ind]] += 1
+                ranks[self.vert_ind] = 0
+            # Loop over all children and make list of all ds-nodes grouped by child
+            connectingNodes = [child.dsNodes for child in self.childNodes]
+            if not self.isRoot:
+                connectingNodes += [self.usNodes]
+            nShades = len(connectingNodes)
+            shades = np.zeros(nShades)
+            min_max_angle = np.zeros((nShades, 2))
+            for ind, dsNodes in enumerate(connectingNodes):
+                childDegs = degs[dsNodes]
+                childRanks = ranks[dsNodes]
+                # Given the ranks of the nodes on this child, find where the biggest gap is. That's where you find the
+                # max and min angle
+                argSortRanks = np.argsort(childRanks)
+                sortedRanks = childRanks[argSortRanks]
+                # Get the jumps in ranks. A large jump indicates that in-between there are other branches
+                # The additional - 1 is to compensate for the node itself always having rank 0
+                rankJumps = np.append(np.diff(sortedRanks), sortedRanks[0] - sortedRanks[-1] - 1) % len(degs)
+                maxJump = np.argmax(rankJumps)
+                if break_at_branch_overlap and (len(rankJumps) > 1):
+                    if np.partition(rankJumps, -2)[-2] > 1:
+                        if get_dev:
+                            return np.zeros(shape=new_angles.shape), -360, 360
+                        return np.zeros(shape=new_angles.shape), -360
+                maxAngleInd, minAngleInd = argSortRanks[maxJump], argSortRanks[(maxJump + 1) % len(argSortRanks)]
+                min_max_angle_curr = (childDegs[minAngleInd], childDegs[maxAngleInd])
+                min_max_angle[ind, :] = min_max_angle_curr
+                shades[ind] = (min_max_angle_curr[1] - min_max_angle_curr[0]) % 360
+            daylight = (360 - np.sum(shades)) / nShades
+            if daylight < 0:
+                if get_dev:
+                    return np.zeros(shape=new_angles.shape), daylight, 360
+                return np.zeros(shape=new_angles.shape), daylight
+            # Each child gets an equal portion of the remaining daylight, so we add half of that to their extreme angles
+            min_max_angle[:, 1] += daylight / 2
+            min_max_angle[:, 0] -= daylight / 2
+            # Also, angles are measured with respect to the angle to the parent
+            min_max_angle = (min_max_angle - self.thetaParent) % 360
+            # Now we can compare that to the current angle of the child-edge to get the shade to the left and right of
+            # that edge
+            curr_angles = [child.angle for child in self.childNodes]
+            if not self.isRoot:
+                curr_angles.append(0)
+            curr_angles = np.array(curr_angles)
+            shade_left = (min_max_angle[:, 1] - curr_angles) % 360
+            shade_right = (curr_angles - min_max_angle[:, 0]) % 360
+            # By definition the angle for the parent edge from the parent edge is zero
+            theta_prev = 0 if (not self.isRoot) else curr_angles[-1]
+            shade_left_prev = shade_left[-1]
+            for ind, child in enumerate(self.childNodes):
+                child.opt_angle = (theta_prev + shade_left_prev + shade_right[ind]) % 360
+                theta_prev = child.opt_angle
+                shade_left_prev = shade_left[ind]
+        else:
+            daylight = 360
+            # omicverse: this branch leaves opt_angle unset, and the loop below
+            # subtracts it -> TypeError on None. With no shade to balance there
+            # is nothing to correct, so the optimal angle is the current one.
+            for child in self.childNodes:
+                if child.opt_angle is None:
+                    child.opt_angle = child.angle
+        if get_dev:
+            total_dev = 0
+        for ind, child in enumerate(self.childNodes):
+            dev = child.opt_angle - child.angle
+            new_angles[child.vert_ind] = child.angle + stepsize * dev
+            if set_angles:
+                child.angle += stepsize * dev
+            if get_dev:
+                total_dev += np.abs(dev)
+        if get_dev:
+            return new_angles, daylight, total_dev
+        return new_angles, daylight
+        # if not self.isRoot:
+        #     self.angle = 360 - angles[-1]
+
+    def rearrange_branches_node(self, flipped_node_ids=[], ladderize_all=False, nNodes=None):
+        if self.dsLeafs is None:
+            self.getDsLeafs(nNodes=nNodes, get_nodelist=False, verbose=False)
+
+        if self.isLeaf:
+            return
+
+        if (self.nodeId in flipped_node_ids) or ladderize_all:
+            # First get ladderized order
+            ds_leafs_ch = np.zeros(len(self.childNodes), dtype=int)
+            for ind, child in enumerate(self.childNodes):
+                ds_leafs_ch[ind] = child.dsLeafs
+            sorted_ch_inds_ladder = np.argsort(ds_leafs_ch)
+
+            # Then pick the n-th permutation given by how many times self.node_ids is in the flipped_node_ids
+            count = flipped_node_ids.count(self.nodeId)
+            if len(sorted_ch_inds_ladder) <= 4:
+                diff_orderings = list(itertools.permutations(sorted_ch_inds_ladder))
+                sorted_ch_inds_ladder = list(diff_orderings[count % len(diff_orderings)])
+            else:
+                if count != 0:
+                    shuffle(sorted_ch_inds_ladder)
+            if not ladderize_all:
+                logger.info("The {} branches downstream of {} flipped {} times.".format(len(sorted_ch_inds_ladder),
+                                                                                         self.nodeId, count))
+
+            # Then arrange the children in that order
+            self.childNodes = [self.childNodes[ind] for ind in sorted_ch_inds_ladder]
+
+        # Move on to do children
+        for child in self.childNodes:
+            child.rearrange_branches_node(flipped_node_ids=flipped_node_ids, ladderize_all=ladderize_all)
+
+    def getDsLeafs(self, nNodes=None, get_nodelist=True, verbose=False):
+        if verbose and (self.vert_ind % 100000 == 0) and (self.vert_ind != 0):
+            logger.debug("Getting downstream information at vertex number {c:d}.".format(c=self.vert_ind))
+        dsNodes = [self.vert_ind] if get_nodelist else None
+        if self.isLeaf:
+            self.dsLeafs = 1
+            if self.dsLeafs_weighted is None:
+                self.dsLeafs_weighted = 1
+        else:
+            self.dsLeafs = 0
+            self.dsLeafs_weighted = 0
+            for child in self.childNodes:
+                dsLeafsCh, dsLeafsChWeighted, dsNodesChild = child.getDsLeafs(nNodes=nNodes,
+                                                                              verbose=verbose,
+                                                                              get_nodelist=get_nodelist)
+                self.dsLeafs += dsLeafsCh
+                self.dsLeafs_weighted += dsLeafsChWeighted
+                if get_nodelist:
+                    dsNodes += dsNodesChild
+        if get_nodelist:
+            self.dsNodes = np.array(dsNodes)
+            self.usNodes = np.setdiff1d(range(nNodes), np.array(dsNodes + [self.vert_ind]))
+        return self.dsLeafs, self.dsLeafs_weighted, dsNodes
+
+    def get_dsNodes(self):
+        if self.dsNodes is not None:
+            return list(self.dsNodes)
+        dsNodes = [self.vert_ind]
+        for child in self.childNodes:
+            dsNodesCh = child.get_dsNodes()
+            dsNodes += dsNodesCh
+        self.dsNodes = np.array(dsNodes)
+        return dsNodes
+
+    # def getAnglesDs(self):
+    #     for child in self.childNodes:
+    #         test
+
+    def set_eq_angles(self, my_shade, use_weights=False, verbose=False):
+        shades = np.zeros(len(self.childNodes))
+        for ind, child in enumerate(self.childNodes):
+            if not use_weights:
+                shades[ind] = my_shade * child.dsLeafs / self.dsLeafs
+            else:
+                shades[ind] = my_shade * child.dsLeafs_weighted / self.dsLeafs_weighted
+            if verbose and (child.vert_ind % 100000 == 0):
+                logger.debug("Calculating equal-angles for vertex number %d." % child.vert_ind)
+        shades_sum = np.sum(shades)
+        shade_parent = 360 - shades_sum
+        theta_prev = 0
+        shade_prev = shade_parent
+        for ind, child in enumerate(self.childNodes):
+            shade_curr = shades[ind]
+            child.set_eq_angles(shade_curr, use_weights=use_weights, verbose=verbose)
+            child.angle = (theta_prev + (shade_prev + shade_curr) / 2) % 360
+            theta_prev = child.angle
+            shade_prev = shade_curr
+
+    def positionChildren(self, all_coords, verbose=False):
+        theta_parent = self.thetaParent
+        for child in self.childNodes:
+            theta_child = (theta_parent + child.angle) % 360
+            theta_child_rad = np.radians(theta_child)
+            child.coords = self.coords + child.tParent * np.array([np.cos(theta_child_rad), np.sin(theta_child_rad)])
+            all_coords[child.vert_ind, :] = child.coords
+            child.thetaParent = (theta_child + 180) % 360
+            all_coords = child.positionChildren(all_coords, verbose=verbose)
+        return all_coords
+
+    def set_thetaParent(self):
+        theta_parent = self.thetaParent
+        for child in self.childNodes:
+            theta_child = (theta_parent + child.angle) % 360
+            child.thetaParent = (theta_child + 180) % 360
+            child.set_thetaParent()
+
+    def set_dendrogram_coords(self, coords, verbose=False):
+        if self.isLeaf:
+            return coords, coords[self.vert_ind, 1]
+        ch_ycoords = np.zeros(len(self.childNodes))
+        my_coords = coords[self.vert_ind, :]
+        for ind, child in enumerate(self.childNodes):
+            coords[child.vert_ind, 0] = my_coords[0] + child.tParent
+            coords, ch_ycoords[ind] = child.set_dendrogram_coords(coords, verbose=verbose)
+        mean_ch_y = np.mean(ch_ycoords)
+        coords[self.vert_ind, 1] = mean_ch_y
+        return coords, mean_ch_y
+
+
+def reconstructTreeFromEdgeVertInfo(mergerFolder):
+    # Read reconstructed tree information
+    edgeList = []
+    distList = []
+    edgeFile = os.path.join(mergerFolder, 'edgeInfo.txt')
+    with open(edgeFile, "r") as file:
+        reader = csv.reader(file, delimiter="\t")
+        for row in reader:
+            edgeList.append((int(row[0]), int(row[1])))
+            distList.append(float(row[2]))
+
+    vertIndToNodeInd = {}
+    vertIndToNodeId = {}
+    vertFile = os.path.join(mergerFolder, 'vertInfo.txt')
+    with open(vertFile, "r") as file:
+        reader = csv.reader(file, delimiter="\t")
+        skipRow = True
+        for row in reader:
+            if skipRow:
+                skipRow = False
+                continue
+            vertIndToNodeInd[int(row[0])] = int(row[1])
+            vertIndToNodeId[int(row[0])] = row[2]
+
+    tree = Layout_Tree()
+    vertIndToNode = {}
+    for ind, edge in enumerate(edgeList):
+        if ind == 0:
+            tree.root = Layout_TreeNode(vert_ind=vertIndToNodeInd[edge[0]], childNodes=[], isLeaf=False, isRoot=True,
+                                        tParent=None, nodeId=vertIndToNodeId[edge[0]])
+            vertIndToNode[edge[0]] = tree.root
+            childNode = Layout_TreeNode(vert_ind=vertIndToNodeInd[edge[1]], childNodes=[], isLeaf=True, isRoot=False,
+                                        tParent=distList[ind], nodeId=vertIndToNodeId[edge[1]])
+            tree.root.childNodes.append(childNode)
+            vertIndToNode[edge[1]] = childNode
+            tree.nNodes = 2
+            continue
+        if edge[0] in vertIndToNode:
+            parentVert = edge[0]
+            childVert = edge[1]
+        else:
+            parentVert = edge[1]
+            childVert = edge[0]
+        childNode = Layout_TreeNode(vert_ind=vertIndToNodeInd[childVert], childNodes=[], isLeaf=True, isRoot=False,
+                                    tParent=distList[ind], nodeId=vertIndToNodeId[childVert])
+        parentNode = vertIndToNode[parentVert]
+        parentNode.childNodes.append(childNode)
+        parentNode.isLeaf = False
+        vertIndToNode[childVert] = childNode
+        tree.nNodes += 1
+
+    logger.debug("\n\nReconstructed tree loaded from: \n%s \n%s" % (edgeFile, vertFile))
+
+    return vertIndToNode, vertIndToNodeInd, edgeList, distList, tree
+
+
+def getLayout(scdata_tree, eq_daylight=True, dendrogram=True, verbose=True, all_coords_dict=None,
+              eq_dl_max_stepsize_changes=20, eq_dl_max_steps=100, flipped_node_ids=[]):
+    if verbose:
+        logger.debug("Starting reconstruction of tree.")
+    ly_tree = get_ly_tree_from_scdata_tree(scdata_tree)
+    if verbose:
+        logger.debug("Starting equal angle algorithm.")
+    start = time.time()
+    ly_tree.equalAngle(verbose=verbose, get_nodelist=eq_daylight)
+    if all_coords_dict is not None:
+        all_coords_dict['ly_eq_angle'] = ly_tree.coords.copy()
+    if verbose:
+        logger.debug("Equal-angle algorithm took %f seconds." % (time.time() - start))
+    if eq_daylight:
+        ly_tree = ly_tree.equalDaylightAll(verbose=verbose, max_stepsize_changes=eq_dl_max_stepsize_changes,
+                                 max_steps=eq_dl_max_steps)
+        if all_coords_dict is not None:
+            all_coords_dict['ly_eq_daylight'] = ly_tree.coords.copy()
+    # if dendrogram:
+    #     ly_tree.get_dendrogram(verbose=verbose)
+    # if all_coords_dict is not None:
+    #     all_coords_dict['ly_dendrogram'] = ly_tree.coords.copy()
+    if dendrogram:
+        ly_tree.get_dendrogram(ladderized=True, flipped_node_ids=flipped_node_ids)
+        if all_coords_dict:
+            all_coords_dict['ly_dendrogram_ladderized'] = ly_tree.coords.copy()
+
+    # for ind in range(n_equal_daylight):
+    #     start = time.time()
+    #     ly_tree.equalDaylight(ind, allowNegDaylight=False, verbose=verbose)
+    #     if verbose:
+    #         logger.debug("Loop %d of equal-daylight took %f seconds." % (ind, time.time() - start))
+    # with open(result_path, 'w') as f:
+    #     f.write("label,x,y\n")
+    #     for ind, vert_ind in enumerate(ly_tree.nodeIds):
+    #         labelXY = "%s,%f,%f" % (ly_tree.nodeIds[vert_ind], ly_tree.coords[ind, 0], ly_tree.coords[ind, 1])
+    #         f.write("%s\n" % labelXY)
+    return ly_tree, all_coords_dict
+
+
+if __name__ == '__main__':
+    resultsFolder = '/Users/Daan/Documents/postdoc/waddington-code-github/python_waddington_code/results'
+    dataset = 'bonsai_simbin_6gens_groundtruth_addedNoise_fracInformative0.02'
+    mergerfile = 'mergers_zscore1.0_ellipsoidsize2.0_redoStarry_optTimes_nnnReorder_reorderedEdges'
+    mergerFolder = os.path.join(resultsFolder, dataset, mergerfile)
+    vertIndToNode, vertIndToNodeInd, edgeList, distList, tree = reconstructTreeFromEdgeVertInfo(mergerFolder)
+
+    coords = tree.equalAngle()
+
+
+def get_ly_tree_from_scdata_tree(scdata_tree):
+    ly_tree = Layout_Tree()
+    ly_tree.root = Layout_TreeNode(vert_ind=scdata_tree.root.vert_ind, childNodes=[], parentNode=None,
+                                   isLeaf=scdata_tree.root.isLeaf, isRoot=True, tParent=None,
+                                   nodeId=scdata_tree.root.nodeId, opt_angle=360)
+    ly_tree.nNodes = scdata_tree.nNodes
+    copy_from_scdata_tree(ly_tree.root, scdata_tree.root)
+    # Ladderize all branches
+    ly_tree.root.rearrange_branches_node(flipped_node_ids=[], ladderize_all=True, nNodes=ly_tree.nNodes)
+    return ly_tree
+
+
+def copy_from_scdata_tree(ly_tree_node, scdata_tree_node):
+    for ind, child in enumerate(scdata_tree_node.childNodes):
+        ly_child = Layout_TreeNode(vert_ind=child.vert_ind, parentNode=ly_tree_node, isLeaf=child.isLeaf,
+                                   isRoot=child.isRoot, tParent=child.tParent, nodeId=child.nodeId)
+        ly_tree_node.childNodes.append(ly_child)
+        if not child.isLeaf:
+            copy_from_scdata_tree(ly_child, child)
+
+
+# TODO: Should go to tree layout file
+def my_tree_layout(scData, calc=False, filepath='layout.csv', daylight_subset=None, eq_daylight=True, verbose=False,
+                   return_all=False, eq_dl_max_stepsize_changes=20, eq_dl_max_steps=100):
+    """
+    This function assumes that a tree-object is already stored in self.
+    :param calc: Boolean indicating whether new layout is calculated.
+    :param filepath: Absolute path to file where layout coordinates will be stored
+    :param daylight_subset: subset of nodes on which to perform equal-daylight. Will be updated later
+    :param n_equal_daylight: Number of rounds of equal daylight, 1 is usually enough
+    :param verbose:
+    :return:
+    """
+    # Determine which nodes should be used for equal-daylight here. By default, use everything starting from root
+    # and doing a breadth-first passage.
+    # if only_branch_points:
+    #     if self.branchingInds is None:
+    #         self.find_branching_points()
+    all_coords_dict = {} if return_all else None
+    if calc:
+        start = time.time()
+        tree, all_coords_dict = getLayout(scData.tree, eq_daylight=eq_daylight,
+                                          dendrogram=True, verbose=verbose, all_coords_dict=all_coords_dict,
+                                          eq_dl_max_stepsize_changes=eq_dl_max_stepsize_changes,
+                                          eq_dl_max_steps=eq_dl_max_steps)
+        logger.debug("The layout algorithms took {:.2f} seconds.".format(time.time() - start))
+
+        # Store calculated layouts in file
+        coords = np.zeros((scData.nVerts, 2 * len(all_coords_dict)))
+        node_ids = [''] * scData.nVerts
+        for vert_ind, node in scData.tree.vert_ind_to_node.items():
+            node_ids[vert_ind] = node.nodeId
+        labels = []
+        for type_ind, ly_type in enumerate(all_coords_dict):
+            labels += [ly_type + '_x', ly_type + '_y']
+            coords[:, type_ind * 2: type_ind * 2 + 2] = all_coords_dict[ly_type]
+        coords_df = pd.DataFrame(columns=labels, index=node_ids, data=coords)
+        coords_df.to_csv(filepath)
+        if 'ly_dendrogram_ladderized' in all_coords_dict:
+            ly_type = 'ly_dendrogram_ladderized'
+        elif 'ly_eq_daylight' in all_coords_dict:
+            ly_type = 'ly_eq_daylight'
+        elif 'ly_eq_angle' in all_coords_dict:
+            ly_type = 'ly_eq_angle'
+        else:
+            ly_type = list(all_coords_dict.keys())[0]
+    # else:
+    #     coords_df = pd.read_csv(filepath, index_col=0)
+    #     # nodeIds = list(coords_df.index)
+    #     # node_id_to_vert_ind = {node.nodeId: vert_ind for vert_ind, node in self.tree.vert_ind_to_node.items()}
+    #     node_ids_ordered = [scData.tree.vert_ind_to_node[vert_ind].nodeId for vert_ind in range(self.nVerts)]
+    #     coords_df.reindex(labels=node_ids_ordered)
+    #     if 'ly_eq_daylight_x' in coords_df.columns:
+    #         ly_type = 'ly_eq_daylight'
+    #     elif 'ly_eq_angle_x' in coords_df.columns:
+    #         ly_type = 'ly_eq_angle'
+    #     else:
+    #         ly_type = coords_df.columns[0][:-2]
+    #     # vert_ind_order = [node_id_to_vert_ind[node_id] for node_id in nodeIds]
+    #     # coords_df.values = coords_df.values[]
+    #     # for ind, node_id in enumerate(nodeIds):
+    #     #     if verbose and (ind % 100000 == 0):
+    #     #         logger.debug("Loading %d-th coordinates." % ind)
+    #     #     coords[ind, :] = tree_coords[nodeIdsToTreeInd[nodeId], :]
+    #     # coords = np.array(list(coords))
+    #     n_types = int(len(coords_df.columns) / 2)
+    #     all_coords_dict = {}
+    #     for type_ind in range(n_types):
+    #         ly_type_curr = coords_df.columns[type_ind * 2][:-2]
+    #         all_coords_dict[ly_type_curr] = coords_df.values[:, type_ind * 2: type_ind * 2 + 2]
+    return all_coords_dict, ly_type
+    # mst_layout = igraph.Layout(coord_list)
+    # self.mstLayout = mst_layout
+
+# # TODO: Should go to tree layout file
+# def get_layout(scData, calc=False, filename='layout.csv', only_branch_points=False, myOwn=False,
+#                vertIndToNodeId=None, treeFolder=None, n_equal_daylight=1, verbose=False):
+#     # TODO: Clean this up
+#     # if only_branch_points:
+#     #     if self.branchingInds is None:
+#     #         self.find_branching_points()
+#     got_layout = False
+#     if calc:
+#         start = time.time()
+#         tree = getLayout(treeFolder, outputFolder=self.result_path(), layoutFilename=filename,
+#                          nEqualDaylight=n_equal_daylight, verbose=verbose)
+#         logger.debug("My equal-daylight algorithm took %f seconds." % (time.time() - start))
+#         got_layout = True
+#         # else:
+#         #     start = time.time()
+#         #     # Note that we have to add one to all vertices here, because R-indexing starts at 1
+#         #     edge_df_forR = self.mst.get_edge_dataframe()
+#         #     edge_df_forR[['source', 'target']] = edge_df_forR[['source', 'target']] + 1
+#         #     edge_df_forR.to_csv(self.result_path('edge_df.txt'), sep='\t', index=False)
+#         #     vert_df_forR = self.mst.get_vertex_dataframe()
+#         #     vert_df_forR.index += 1
+#         #     if only_branch_points:
+#         #         vert_df_forR['branch_point'] = [(ind in self.branchingInds) for ind in range(self.nVerts)]
+#         #     vert_df_forR.to_csv(self.result_path('vert_df.txt'), sep=',', index=False, header=True)
+#         #
+#         #     Rscript_path = os.path.join(os.getcwd(), "tree_visualisation", "tree_vis.R")
+#         #     command = ["Rscript", "--vanilla", Rscript_path, self.result_path(), filename, '0.05', '1']
+#         #     run_output = subprocess.run(command)
+#         #     run_output.check_returncode()
+#         #     logger.debug("Equal-daylight algorithm from ggtree took %f seconds." % (time.time() - start))
+#     if got_layout:
+#         coords = np.zeros((len(vertIndToNodeId), 2))
+#         nodeIdsToTreeInd = {nodeId: ind for ind, nodeId in tree.nodeIds.items()}
+#         for ind, vert in enumerate(vertIndToNodeId):
+#             if verbose and (ind % 100000 == 0):
+#                 logger.debug("Loading %d-th coordinates." % ind)
+#             nodeId = vertIndToNodeId[vert]
+#             coords[ind, :] = tree.coords[nodeIdsToTreeInd[nodeId], :]
+#         coord_list = list(coords)
+#     elif myOwn:
+#         imported_layout = pd.read_csv(self.result_path(filename))
+#         coords = np.zeros((len(vertIndToNodeId), 2))
+#         nodeIds = list(imported_layout['label'])
+#         nodeIdsToTreeInd = {nodeId: ind for ind, nodeId in enumerate(nodeIds)}
+#         tree_coords = imported_layout[['x', 'y']].values
+#         for ind, vert in enumerate(vertIndToNodeId):
+#             if verbose and (ind % 100000 == 0):
+#                 logger.debug("Loading %d-th coordinates." % ind)
+#             nodeId = vertIndToNodeId[vert]
+#             coords[ind, :] = tree_coords[nodeIdsToTreeInd[nodeId], :]
+#         coord_list = list(coords)
+#     else:
+#         imported_layout = pd.read_csv(self.result_path(filename))
+#         coord_list = []
+#         for vert in self.mst.vs:
+#             coords = list(imported_layout[imported_layout["label"] == vert["name"]][['x', 'y']].values.flatten())
+#             if len(coords) == 0:
+#                 logger.debug("No vertex in R-output found with name:" + vert['name'])
+#             coord_list.append(coords)
+#     self.coords = np.array(coord_list)
+#     # mst_layout = igraph.Layout(coord_list)
+#     # self.mstLayout = mst_layout

--- a/omicverse/pl/__init__.py
+++ b/omicverse/pl/__init__.py
@@ -195,6 +195,7 @@ from ._flowsig import (
     plot_flowsig_network,
 )
 from ._embedding import embedding_atlas
+from ._bonsai import bonsai
 from ._cnv import cnv_heatmap, cnv_summary, cnv_umap
 from ._metabolism import metabolism_heatmap
 from ._metacell import (
@@ -380,6 +381,7 @@ __all__ = [
     "trajectory_tree",
     "purple_color",
     "red_color",
+    "bonsai",
     "sc_color",
     "vibrant_palette",
     "palplot",

--- a/omicverse/pl/_bonsai.py
+++ b/omicverse/pl/_bonsai.py
@@ -1,0 +1,320 @@
+r"""``ov.pl.bonsai`` — draw the Bonsai tree computed by :func:`omicverse.tl.bonsai`.
+
+Bonsai returns a tree, not coordinates, so the layout is computed at draw time by
+:func:`omicverse.external.bonsai.equal_angle_layout`. Branch lengths survive the
+layout, which is the point: distance along the drawing is distance in the model,
+unlike a UMAP where the gap between two clusters carries no meaning.
+"""
+from __future__ import annotations
+
+from typing import Optional, Sequence, Union
+
+import numpy as np
+
+from .._registry import register_function
+
+__all__ = ["bonsai"]
+
+
+@register_function(
+    aliases=["bonsai plot", "Bonsai树图", "plot bonsai", "画Bonsai树"],
+    category="pl",
+    description="Draw the Bonsai tree from ov.tl.bonsai, colouring leaves by an "
+                "obs column.",
+    examples=["ov.pl.bonsai(adata, color='leiden')"],
+    related=["ov.tl.bonsai", "ov.pl.embedding"],
+    requires={"uns": ["bonsai"]},
+)
+def bonsai(
+    adata,
+    color: Optional[str] = None,
+    *,
+    key: str = "bonsai",
+    style: str = "scout",
+    layer: Optional[str] = None,
+    use_raw: Optional[bool] = None,
+    gene_symbols: Optional[str] = None,
+    ax=None,
+    figsize=(4.6, 4.6),
+    radius: Optional[float] = None,
+    edge_color: str = "#b4b4b4",
+    edge_width: float = 0.55,
+    edge_style: str = "--",
+    disk: bool = True,
+    spread: float = 0.8,
+    cache_layout: bool = True,
+    palette: Optional[Sequence[str]] = None,
+    cmap: Optional[str] = None,
+    color_map: Optional[str] = None,
+    na_color: str = "lightgray",
+    title: Optional[str] = None,
+    legend_loc: Optional[str] = "right margin",
+    legend_fontsize: Optional[float] = None,
+    legend_fontweight: str = "bold",
+    legend_fontoutline: Optional[float] = None,
+    colorbar_loc: Optional[str] = "right",
+    frameon: Union[bool, str] = "small",
+    show: Optional[bool] = None,
+    save: Union[bool, str, None] = None,
+):
+    r"""Draw the Bonsai tree stored in ``adata.uns[key]``.
+
+    Every cell is a leaf and every internal vertex an inferred ancestral state.
+    Branches are drawn at their inferred lengths, so a long branch means a cell
+    whose state really is far from its neighbours rather than one that a
+    projection happened to push aside.
+
+    Parameters
+    ----------
+    adata
+        Annotated data matrix carrying ``adata.uns[key]`` from
+        :func:`omicverse.tl.bonsai`.
+    color
+        What to colour the leaves by: a column of ``adata.obs`` **or a gene**,
+        resolved exactly as :func:`omicverse.pl.embedding` resolves it (obs, then
+        ``var_names``, then ``raw``). Categorical columns
+        take ``palette`` (default :data:`omicverse.pl.sc_color`), numeric columns
+        take ``cmap`` and get a colourbar. ``None`` draws the bare tree.
+    key
+        Key under ``adata.uns`` written by :func:`omicverse.tl.bonsai`.
+    layer, use_raw, gene_symbols
+        Where to read a gene from, as in :func:`omicverse.pl.embedding`.
+    ax
+        Existing axes to draw into; a new figure is created when omitted.
+    style
+        ``'scout'`` reproduces Bonsai-scout's own view: equal-angle then
+        equal-daylight layout, mapped into the Poincaré disk. ``'equal_angle'``
+        is the plain Euclidean fallback.
+    figsize, edge_color, edge_width, edge_style
+        Figure size, and the colour, width and dash of the branches.
+    radius
+        Leaf marker radius, **in data units** — not ``ov.pl.embedding``'s
+        ``size``, which is a marker area in points². The difference is
+        deliberate: drawing the cells at a fixed radius in the tree's own
+        coordinates is what makes a dense clade read as one blob and keeps it
+        that way when the figure is resized. Defaults to upstream's ``0.015``.
+    disk
+        Draw the bounding circle. Only meaningful for ``style='scout'``, where
+        the circle is the boundary of the Poincaré disk.
+    cache_layout
+        Keep the computed coordinates in ``adata.uns[key]['layout']`` and reuse
+        them when ``style`` and ``spread`` are unchanged, so plotting the same
+        tree by a different ``color`` is instant.
+    spread
+        How far the tree reaches towards the rim: the zoom is chosen so this
+        fraction of vertices sits inside that same radius. ``0.8`` is upstream's
+        framing; raise it to fill more of the disk, lower it to pull in.
+    palette
+        Colours for a categorical ``color``.
+    cmap, color_map
+        Colormap for a numeric ``color``; ``ov.pl.embedding`` accepts both names,
+        so both are taken here. Defaults to ``'RdBu_r'``.
+    na_color
+        Colour for a category with no palette entry.
+    title
+        Axes title; defaults to ``color``.
+    legend_loc, legend_fontsize, legend_fontweight, legend_fontoutline
+        As in :func:`omicverse.pl.embedding` — ``'right margin'`` (default),
+        ``'on data'``, or ``'none'``/``None``. Placement, the column rule and the
+        outline handling follow that function so the two look like one family.
+    colorbar_loc
+        Where the colourbar goes for a numeric ``color``; ``None`` omits it.
+    frameon
+        ``False`` strips the axes entirely; ``'small'`` matches the reduced frame
+        :func:`omicverse.pl.embedding` uses.
+    show
+        Call :func:`matplotlib.pyplot.show` and return ``None``. Defaults to
+        ``True`` only when ``ax`` was not supplied.
+    save
+        Path to write the figure to, or ``True`` for ``'bonsai.png'``.
+
+    Returns
+    -------
+    :class:`matplotlib.axes.Axes` or None
+        The axes, unless ``show`` resolved to ``True``.
+
+    Examples
+    --------
+    >>> import omicverse as ov
+    >>> ov.tl.bonsai(adata, use_rep='scaled|original|X_pca')
+    >>> ov.pl.bonsai(adata, color='leiden')
+
+    Draw it beside a UMAP to compare what each representation preserves:
+
+    >>> import matplotlib.pyplot as plt
+    >>> fig, axes = plt.subplots(1, 2, figsize=(9, 4))
+    >>> ov.pl.umap(adata, color='leiden', ax=axes[0], show=False)
+    >>> ov.pl.bonsai(adata, color='leiden', ax=axes[1], show=False)
+    """
+    import matplotlib.pyplot as plt
+    from matplotlib.collections import EllipseCollection, LineCollection
+
+    from ..external.bonsai import equal_angle_layout, scout_layout
+
+    if key not in adata.uns:
+        raise KeyError(
+            f"adata.uns['{key}'] not found — run ov.tl.bonsai(adata, ...) first."
+        )
+    res = adata.uns[key]
+
+    # adata.uns travels through slicing untouched, but leaf_of_obs is indexed by
+    # cell position -- so on a subset it silently refers to the wrong cells. The
+    # raw failure is an IndexError from a mismatched boolean mask, which says
+    # nothing about the cause.
+    n_map = len(np.asarray(res.get("leaf_of_obs", ())))
+    if n_map != adata.n_obs:
+        raise ValueError(
+            f"adata.uns['{key}'] was computed for {n_map} cells but this AnnData "
+            f"has {adata.n_obs}. The tree does not survive subsetting -- slice "
+            f"first, then run ov.tl.bonsai on the subset."
+        )
+
+    edges = np.asarray(res["edges"], dtype=int)
+    lengths = np.asarray(res["edge_lengths"], dtype=float)
+    n_vert = int(max(int(edges.max()), int(np.asarray(res["vert_ind"]).max()))) + 1
+
+    if style not in ("scout", "equal_angle"):
+        raise ValueError(f"style must be 'scout' or 'equal_angle', got {style!r}")
+
+    # Cache the layout on the AnnData. The daylight pass costs ~3 s at 1600
+    # vertices and ~31 s at 12800, so recomputing it for every `color` a user
+    # tries would dominate; a backbone-scale tree makes that unusable. The
+    # signature keys the cache to the parameters that change the coordinates.
+    sig = (style, float(spread), int(n_vert), int(len(edges)))
+    cached = res.get("layout") if isinstance(res, dict) else None
+    if cache_layout and cached is not None and tuple(cached.get("sig", ())) == sig:
+        pos = np.asarray(cached["pos"], dtype=float)
+    else:
+        if style == "scout":
+            pos = scout_layout(edges, lengths, n_vert,
+                               frac_within=spread, within_radius=spread)[0]
+        else:
+            pos = equal_angle_layout(edges, lengths, n_vert)[0]
+        if cache_layout and isinstance(res, dict):
+            res["layout"] = {"sig": sig, "pos": pos}
+
+    if ax is None:
+        fig, ax = plt.subplots(figsize=figsize)
+        show = True if show is None else show
+    else:
+        fig = ax.figure
+        show = False if show is None else show
+
+    # Upstream's own styling (bonsai_scout_helpers.py): a white disk bounded by a
+    # grey circle, dashed grey branches behind it, and cells drawn as circles of a
+    # fixed radius in DATA units -- that last part is what makes dense clades read
+    # as solid blobs instead of dissolving when the figure is resized.
+    span = float(np.abs(pos).max()) or 1.0
+    if disk and style == "scout":
+        ax.add_patch(plt.Circle((0, 0), 1.0, facecolor="white",
+                                edgecolor="#a9a9a9", linewidth=1.1, zorder=-3))
+        lim = 1.06
+    else:
+        lim = span * 1.06
+
+    ax.add_collection(LineCollection(
+        [[pos[a_], pos[b_]] for a_, b_ in edges],
+        colors=edge_color, linewidths=edge_width,
+        linestyles=edge_style, zorder=1))
+
+    leaf_of_obs = np.asarray(res["leaf_of_obs"], dtype=int)
+    keep = leaf_of_obs >= 0
+    pts = pos[leaf_of_obs[keep]]
+    radius = ((0.015 if style == "scout" else 0.015 * span)
+              if radius is None else radius)
+
+    def _blobs(xy, colors, **kw):
+        """Cells as data-unit circles, so their size means the same everywhere."""
+        coll = EllipseCollection(
+            widths=2 * radius, heights=2 * radius, angles=0, units="xy",
+            offsets=xy, offset_transform=ax.transData,
+            facecolors=colors, edgecolors="#16161e", linewidths=0.35,
+            zorder=5, **kw)
+        ax.add_collection(coll)
+        return coll
+
+    if color is None:
+        _blobs(pts, "#7d7d85")
+    else:
+        # ov.pl.embedding resolves `color` against obs, then var, then raw, and
+        # honours layer/use_raw/gene_symbols. Reusing its resolver is what makes
+        # `color='CST3'` work here exactly as it does there, instead of only
+        # accepting obs columns.
+        from ._scatterplot_backend import _get_color_source_vector
+
+        vals = _get_color_source_vector(
+            adata, color,
+            use_raw=(False if use_raw is None else use_raw),
+            gene_symbols=gene_symbols, layer=layer)
+        if vals is None:
+            raise KeyError(
+                f"color='{color}' is neither a column of adata.obs nor a gene "
+                "in adata.var_names")
+        vals = np.asarray(vals)[keep]
+        is_cat = hasattr(vals, "categories") or getattr(vals, "dtype", None) == object
+        if is_cat:
+            import pandas as pd
+            from matplotlib.lines import Line2D
+            cats = list(pd.Categorical(vals).categories)
+            if palette is None:
+                from ._palette import sc_color
+                palette = sc_color
+            cols = {c: palette[i % len(palette)] for i, c in enumerate(cats)}
+            _blobs(pts, [cols.get(v, na_color) for v in vals])
+            if legend_loc in (None, "none"):
+                pass
+            elif legend_loc == "right margin":
+                # Same placement and column rule as ov.pl.embedding, so the two
+                # read as one family. EllipseCollection carries no label, hence
+                # the empty proxy scatters.
+                box = ax.get_position()
+                ax.set_position([box.x0, box.y0, box.width * 0.91, box.height])
+                for c in cats:
+                    ax.scatter([], [], c=cols.get(c, na_color), label=c)
+                ax.legend(frameon=False, loc="center left", bbox_to_anchor=(1, 0.5),
+                          ncol=(1 if len(cats) <= 14 else 2 if len(cats) <= 30 else 3),
+                          fontsize=legend_fontsize)
+            elif legend_loc == "on data":
+                from matplotlib import patheffects
+                fx = ([patheffects.withStroke(linewidth=legend_fontoutline,
+                                              foreground="white")]
+                      if legend_fontoutline is not None else None)
+                for c in cats:
+                    m = np.asarray(vals == c)
+                    if m.any():
+                        # Median, not mean: one straggler on a long branch would
+                        # otherwise drag the label off its own clade.
+                        ax.text(np.median(pts[m, 0]), np.median(pts[m, 1]), str(c),
+                                weight=legend_fontweight, ha="center", va="center",
+                                fontsize=legend_fontsize, path_effects=fx)
+        else:
+            v = np.asarray(vals, dtype=float)
+            coll = _blobs(pts, None, array=v, cmap=(cmap or color_map or "RdBu_r"))
+            if colorbar_loc is not None:
+                fig.colorbar(coll, ax=ax, shrink=0.6, label=color,
+                             location=colorbar_loc)
+
+    ax.set_title(title if title is not None else (color or "Bonsai"), fontsize=13)
+    ax.set_aspect("equal")
+    ax.set_xlim(-lim, lim)
+    ax.set_ylim(-lim, lim)
+
+    if frameon is False or (frameon == "small" and style == "scout"):
+        # The disk is the frame; axes on top of it are noise.
+        ax.set_axis_off()
+    else:
+        ax.set_xticks([])
+        ax.set_yticks([])
+        for s in ("top", "right"):
+            ax.spines[s].set_visible(False)
+        if frameon == "small":
+            for s in ("left", "bottom"):
+                ax.spines[s].set_visible(False)
+
+    if save:
+        plt.savefig(save if isinstance(save, str) else "bonsai.png",
+                    bbox_inches="tight")
+    if show:
+        plt.show()
+        return None
+    return ax

--- a/omicverse/tl/__init__.py
+++ b/omicverse/tl/__init__.py
@@ -5,5 +5,6 @@ Currently hosts the cross-species preprocessing extracted from
 backend.
 """
 from ._cross_species import cross_species_align
+from ._bonsai import bonsai
 
-__all__ = ["cross_species_align"]
+__all__ = ["cross_species_align", "bonsai"]

--- a/omicverse/tl/_bonsai.py
+++ b/omicverse/tl/_bonsai.py
@@ -1,0 +1,69 @@
+r"""``ov.tl.bonsai`` — public entry point for the Bonsai tree reconstruction.
+
+The work lives in :mod:`omicverse.external.bonsai`; this module only registers
+the function and records the citation, mirroring how ``ov.single.samap_integrate``
+fronts the vendored SAMap.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+from .._settings import add_reference
+from .._registry import register_function
+
+__all__ = ["bonsai"]
+
+
+@register_function(
+    aliases=["bonsai", "Bonsai树", "bonsai tree", "细胞树重建"],
+    category="tl",
+    description="Reconstruct a maximum-likelihood Bonsai tree over cells, "
+                "propagating per-feature measurement error.",
+    examples=["ov.tl.bonsai(adata, use_rep='scaled|original|X_pca')"],
+    related=["ov.pl.bonsai", "ov.pp.umap", "ov.pp.mde"],
+    produces={"uns": ["bonsai"]},
+)
+def bonsai(adata, **kwargs):
+    r"""Reconstruct a Bonsai tree over the cells of ``adata``.
+
+    Bonsai infers the maximum-likelihood tree whose leaves are the observed
+    cells, treating each cell as a Gaussian measurement in feature space. Where
+    UMAP and t-SNE compress the data into two dimensions and let noise spread
+    cells apart, Bonsai keeps the uncertainty: a cell measured imprecisely sits
+    on a short branch near its parent instead of being pushed into a corner of
+    the plot.
+
+    .. warning::
+       The vendored Bonsai core is licensed **CC BY-NC 4.0**, which prohibits
+       use by commercial entities, including for research. See
+       ``omicverse/external/bonsai/LICENSE-CC-BY-NC-4.0.md``.
+
+    Parameters
+    ----------
+    adata
+        Annotated data matrix; cells become the leaves of the tree.
+    **kwargs
+        Forwarded to :func:`omicverse.external.bonsai.run_bonsai` — notably
+        ``use_rep``, ``sd_key``, ``n_cores``, ``results_dir`` and ``key_added``.
+        See that function for the full signature.
+
+    Returns
+    -------
+    :class:`anndata.AnnData` or None
+        Writes ``adata.uns['bonsai']`` (``newick``, ``edges``, ``edge_lengths``,
+        ``vert_ind``, ``vert_name``, ``leaf_of_obs``, ``results_dir``). Returns
+        a copy when ``copy=True``.
+
+    Examples
+    --------
+    >>> import omicverse as ov
+    >>> ov.pp.pca(adata, layer='scaled', n_pcs=50)
+    >>> ov.tl.bonsai(adata, use_rep='scaled|original|X_pca', n_cores=4)
+    >>> ov.pl.bonsai(adata, color='leiden')
+    """
+    from ..external.bonsai import run_bonsai
+
+    out = run_bonsai(adata, **kwargs)
+    add_reference(adata if out is None else out, 'Bonsai',
+                  'cell-state tree reconstruction with Bonsai')
+    return out

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -506,6 +506,10 @@ exclude = [
 # Vendored third-party source: the upstream licence has to travel with the code
 # that it covers, so it ships in the wheel alongside it.
 "omicverse.external.samap" = ["LICENSE"]
+# Vendored Bonsai (CC BY-NC 4.0): the licence, the citation file and the
+# config template the runner seeds every run from all have to ship.
+"omicverse.external.bonsai" = ["LICENSE-CC-BY-NC-4.0.md", "CITATION.cff"]
+"omicverse.external.bonsai.bonsai" = ["config_template_do_not_change/*.yaml"]
 "omicverse.llm.UCE" = ["LICENSE"]
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
Bonsai reconstructs a maximum-likelihood **tree** over cells rather than a 2-D embedding: cells are leaves, internal vertices are inferred ancestral states, and branch lengths are distances in expression space — so distance along the drawing means something, which is not true of the gap between two UMAP clusters. It also consumes the measurement error on each feature, so a poorly determined cell sits on a short branch near its parent instead of being scattered outward by noise.

```python
ov.tl.bonsai(adata, use_rep='scaled|original|X_pca')
ov.pl.bonsai(adata, color='leiden')
```

<img width="520" alt="bonsai" src="https://github.com/user-attachments/assets/placeholder" />

## ⚠️ Licence — please read before merging

The upstream core vendored in `omicverse/external/bonsai/bonsai/` is released by its authors (Biozentrum, University of Basel) under **CC BY-NC 4.0**, carried verbatim in `LICENSE-CC-BY-NC-4.0.md`. That licence **prohibits use by any commercial entity, including for research** — an additional restriction that omicverse's own GPL-3.0 does not permit on what it distributes. `ov.tl.bonsai` warns once per session for that reason.

This is the same conflict `omicverse/external/cytotrace2/` already carries, and merging this adds a second. Raised and decided deliberately; recorded here so the decision is visible.

## What is vendored

| Directory | Contents |
|---|---|
| `bonsai/` | upstream tree reconstruction (v1.0.0) |
| `scout/` | Bonsai-scout's equal-daylight layout |
| `backbone/` | backbone-based reconstruction, for datasets a direct run cannot reach |
| `downstream_analyses/` | the two modules `bonsai_treeHelpers` imports |

Every edit to vendored code is mechanical and marked `omicverse:` at the site, with the reasoning in each package's `__init__`:

- absolute imports rewritten to relative form, dropping upstream's `sys.path` injection and its `os.chdir` — the latter would otherwise move the caller's working directory out from under a notebook;
- module-level script bodies wrapped in `main()`, their `ArgumentParser` lifted into `_build_parser()`;
- backbone's four steps dispatched by import rather than by spawning `python` subprocesses.

### Four upstream defects fixed

All four need a tree whose subtrees differ in depth, which is why upstream's balanced-binary example never trips them and a 400-cell PBMC tree trips all four:

1. matplotlib removed `cm.get_cmap` in 3.9;
2. the config template addressed relative to the repository root, which only resolved because of the `os.chdir`;
3. `equalDaylightAll` reverting to an `old_tree` it only assigns after a *successful* step → `UnboundLocalError` when the first step overshoots;
4. `get_ed_angles` leaving `opt_angle` as `None` on the branch with no shade to balance → `TypeError` in the loop below it.

## Scale

Direct reconstruction grows as about `n**1.4` — measured on PBMC, one core:

| cells | 100 | 200 | 400 | 800 | 1600 |
|---|---|---|---|---|---|
| time | 18 s | 33 s | 87 s | 229 s | 699 s |

Past the low thousands use `n_initial_cells=`, which switches to upstream's backbone method. On 800 cells: **250 s direct against 151 s via a 200-cell backbone**, both placing all 800.

## Plotting

`ov.pl.bonsai` reproduces Bonsai-scout's own view — equal-angle, then equal-daylight refinement, mapped into the Poincaré disk — using upstream's own styling values. Parameters follow `ov.pl.embedding` (`legend_loc`, `legend_fontsize`, `na_color`, `colorbar_loc`, `save`, and `color` resolved against `obs` then `var` then `raw`).

The one deliberate difference is `radius`: a leaf radius in **data units**, not `embedding`'s marker area in points². Drawing cells at a fixed radius in the tree's own coordinates is what makes a dense clade read as one blob and keeps it that way when the figure is resized.

Coordinates are cached in `adata.uns[key]['layout']` — the layout costs 31 s at 12 800 vertices, so recomputing it for every `color` would dominate. `adata.uns` survives slicing untouched while `leaf_of_obs` is indexed by cell position, so a subset now raises an explanatory error instead of an `IndexError` from a mismatched mask.

One deviation from upstream is documented in `_layout.py`: its joint zoom/origin search settles far from the layout's centroid on unbalanced trees and the drawing comes out lopsided, so origin and zoom are solved separately using upstream's own primitives.

## Performance

`omicverse/external/bonsai/_fast.py` compiles the two hottest numerical functions and, in place of `scipy.optimize.minimize`, the bounded two-variable optimiser the tree search calls **~78 000 times per run** — profiling put **49.5 s of a 96.6 s run inside those SciPy calls alone**, on a problem where the per-call setup costs more than the optimisation.

**Reconstruction of 400 cells: 80 s → 33 s.**

Validated against L-BFGS-B on 3000 optimisation problems captured from a real run: better objective on 2767, equal on 151, worse on 82, worst case worse by 0.020.

On the trees themselves, five independent subsets:

| seed | upstream path | compiled | Δ |
|---|---|---|---|
| 101 | −1031.97 | −1033.44 | −1.47 |
| 202 | −1120.63 | −1120.14 | +0.49 |
| 303 | −1150.85 | −1150.62 | +0.23 |
| 404 | −1135.97 | −1136.43 | −0.46 |
| 505 | −1199.12 | −1200.19 | −1.07 |

Equivalent — differences of 0.2 to 1.5 against a total near 1100, in neither direction consistently. But the trees are **not bit-identical** to upstream: the search compares quantities that retain about three significant digits after cancellation, so any reimplementation diverges there. **`fast=False` runs upstream's own code path.**

numba is already a declared dependency; `_fast.py` falls back to NumPy if it is unavailable, and the compiled path is skipped above 2000 features, where NumPy's vectorised reduction is already as fast.

## Not in this PR

The tutorial section for `docs/Tutorials-single/t_preprocess_cpu.ipynb` lives in `omicverse/omicverse-tutorials` and follows separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0156k5ARWtUbtjbfRypRavEa